### PR TITLE
 Illrigger 클래스 문서 개선

### DIFF
--- a/README/README_Class_Illrigger.MD
+++ b/README/README_Class_Illrigger.MD
@@ -1,37 +1,173 @@
-# Illrigger
-- Core Traits
-  - Skill Proficiencies
-  - Weapon Proficiencies
-  - Armor Training
-- Level 1: Baleful Interdict
-- Level 1: Weapon Mastery
-- Level 2: Combat Mastery
-- Level 2: Interdiction
-- Level 5: Extra Attack
-- Level 6: Infernal Conduit
-- Level 10: Blood Price
-- Level 11: Terrorizing Force
-## Hellspeaker
-- Level 3: Moloch’s Blessing
-- Level 3: Charm Enemy
-- Level 3: Honey-Sweet Blades
-- Level 7: Intransigent
-- Level 11: Incontrovertible
-## Painkiller
-- Level 3: Dispater’s Blessing
-- Level 3: Devastator
-- Level 3: Grand Strategist
-- Level 7: Dispater’s Supremacy
-- Level 11: You Die on My Command!
-## Sanguine Knight
-- Level 3: Exsanguinate
-- Level 3: Sutekh’s Blessing
-- Level 3: Embolden Allies
-- Level 7: Blood for Blood
-- Level 11: Bloodstroke
-## Shadowmaster
-- Level 3: Marked for Death
-- Level 3: Strike from the Dark
-- Level 3: No Escape
-- Level 7: Hell’s Assassin
-- Level 11: Umbral Killer
+<div align="center">
+
+![Illrigger Banner](https://raw.githubusercontent.com/incolhermex-droid/Assets/refs/heads/main/illrigger-banner.svg)
+
+</div>
+
+---
+
+<div align="center">
+
+*The Paladin swore an oath to the light.*
+*The Illrigger signed a contract with something older, hungrier, and far more honest.*
+**Hell doesn't ask for faith. It asks for results.**
+
+</div>
+
+---
+
+## ⛓ Core Traits
+
+| Trait | Details |
+|-------|---------|
+| **Hit Die** | d10 |
+| **Armor Training** | Light, Medium, Heavy Armor · Shields |
+| **Weapon Proficiencies** | Simple Weapons · Martial Weapons |
+| **Skill Proficiencies** | Choose 2: Athletics, Deception, Insight, Intimidation, Persuasion, Religion |
+| **Saving Throws** | Wisdom · Charisma |
+| **Primary Ability** | Strength / Charisma |
+
+> *The Illrigger is not a fallen hero. A fallen hero chose wrong. The Illrigger chose deliberately — and Hell rewards deliberate choices.*
+
+---
+
+## 📜 Class Features
+
+### Level 1 — The Infernal Pact
+
+> *Every Illrigger bears a Mark. Not a brand of shame — a seal of authority. Hell's warrant for what comes next.*
+
+**☠ Baleful Interdict**
+You can place a supernatural curse — an Interdict — upon a target you can see. The Interdict brands them as your quarry, marking them for infernal judgment. While Interdicted, the target suffers additional effects based on your subclass, and you can exploit their marked state to fuel your most devastating abilities.
+
+The Interdict is not merely a debuff. It is a declaration: *this creature belongs to Hell, and I am Hell's collector.*
+
+**⚔ Weapon Mastery**
+Your infernal training goes beyond mortal technique. Choose two weapons whose Mastery properties you can apply when you attack with them. You can change your Mastery choices on a Long Rest.
+
+---
+
+### Level 2 — Infernal Discipline
+
+> *A mortal soldier masters their blade. An Illrigger masters the battlefield itself.*
+
+**🔱 Combat Mastery**
+Your infernal conditioning grants you a supernatural edge in combat. You gain a pool of Combat Mastery dice — d8s — that fuel tactical abilities and reactions. These replenish on a Short or Long Rest, because Hell never lets its enforcers run dry.
+
+**🩸 Interdiction**
+Your Baleful Interdict evolves. You can now apply its effects more broadly, and creatures who attempt to remove or resist your Interdict find the curse only tightens. An Illrigger's mark does not wash off.
+
+---
+
+### Level 5 — The Enforcer
+
+> *One strike was never enough. Hell's enforcers don't negotiate — they enforce.*
+
+**💀 Extra Attack**
+You can attack twice, instead of once, whenever you take the Attack action on your turn. The Interdict on your target makes each blow land with compounding dread.
+
+---
+
+### Level 6 — Infernal Conduit
+
+**🔥 Infernal Conduit**
+You become a living channel between the mortal plane and the infernal hierarchy. Once per turn, when you deal damage to an Interdicted creature, you can siphon a fragment of their life force — restoring hit points to yourself or an ally, or fueling one of your infernal abilities without expending a resource.
+
+The damned exist to serve Hell. You are simply the instrument of collection.
+
+---
+
+### Level 10 — The Price
+
+**💰 Blood Price**
+Hell's power does not come free — but you've learned to make *others* pay the cost. When a creature under your Interdict is reduced to 0 hit points, you can immediately transfer the Interdict to a new target within 30 feet as a free action. The hunt continues without pause.
+
+Additionally, once per Long Rest, you can invoke the Blood Price directly: force a creature to make a Charisma saving throw or be Frightened of you until the end of combat. Their terror is your armor.
+
+---
+
+### Level 11 — Terrorizing Force
+
+**👁 Terrorizing Force**
+At this level, your presence alone is a weapon. When you enter combat, every creature that can see you must make a Wisdom saving throw or be Rattled — unable to benefit from advantage on attack rolls until the end of their next turn.
+
+Your Interdict now deals additional psychic damage whenever the target fails a saving throw against any of your abilities. Hell doesn't just punish the body. It punishes the *mind*.
+
+---
+
+<div align="center">
+
+![Subclasses](https://raw.githubusercontent.com/incolhermex-droid/Assets/refs/heads/main/illrigger-subclass.svg)
+
+</div>
+
+---
+
+## 🗣 Hellspeaker
+*"I don't need to hurt you. I just need you to believe I will."*
+
+The Hellspeaker wields something more dangerous than any blade: **words**. Backed by Moloch's authority — Lord of the Nine Hells' infernal bureaucracy — the Hellspeaker can charm, compel, and unmake an enemy's will before the first blow is ever struck. By the time they raise a weapon, the fight is already over.
+
+| Level | Feature | Description |
+|-------|---------|-------------|
+| 3 | **Moloch's Blessing** | Moloch's patron power flows through your voice. You gain proficiency in Persuasion and Deception, and can add your Charisma modifier to Intimidation checks. |
+| 3 | **Charm Enemy** | As an Action, force a creature under your Interdict to make a Wisdom saving throw. On a failure, they are Charmed by you until the Interdict ends or they take damage from your allies. |
+| 3 | **Honey-Sweet Blades** | When you attack a creature Charmed by you, you deal extra psychic damage equal to your Charisma modifier. Betrayal is the sharpest blade. |
+| 7 | **Intransigent** | Your will cannot be bent. You are immune to being Charmed and have advantage on saving throws against mind-affecting magic. |
+| 11 | **Incontrovertible** | Once per Long Rest, you can speak a single sentence of absolute infernal authority. Every creature that hears it and fails a Charisma saving throw must obey the command as if affected by *Dominate Monster* for 1 minute. |
+
+---
+
+## ⚔ Painkiller
+*"Grand Strategist. Devastator. The difference is which end of the blade you're holding."*
+
+Dispater — the Iron Duke of Hell, master of strategy and paranoia — blesses the Painkiller with something more insidious than raw power: **precision**. The Painkiller does not fight with rage. They fight with math, positioning, and the cold certainty that pain, applied correctly, is the most efficient tool in existence.
+
+| Level | Feature | Description |
+|-------|---------|-------------|
+| 3 | **Dispater's Blessing** | Dispater's iron will fortifies your tactics. You gain proficiency with all martial weapons and ignore the two-handed property of weapons when you have a free hand. |
+| 3 | **Devastator** | When you hit an Interdicted creature, you can choose to Devastate them — dealing maximum damage instead of rolling. Once you use this, you cannot use it again until the start of your next turn. |
+| 3 | **Grand Strategist** | You can take the Help action as a Bonus Action. When you Help an ally, they also gain a bonus to their damage roll equal to your Charisma modifier. |
+| 7 | **Dispater's Supremacy** | Your Interdict now causes the target to have disadvantage on Constitution saving throws. Additionally, your critical hit range with weapons expands by 1. |
+| 11 | **You Die on My Command!** | Once per Short Rest, when a creature under your Interdict is reduced to 0 HP, you can use your Reaction to have them make one final action — a single attack against a target of your choice — before falling. Even in death, they serve. |
+
+---
+
+## 🩸 Sanguine Knight
+*"Every drop you bleed makes me stronger. Keep fighting."*
+
+Where other Illriggers draw power from curses, fear, or authority, the Sanguine Knight draws power from the most primal currency of all: **blood**. Under Sutekh's blessing — the forgotten god of blood and sacrifice — every wound dealt and received becomes fuel. The Sanguine Knight gets stronger as battles escalate, transforming a war of attrition into a feast.
+
+| Level | Feature | Description |
+|-------|---------|-------------|
+| 3 | **Sutekh's Blessing** | Blood feeds your infernal power. Whenever you deal damage that reduces a creature below half its maximum hit points for the first time, you gain temporary hit points equal to your Charisma modifier + your Illrigger level. |
+| 3 | **Exsanguinate** | When you hit an Interdicted creature, you can drain their vitality — dealing extra necrotic damage and healing yourself for half the amount. Once per turn. |
+| 3 | **Embolden Allies** | As a Bonus Action, you can sacrifice hit points equal to your level to grant one ally temporary hit points equal to twice the amount sacrificed. Blood spent for allies returns threefold in Hell's ledger. |
+| 7 | **Blood for Blood** | When you are hit by an attack, you can use your Reaction to mark the attacker with your Interdict and immediately make one weapon attack against them. Retaliation is automatic. |
+| 11 | **Bloodstroke** | Once per Long Rest, when you reduce a creature to 0 HP, you erupt in infernal energy — every creature within 15 feet must make a Constitution saving throw or take necrotic damage equal to your level + Charisma modifier, and be Stunned until the end of their next turn. The blood sacrifice complete, Hell acknowledges you. |
+
+---
+
+## 🌑 Shadowmaster
+*"They didn't see me. That was the last mistake they ever made."*
+
+The Shadowmaster does not announce their presence. They do not issue warnings. They are already behind you, already done, already gone — and you won't understand what happened until it's far too late. Where other Illriggers confront their enemies, the Shadowmaster **erases** them. Marked for death means exactly that.
+
+| Level | Feature | Description |
+|-------|---------|-------------|
+| 3 | **Marked for Death** | When you apply your Interdict, you also Shadow-Mark the target. Shadow-Marked creatures cannot benefit from invisibility or Hiding, and allies who attack them deal additional damage equal to your Charisma modifier. |
+| 3 | **Strike from the Dark** | When you attack a creature that cannot see you, or that is Frightened, you deal extra necrotic damage equal to 2d6 + your Charisma modifier. Darkness is a weapon. |
+| 3 | **No Escape** | Shadow-Marked creatures cannot use the Dash or Disengage action. If they attempt to teleport, they must first succeed on a Charisma saving throw against your spell save DC or the teleportation fails. |
+| 7 | **Hell's Assassin** | You can cast *Invisibility* on yourself as a Bonus Action, without expending a spell slot, a number of times equal to your Charisma modifier. The invisibility lasts until you attack or cast a spell. |
+| 11 | **Umbral Killer** | Once per Long Rest, you can designate a Shadow-Marked target as Condemned. For the next minute, your attacks against them automatically score a Critical Hit if they hit, and the target cannot regain hit points from any source. Hell's sentence is final. |
+
+---
+
+<div align="center">
+
+![Divider](https://raw.githubusercontent.com/incolhermex-droid/Assets/refs/heads/main/illrigger-divider.svg)
+
+*Part of the [DnD 5.5e All-in-One BEYOND](https://github.com/Yoonmoonsik/dnd55e) mod.*
+*For the full changelog and documentation, visit the [Wiki](https://github.com/Yoonmoonsik/dnd55e/wiki).*
+
+</div>


### PR DESCRIPTION
일리거 클래스의 세부 정보를 확장하여 헬스피커, 페인킬러, 상귄 나이트, 섀도우마스터와 같은 하위 클래스의 핵심 특성 및 클래스 기능을 포함시켰습니다.