### PR TITLE
French localization: full coverage and terminology harmonization

### DIFF
--- a/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/French/french.xml
+++ b/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/French/french.xml
@@ -19,7 +19,7 @@ Attaques affectées : Un jet d'attaque contre vous a l'Avantage si l'assaillant 
   <content contentuid="h240aa2f4g6571ge23eg8142g83ee7b985b8d" version="2">Éraflure</content>
   <content contentuid="h0fbee9aag6abeg6294g3fd8gbeb26ffd19f6" version="1">Si votre jet d'attaque avec cette arme manque une créature, vous pouvez lui infliger des dégâts égaux au modificateur de caractéristique que vous avez utilisé pour effectuer le jet d'attaque. Ces dégâts sont du même type que ceux infligés par l'arme, et les dégâts ne peuvent être augmentés qu'en augmentant le modificateur de caractéristique.</content>
   <content contentuid="hdbe460a9gf800gdb75g15bbg2b81a80fe8ab" version="2">Entaille</content>
-  <content contentuid="h84f8977cg06ecg1e31gebd6g21e4b7346121" version="2">Lorsque vous effectuez l'attaque supplémentaire de la propriété Légère, vous pouvez la faire dans le cadre de l'action Attaque plutôt que comme Action bonus. Vous ne pouvez effectuer cette attaque supplémentaire qu'une seule fois par tour.</content>
+  <content contentuid="h84f8977cg06ecg1e31gebd6g21e4b7346121" version="2">Lorsque vous effectuez l'attaque supplémentaire de la propriété Légère, vous pouvez la faire dans le cadre de l'action Attaquer plutôt que comme Action bonus. Vous ne pouvez effectuer cette attaque supplémentaire qu'une seule fois par tour.</content>
   <content contentuid="h64e7021cg8b69g3f60gde38gd59f3cdc5846" version="2">Poussée</content>
   <content contentuid="h694f6a66g0531g98f0ga23eg525e146eb4d7" version="1">Si vous touchez une créature avec cette arme, vous pouvez la pousser jusqu'à [1] en ligne droite dans la direction opposée à vous, si elle est de taille Grande ou inférieure.</content>
   <content contentuid="haf74199bg92cbg93dega0fbgebb535603f83" version="2">Affaiblissement</content>
@@ -35,7 +35,7 @@ Attaques affectées : Un jet d'attaque contre vous a l'Avantage si l'assaillant 
   <content contentuid="h0de5940ag21a0gff32gb8dfg01c84e54f73e" version="1">Dague, Marteau léger, Faucille, Cimeterre</content>
   <content contentuid="h6fd4a879g6dd9g5936gc329gc012af72f9c6" version="1">Grande massue, Pique, Marteau de guerre, Arbalète lourde</content>
   <content contentuid="h05a1ab8cg6b39gabd2g55c7g3a1f851c31fb" version="1">Masse d'armes, Épieu, Fléau, Épée longue, Morgenstern, Pic de guerre</content>
-  <content contentuid="h53e29765gaf78g1680g5805g24b5594244ac" version="1">Gourdin, Javelot, Arbalète légère, Fronde, Arc long, Mousquet</content>
+  <content contentuid="h53e29765gaf78g1680g5805g24b5594244ac" version="2">Gourdin, Javelot, Arbalète légère, Arc long, Mousquet, Fouet</content>
   <content contentuid="h8ab19fdega28dg1fd1g0de1gc672bac4e6d3" version="2">Bâton, Hache de bataille, Maillet de guerre, Trident</content>
   <content contentuid="hd724f72fgcda8gb6acgb5c4gd95d169dd0b4" version="1">Hachette, Arc court, Rapière, Épée courte, Arbalète de poing, Pistolet</content>
   <content contentuid="h6e0a316bg6ce3gc18fgb7c0ge96c73d6dfa0" version="1">Maîtrise des armes</content>
@@ -57,13 +57,13 @@ De plus, lorsque votre Rage est active, vous pouvez canaliser une puissance prim
   <content contentuid="h28d4b453gc36cg810egf9e2g1dbff5d018d8" version="1">Niveau 7 : Bond instinctif</content>
   <content contentuid="hdb025275gf26dg03dfg7370g4dddf3f0ffb9" version="1">Dans le cadre de l'Action bonus que vous prenez pour entrer en Rage, vous pouvez vous déplacer jusqu'à la moitié de votre Vitesse.</content>
   <content contentuid="hb6144726g336aga60cg63d6gf6c4bc669e6a" version="1">Niveau 9 : Frappe brutale</content>
-  <content contentuid="h3a320da8g90b9g9714ge237g45c9782afbd0" version="1">Si vous utilisez l'Attaque imprudente, la cible subit 1d10 dégâts supplémentaires du même type que ceux infligés par l'arme ou l'Attaque à mains nues, et vous pouvez provoquer un effet de Frappe brutale de votre choix.
+  <content contentuid="h3a320da8g90b9g9714ge237g45c9782afbd0" version="1">Si vous utilisez la Témérité, la cible subit 1d10 dégâts supplémentaires du même type que ceux infligés par l'arme ou l'Attaque à mains nues, et vous pouvez provoquer un effet de Frappe brutale de votre choix.
 
 Coup de force. La cible est repoussée de [1] en ligne droite dans la direction opposée à vous. Vous pouvez ensuite vous déplacer jusqu'à la moitié de votre Vitesse en ligne droite vers la cible sans provoquer d'Attaques d'opportunité.
 Coup jarretier. La Vitesse de la cible est réduite de [1] jusqu'au début de votre prochain tour. Une cible ne peut être affectée que par un seul Coup jarretier à la fois—le plus récent.</content>
-  <content contentuid="hf41a9d96ge143g36f0g9f1eg51d9ca5a4cee" version="1">Attaque imprudente : Coup de force</content>
+  <content contentuid="hf41a9d96ge143g36f0g9f1eg51d9ca5a4cee" version="1">Témérité : Coup de force</content>
   <content contentuid="hab5f59ebgf7a8g70bag4453g8c9195f80563" version="1">La cible est repoussée de [1] en ligne droite à partir de vous. Vous pouvez ensuite vous déplacer jusqu'à la moitié de votre Vitesse en ligne droite vers la cible sans provoquer d'Attaques d'opportunité.</content>
-  <content contentuid="hebd8f833g052cg4774g5e19geb34be606a5f" version="1">Attaque imprudente : Coup jarretier</content>
+  <content contentuid="hebd8f833g052cg4774g5e19geb34be606a5f" version="1">Témérité : Coup jarretier</content>
   <content contentuid="h0eff4b2bgeb61g4e62ga1ffg3b4f777317e1" version="1">La Vitesse de la cible est réduite de [1] jusqu'au début de votre prochain tour. Une cible ne peut être affectée que par un seul Coup jarretier à la fois—le plus récent.</content>
   <content contentuid="h2fea2840g0902gdf2bg7797g549c20c3d6e3" version="1">Coup de force</content>
   <content contentuid="hcd10eb1fgc367ga39egd371g5e071e079549" version="1">Vous pouvez vous déplacer jusqu'à la moitié de votre Vitesse en ligne droite vers la cible sans provoquer d'Attaques d'opportunité.</content>
@@ -72,7 +72,7 @@ Coup jarretier. La Vitesse de la cible est réduite de [1] jusqu'au début de vo
   <content contentuid="hebad3866ga362g915cge97fg661e8b92ea36" version="1">Niveau 11 : Rage implacable</content>
   <content contentuid="hfd45d1c1g9dd3g206agfb7eg456c6af02ac0" version="1">Une fois par &lt;LSTag Tooltip="ShortRest"&gt;Repos court&lt;/LSTag&gt;, lorsque vous tomberiez à [1] &lt;LSTag Tooltip="HitPoints"&gt;point de vie&lt;/LSTag&gt; tandis que vous êtes &lt;LSTag Type="Status" Tooltip="RAGE"&gt;en Rage&lt;/LSTag&gt;, vous récupérez à la place des points de vie égaux au double de votre niveau de Barbare et évitez d'être &lt;LSTag Type="Status" Tooltip="DOWNED"&gt;À l'agonie&lt;/LSTag&gt;.</content>
   <content contentuid="h784061e1gf2a8g748bg99cfg9e391dd4569c" version="1">Niveau 3 : Frénésie</content>
-  <content contentuid="hd21b5d53gc033g82abgfcdag21730bb83c68" version="1">Si vous utilisez l'Attaque imprudente lorsque votre Rage est active, vous infligez des dégâts supplémentaires à la première cible que vous touchez à votre tour avec une attaque basée sur la Force. Pour déterminer les dégâts supplémentaires, lancez un nombre de d6 égal à votre bonus de dégâts de Rage et additionnez-les. Les dégâts sont du même type que l'arme ou l'Attaque à mains nues utilisée pour l'attaque.</content>
+  <content contentuid="hd21b5d53gc033g82abgfcdag21730bb83c68" version="1">Si vous utilisez la Témérité lorsque votre Rage est active, vous infligez des dégâts supplémentaires à la première cible que vous touchez à votre tour avec une attaque basée sur la Force. Pour déterminer les dégâts supplémentaires, lancez un nombre de d6 égal à votre bonus de dégâts de Rage et additionnez-les. Les dégâts sont du même type que l'arme ou l'Attaque à mains nues utilisée pour l'attaque.</content>
   <content contentuid="h7f8570c9g2cd6g2327g3c99g18d5c393bf5e" version="1">Niveau 6 : Rage aveugle</content>
   <content contentuid="h42189866g05d1g89b4g6e9dg1f97d248b2a9" version="1">Niveau 10 : Représailles</content>
   <content contentuid="hde644cc1g1dc6g103bg095ege867e6fa22ad" version="1">Lorsque vous subissez des dégâts d'une créature à [1] ou moins de vous, vous pouvez utiliser une Réaction pour effectuer une attaque de corps à corps contre cette créature, en utilisant une arme ou une Attaque à mains nues.</content>
@@ -86,9 +86,9 @@ Coup jarretier. La Vitesse de la cible est réduite de [1] jusqu'au début de vo
   <content contentuid="h3c4853cag177dg4ea8g0c15gde7e940ee735" version="1">Source d'inspiration</content>
   <content contentuid="h7c14769cg0f8ag7968g4156g1272fd5b7850" version="3">Dépensez un emplacement de sort pour récupérer une utilisation dépensée d'Inspiration bardique.</content>
   <content contentuid="he36b3403gbab9gf77fg17fbg32e95953478c" version="1">Niveau 7 : Contre-charme</content>
-  <content contentuid="h1dedae79g3922gbd27g0925g98aec4318fa7" version="1">Vous pouvez utiliser des notes musicales ou des paroles puissantes pour perturber les effets influençant l'esprit. Si vous ou une créature à 30 pieds de vous ratez un jet de sauvegarde contre un effet qui applique la condition Charmé ou Effrayé, vous pouvez utiliser une Réaction pour que le jet soit retenté, et le nouveau jet bénéficie de l'Avantage.</content>
+  <content contentuid="h1dedae79g3922gbd27g0925g98aec4318fa7" version="1">Vous pouvez utiliser des notes musicales ou des paroles puissantes pour perturber les effets influençant l'esprit. Si vous ou une créature à 9 mètres de vous ratez un jet de sauvegarde contre un effet qui applique la condition Charmé ou Effrayé, vous pouvez utiliser une Réaction pour que le jet soit retenté, et le nouveau jet bénéficie de l'Avantage.</content>
   <content contentuid="hf8844bacg4eb3geecdg5fbagf17d5ba9d6b0" version="1">Contre-charme</content>
-  <content contentuid="h0f358bf7g4a10gc77fg43cfg0c187137ef7a" version="1">Vous pouvez utiliser des notes musicales ou des paroles puissantes pour perturber les effets influençant l'esprit. Si vous ou une créature à 30 pieds de vous ratez un jet de sauvegarde contre un effet qui applique la condition Charmé ou Effrayé, vous pouvez utiliser une Réaction pour que le jet soit retenté, et le nouveau jet bénéficie de l'Avantage.</content>
+  <content contentuid="h0f358bf7g4a10gc77fg43cfg0c187137ef7a" version="1">Vous pouvez utiliser des notes musicales ou des paroles puissantes pour perturber les effets influençant l'esprit. Si vous ou une créature à 9 mètres de vous ratez un jet de sauvegarde contre un effet qui applique la condition Charmé ou Effrayé, vous pouvez utiliser une Réaction pour que le jet soit retenté, et le nouveau jet bénéficie de l'Avantage.</content>
   <content contentuid="h3169b2acg5134gbc8dge8fagb01eabf3a278" version="1">Niveau 3 : Magie séduisante</content>
   <content contentuid="h035b29c1g51d0ge9f8gb63fgc75cd5045b0c" version="2">Vous avez toujours les sorts Charme-personne et Image miroir préparés.
 
@@ -105,37 +105,37 @@ Chacune de ces créatures gagne des Points de vie temporaires égaux au double d
   <content contentuid="h52a153aag53d8g2658g72aegc55c7baffc11" version="1">Chacune de ces créatures gagne des Points de vie temporaires égaux au double du résultat obtenu sur le dé d'Inspiration bardique, et chacune peut se déplacer sans provoquer d'Attaques d'opportunité jusqu'à la fin de son prochain tour.</content>
   <content contentuid="h530230d7ge34cg06b9g06a3ge16228b8a608" version="1">Les créatures gagnent des Points de vie temporaires égaux au double du résultat obtenu sur le dé d'Inspiration bardique, et chacune peut se déplacer sans provoquer d'Attaques d'opportunité jusqu'à la fin de son prochain tour.</content>
   <content contentuid="hcc01542ag2ea8ge230g53b5g6bae54a352d2" version="1">Niveau 3 : Paroles cinglantes</content>
-  <content contentuid="hfac955c9g640eg8dc8gfdefgfa559fa195f8" version="3">Attaque supplémentaire (Tour de magie)</content>
-  <content contentuid="he6112d47g8846ge668gbd97g45ddd36eeb46" version="1">Vous pouvez attaquer deux fois au lieu d'une chaque fois que vous effectuez l'action Attaque à votre tour.
+  <content contentuid="hfac955c9g640eg8dc8gfdefgfa559fa195f8" version="3">Attaque supplémentaire (Sort mineur)</content>
+  <content contentuid="he6112d47g8846ge668gbd97g45ddd36eeb46" version="1">Vous pouvez attaquer deux fois au lieu d'une chaque fois que vous effectuez l'action Attaquer à votre tour.
 
-De plus, vous pouvez lancer l'un de vos tours de magie dont le temps d'incantation est une action à la place de l'une de ces attaques.</content>
+De plus, vous pouvez lancer l'un de vos sorts mineurs dont le temps d'incantation est une action à la place de l'une de ces attaques.</content>
   <content contentuid="h1a1b446eg2636gca22g7bafg910726511c02" version="1">Aide</content>
   <content contentuid="h5380e85fg27eagff54gaa61g803d6710929e" version="1">Choisissez jusqu'à trois créatures à portée. Le maximum de Points de vie de chaque cible et ses Points de vie actuels augmentent de [1] pour la durée.</content>
   <content contentuid="he6319c8dga9bagd985gfc80gc057d99c3f06" version="1">Aide</content>
   <content contentuid="h8c0c79e8geefage313gb534gd315de67d298" version="1">Augmentez le maximum de points de vie de vos alliés de [1].</content>
-  <content contentuid="hbdf4d91ege560gf373gb78fgc694716131ec" version="1">Parole de Radiance</content>
+  <content contentuid="hbdf4d91ege560gf373gb78fgc694716131ec" version="1">Mot de radiance</content>
   <content contentuid="h0dd0eba8g9b93g7909g9d9cg2a09e01a4c46" version="2">Niveau 1 : Ordre divin : Protecteur</content>
   <content contentuid="h82c38cb3g39e6g13c8g7a26g5c63f737aa79" version="1">Protecteur : Entraîné pour la bataille, vous gagnez la maîtrise des armes de guerre et l'entraînement aux armures lourdes.</content>
-  <content contentuid="hd91012edgb1a6g4aabg14d4g0d685464de55" version="1">Thaumaturge : Vous connaissez un tour de magie supplémentaire de la liste de sorts du Clerc. De plus, votre connexion mystique au divin vous confère un bonus à vos tests d'Intelligence (Arcanes ou Religion). Ce bonus est égal à votre modificateur de Sagesse (minimum +1).</content>
-  <content contentuid="h5eae110bgf170g8febg7b95gaf9957eab275" version="1">Guidance</content>
+  <content contentuid="hd91012edgb1a6g4aabg14d4g0d685464de55" version="1">Thaumaturge : Vous connaissez un sort mineur supplémentaire de la liste de sorts du Clerc. De plus, votre connexion mystique au divin vous confère un bonus à vos tests d'Intelligence (Arcanes ou Religion). Ce bonus est égal à votre modificateur de Sagesse (minimum +1).</content>
+  <content contentuid="h5eae110bgf170g8febg7b95gaf9957eab275" version="1">Assistance</content>
   <content contentuid="hf42e4215gdaa7g8b2cg6d6cg34b3a7233576" version="1">Lumière</content>
   <content contentuid="h08e84982gdf0fgadf1g29d5g02cc8281827c" version="2">Tendon éclaté</content>
   <content contentuid="hf2980afegb1f3g08e3g5b30g296c1e8141b7" version="1">Résistance</content>
   <content contentuid="h3dc64960ga68egb106gddd9g8a83f2e5394a" version="1">Flamme sacrée</content>
-  <content contentuid="h37124d24g1b0dg1b86g632dg14623f5d21b6" version="1">Épargner les mourants</content>
+  <content contentuid="h37124d24g1b0dg1b86g632dg14623f5d21b6" version="1">Stabilisation</content>
   <content contentuid="h31c6269fga1bfge0a9gb4bfg7f845b81b38a" version="1">Thaumaturgie</content>
-  <content contentuid="h4d2d81f9g6a4cg493ege377gd246536aefa0" version="1">Glas des morts</content>
+  <content contentuid="h4d2d81f9g6a4cg493ege377gd246536aefa0" version="1">Glas</content>
   <content contentuid="h5d663b96gee20gd7abg28bdgde325d686903" version="1">Ordre divin</content>
   <content contentuid="hf078c843g4ca9gd89bgde69g7b94c3d7e9b4" version="1">Vous vous êtes consacré à l'un des rôles sacrés suivants, à votre choix.</content>
-  <content contentuid="hc0f7da49g83b0g2364gd22fg0e72e6d0f671" version="1">Niveau 1 : Ordre divin : Parole de Radiance</content>
+  <content contentuid="hc0f7da49g83b0g2364gd22fg0e72e6d0f671" version="1">Niveau 1 : Ordre divin : Mot de radiance</content>
   <content contentuid="h4d5b8b7cg1eddg15a0g6e0cgb4e68f50ee06" version="1">Niveau 1 : Ordre divin : Guidance</content>
   <content contentuid="h865f785bge303g1b8ag2f0egee91191a55fd" version="1">Niveau 1 : Ordre divin : Lumière</content>
   <content contentuid="h0bfe486dga99eg5aefg818agacd35ff6e130" version="2">Niveau 1 : Ordre divin : Tendon éclaté</content>
   <content contentuid="hd5ac78c8g2d8cg02bag6ebbg2f9ccd67bc36" version="1">Niveau 1 : Ordre divin : Résistance</content>
   <content contentuid="h63c03147gca42g60bdgfa7ag47ceb695bc38" version="1">Niveau 1 : Ordre divin : Flamme sacrée</content>
-  <content contentuid="hf2f5e5c4g141ag2b8egb90cg9ff6727b6910" version="1">Niveau 1 : Ordre divin : Épargner les mourants</content>
+  <content contentuid="hf2f5e5c4g141ag2b8egb90cg9ff6727b6910" version="1">Niveau 1 : Ordre divin : Stabilisation</content>
   <content contentuid="h50136471gff21g505fg888cgf856fc01281a" version="1">Niveau 1 : Ordre divin : Thaumaturgie</content>
-  <content contentuid="h9b0eeaeeg6a13gc99dg6669gc97c57ec0db5" version="1">Niveau 1 : Ordre divin : Glas des morts</content>
+  <content contentuid="h9b0eeaeeg6a13gc99dg6669gc97c57ec0db5" version="1">Niveau 1 : Ordre divin : Glas</content>
   <content contentuid="h84a7d362gf65ag0f66g6103g7d1f4fc707d2" version="1">Niveau 2 : Conduit divin</content>
   <content contentuid="h619804afg28a4g6f48g9db2gb39ec7c1d073" version="1">Vous pouvez canaliser de l'énergie divine pour créer des effets spéciaux tels qu'Étincelle divine et Renvoi des morts-vivants, en choisissant l'un d'eux à chaque utilisation du Conduit divin. Des effets et utilisations supplémentaires sont obtenus à des niveaux de Clerc plus élevés. Vous récupérez une utilisation lors d'un Repos court et toutes les utilisations lors d'un Repos long. Les DD des jets de sauvegarde utilisent votre DD de sauvegarde de sort.</content>
   <content contentuid="h0fdb1f5ag867fg21d4g6beeg681eae4df812" version="1">Étincelle divine</content>
@@ -150,13 +150,13 @@ De plus, vous pouvez lancer l'un de vos tours de magie dont le temps d'incantati
   <content contentuid="ha5f17982g16bdg018bg655eg1db1622f5096" version="1">Niveau 7 : Frappes bénies : Frappe divine (Nécrotique)</content>
   <content contentuid="hd61761e0gbebfg6542gac8bgd70ab3faa548" version="1">Une fois à chacun de vos tours lorsque vous touchez une créature avec un jet d'attaque utilisant une arme, vous pouvez faire en sorte que la cible subisse 1d8 dégâts Nécrotiques supplémentaires.</content>
   <content contentuid="hdbdc1e3fg886agebc7gf898gdd7b5aea06a3" version="1">Niveau 7 : Frappes bénies : Incantation puissante</content>
-  <content contentuid="h2d199d0egf3a1ga886gf931gb46f01ab73e5" version="1">Incantation puissante. Ajoutez votre modificateur de Sagesse aux dégâts que vous infligez avec n'importe quel tour de magie de Clerc.</content>
+  <content contentuid="h2d199d0egf3a1ga886gf931gb46f01ab73e5" version="1">Incantation puissante. Ajoutez votre modificateur de Sagesse aux dégâts que vous infligez avec n'importe quel sort mineur de Clerc.</content>
   <content contentuid="h4bebd04fg3a81gc270gd50bga237aecd8ef8" version="1">Frappes bénies</content>
   <content contentuid="h0c4d3581gf44cg6a9ag27f8ge9f2dd54d6ed" version="1">La puissance divine vous imprègne au combat. Vous gagnez l'une des options suivantes de votre choix.</content>
   <content contentuid="hb6ac0f1cg84d4g5137g1a23g92f5941f06dc" version="1">Niveau 5 : Brûler les morts-vivants</content>
-  <content contentuid="hd9e8561fg5920g7f26g9d66g15b2d44e24f3" version="1">Épargner les mourants</content>
+  <content contentuid="hd9e8561fg5920g7f26g9d66g15b2d44e24f3" version="1">Stabilisation</content>
   <content contentuid="hb742b3aagabfcg536cg10e0g99bbe354e49a" version="1">Soignez une créature à portée qui a 0 Points de vie et n'est pas morte.</content>
-  <content contentuid="hd085b0deg3cc9g0858gdf14geef98a4164c3" version="1">Parole de Radiance</content>
+  <content contentuid="hd085b0deg3cc9g0858gdf14geef98a4164c3" version="1">Mot de radiance</content>
   <content contentuid="hbb7ccd06g2737gdcf2gc167g21f32c9615fb" version="1">Une radiance brûlante éclate de vous dans une Émanation de [1]. Chaque créature de votre choix que vous voyez à l'intérieur doit réussir un jet de sauvegarde de Constitution ou subir des dégâts Radiants.</content>
   <content contentuid="hf652a768gef39g78fdg661dg8ddbb887d3f3" version="1">Niveau 3 : Disciple de la vie</content>
   <content contentuid="h748a060egc16cg7d82gf97eg22830dd0c9f1" version="1">Lorsqu'un sort que vous lancez avec un emplacement de sort restaure des Points de vie à une créature, cette créature récupère des Points de vie supplémentaires au tour où vous lancez le sort. Les Points de vie supplémentaires sont égaux à 2 plus le niveau de l'emplacement de sort.</content>
@@ -168,18 +168,18 @@ De plus, vous pouvez lancer l'un de vos tours de magie dont le temps d'incantati
   <content contentuid="h28bdf1edg1a62gc8a2gc601gdedb4f01f3b6" version="1">Les Points de vie de cette créature sont descendus en dessous de 50 %.</content>
   <content contentuid="h12e63398gc863ged08g09d8g9e2fffc91af3" version="1">Conduit divin</content>
   <content contentuid="h62870381g3b8dgbb2cgfc78gf6ba26bd778f" version="1">Le nombre de fois où vous pouvez canaliser vos pouvoirs divins.</content>
-  <content contentuid="h39b48f39g9a41g2ba3g3567g7ab1cb265f82" version="1">Niveau 3 : Éclat protecteur</content>
+  <content contentuid="h39b48f39g9a41g2ba3g3567g7ab1cb265f82" version="1">Niveau 3 : Illumination protectrice</content>
   <content contentuid="ha7d55e66g6f97ga4b7g45b4g5829f0c36910" version="2">Lorsqu'une créature que vous voyez à [1] de vous effectue un jet d'attaque, vous pouvez utiliser une Réaction pour imposer le Désavantage au jet d'attaque, faisant jaillir de la lumière avant qu'il touche ou rate.
 
 Vous pouvez utiliser cette capacité un nombre de fois égal à votre modificateur de Sagesse (minimum une fois). Vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
-  <content contentuid="h67f1e6b2g8adcge989g555ag3cbae9d62375" version="1">Niveau 6 : Éclat protecteur amélioré</content>
-  <content contentuid="hcac62cb2g678dgbdc4g4a80g875b53ed7a48" version="1">Vous récupérez toutes les utilisations dépensées de votre Éclat protecteur lorsque vous terminez un Repos court ou long.
+  <content contentuid="h67f1e6b2g8adcge989g555ag3cbae9d62375" version="1">Niveau 6 : Illumination protectrice améliorée</content>
+  <content contentuid="hcac62cb2g678dgbdc4g4a80g875b53ed7a48" version="1">Vous récupérez toutes les utilisations dépensées de votre Illumination protectrice lorsque vous terminez un Repos court ou long.
 
-De plus, chaque fois que vous utilisez l'Éclat protecteur, vous pouvez accorder à la cible de l'attaque déclenchante un nombre de Points de vie temporaires égal à 2d6 plus votre modificateur de Sagesse.</content>
-  <content contentuid="h772e3772g49fdg8cf4g0f02g893153584b30" version="1">Éclat protecteur</content>
-  <content contentuid="h6c1ab5a0g8a40g1755g2eacg01f53db2903f" version="1">Lorsqu'une créature que vous voyez à 30 pieds de vous effectue un jet d'attaque, vous pouvez utiliser une Réaction pour imposer le Désavantage au jet d'attaque, faisant jaillir de la lumière avant qu'il touche ou rate.</content>
-  <content contentuid="h03dc1992g1d8agc3e0ga6bbg22607e81d966" version="1">Éclat protecteur (Allié)</content>
-  <content contentuid="hcb0f1d4dg6ea8gf1eag5e72g32b56f306af2" version="1">Éclat protecteur (Soi-même)</content>
+De plus, chaque fois que vous utilisez l'Illumination protectrice, vous pouvez accorder à la cible de l'attaque déclenchante un nombre de Points de vie temporaires égal à 2d6 plus votre modificateur de Sagesse.</content>
+  <content contentuid="h772e3772g49fdg8cf4g0f02g893153584b30" version="1">Illumination protectrice</content>
+  <content contentuid="h6c1ab5a0g8a40g1755g2eacg01f53db2903f" version="1">Lorsqu'une créature que vous voyez à 9 mètres de vous effectue un jet d'attaque, vous pouvez utiliser une Réaction pour imposer le Désavantage au jet d'attaque, faisant jaillir de la lumière avant qu'il touche ou rate.</content>
+  <content contentuid="h03dc1992g1d8agc3e0ga6bbg22607e81d966" version="1">Illumination protectrice (Allié)</content>
+  <content contentuid="hcb0f1d4dg6ea8gf1eag5e72g32b56f306af2" version="1">Illumination protectrice (Soi-même)</content>
   <content contentuid="hdc4e30afg0702g20ddgf4a5g1751c8b46770" version="1">Niveau 3 : Invoquer la duplicité</content>
   <content contentuid="h31748432g34ebg740cgf353g2071d6cae486" version="1">Comme Action bonus, vous pouvez dépenser une utilisation de votre Conduit divin pour créer une parfaite illusion visuelle de vous-même dans un espace inoccupé que vous voyez à [1]. L'illusion dure 1 minute. Comme Action bonus, vous pouvez déplacer l'illusion jusqu'à [1] vers un autre espace inoccupé que vous voyez.</content>
   <content contentuid="h002b7ed0g2d07g9ecbg0301g13b767a04c7e" version="1">Niveau 6 : Transposition du filou</content>
@@ -188,7 +188,7 @@ De plus, chaque fois que vous utilisez l'Éclat protecteur, vous pouvez accorder
   <content contentuid="h82f58797g491fg0f3ag42b4g05c22ee9679d" version="1">Chaque fois que vous prenez l'Action bonus pour créer ou déplacer l'illusion de votre Invoquer la duplicité, vous pouvez vous téléporter, échangeant votre position avec celle de l'illusion.</content>
   <content contentuid="hb5220d58g095fg5ae1g7115g72d15a96ef0c" version="1">Vous pouvez surnaturellement inspirer les autres par des mots, de la musique ou de la danse. Cette inspiration est représentée par votre dé d'Inspiration bardique, qui est un d6.
 
-Utiliser l'Inspiration bardique. Comme Action bonus, vous pouvez inspirer une autre créature à 60 pieds de vous qui peut vous voir ou vous entendre. Cette créature gagne l'un de vos dés d'Inspiration bardique. Une créature ne peut avoir qu'un seul dé d'Inspiration bardique à la fois.
+Utiliser l'Inspiration bardique. Comme Action bonus, vous pouvez inspirer une autre créature à 18 mètres de vous qui peut vous voir ou vous entendre. Cette créature gagne l'un de vos dés d'Inspiration bardique. Une créature ne peut avoir qu'un seul dé d'Inspiration bardique à la fois.
 
 Une fois au cours de l'heure suivante, lorsque la créature rate un Test de d20, elle peut lancer le dé d'Inspiration bardique et ajouter le résultat obtenu au d20, transformant potentiellement l'échec en succès. Un dé d'Inspiration bardique est dépensé quand il est lancé.
 
@@ -198,7 +198,7 @@ Nombre d'utilisations. Vous pouvez accorder un dé d'Inspiration bardique un nom
   <content contentuid="h63129871gfb37gc314g1fdfg9b10303bcc26" version="1">Niveau 1 : Inspiration bardique</content>
   <content contentuid="h2810e8cag53f2gddb2gb1bbg7d5f6848ec0b" version="1">Vous pouvez surnaturellement inspirer les autres par des mots, de la musique ou de la danse. Cette inspiration est représentée par votre dé d'Inspiration bardique, qui est un d6.
 
-Utiliser l'Inspiration bardique. Comme Action bonus, vous pouvez inspirer une autre créature à 60 pieds de vous qui peut vous voir ou vous entendre. Cette créature gagne l'un de vos dés d'Inspiration bardique. Une créature ne peut avoir qu'un seul dé d'Inspiration bardique à la fois.
+Utiliser l'Inspiration bardique. Comme Action bonus, vous pouvez inspirer une autre créature à 18 mètres de vous qui peut vous voir ou vous entendre. Cette créature gagne l'un de vos dés d'Inspiration bardique. Une créature ne peut avoir qu'un seul dé d'Inspiration bardique à la fois.
 
 Une fois au cours de l'heure suivante, lorsque la créature rate un Test de d20, elle peut lancer le dé d'Inspiration bardique et ajouter le résultat obtenu au d20, transformant potentiellement l'échec en succès. Un dé d'Inspiration bardique est dépensé quand il est lancé.
 
@@ -212,23 +212,23 @@ Nombre d'utilisations. Vous pouvez accorder un dé d'Inspiration bardique un nom
   <content contentuid="h7ea2f219gec23g1a96ga5efgce5d1bc88951" version="1">Charges d'attaque supplémentaire du Prêtre de guerre</content>
   <content contentuid="ha96c97feg6fd1gc562g799fgde13a4800459" version="1">Point utilisé pour obtenir une attaque supplémentaire comme Action bonus.</content>
   <content contentuid="h4dc018cagbaa3ga624g7da2g0a6dab9353ce" version="1">Niveau 3 : Frappe guidée</content>
-  <content contentuid="ha052e514g0261g1570g0745g00d44f89cc3d" version="1">Lorsque vous ou une créature à 30 pieds de vous ratez un jet d'attaque, vous pouvez dépenser une utilisation de votre Conduit divin et accorder à ce jet un bonus de +10, ce qui pourrait le faire toucher. Lorsque vous utilisez cette capacité pour bénéficier au jet d'attaque d'une autre créature, vous devez utiliser une Réaction.</content>
+  <content contentuid="ha052e514g0261g1570g0745g00d44f89cc3d" version="1">Lorsque vous ou une créature à 9 mètres de vous ratez un jet d'attaque, vous pouvez dépenser une utilisation de votre Conduit divin et accorder à ce jet un bonus de +10, ce qui pourrait le faire toucher. Lorsque vous utilisez cette capacité pour bénéficier au jet d'attaque d'une autre créature, vous devez utiliser une Réaction.</content>
   <content contentuid="h81ab1ec4g5097gf34cg7f12g4d040607771b" version="2">Frappe guidée (Soi-même)</content>
   <content contentuid="h900f0f0bgcd61g0708g6d02gf89738f718de" version="1">Niveau 6 : Bénédiction du dieu de la guerre</content>
-  <content contentuid="h0c6d3ec2g7683g7e9fg7d62g08a6874b3c5f" version="1">Vous pouvez dépenser une utilisation de votre Conduit divin pour lancer Armure de foi ou Arme spirituelle sans dépenser d'emplacement de sort. Lorsque vous lancez l'un ou l'autre sort de cette façon, le sort ne nécessite pas de Concentration. Le sort dure plutôt 1 minute, mais il se termine prématurément si vous lancez à nouveau ce sort, avez la condition Neutralisé, ou mourez.</content>
-  <content contentuid="h3bb1c07ag3913g5b74g9454gdcebc7737556" version="1">Armure de foi : Bénédiction du dieu de la guerre</content>
+  <content contentuid="h0c6d3ec2g7683g7e9fg7d62g08a6874b3c5f" version="1">Vous pouvez dépenser une utilisation de votre Conduit divin pour lancer Bouclier de la foi ou Arme spirituelle sans dépenser d'emplacement de sort. Lorsque vous lancez l'un ou l'autre sort de cette façon, le sort ne nécessite pas de Concentration. Le sort dure plutôt 1 minute, mais il se termine prématurément si vous lancez à nouveau ce sort, avez la condition Neutralisé, ou mourez.</content>
+  <content contentuid="h3bb1c07ag3913g5b74g9454gdcebc7737556" version="1">Bouclier de la foi : Bénédiction du dieu de la guerre</content>
   <content contentuid="hcaeae1ebgf2c5gb598g6716gb1b7c699916c" version="1">Arme spirituelle : Bénédiction du dieu de la guerre</content>
-  <content contentuid="h002f5e57g1181g2dbbg226fgf29f606b801c" version="1">Frappe des vents d'acier</content>
-  <content contentuid="h0da58492g230cg424fg00cdg006fb672dd4d" version="1">Vous faites tournoyer l'arme utilisée pour l'incantation, puis vous vous évanouissez pour frapper comme le vent. Choisissez jusqu'à cinq créatures que vous voyez à portée. Effectuez une attaque de sort de corps à corps contre chaque cible. En cas de touche, une cible subit [1].</content>
+  <content contentuid="h002f5e57g1181g2dbbg226fgf29f606b801c" version="2">Frappe des vents d'acier</content>
+  <content contentuid="h0da58492g230cg424fg00cdg006fb672dd4d" version="2">Vous faites tournoyer l'arme utilisée pour l'incantation, puis vous vous évanouissez pour frapper comme le vent, réapparaissant à côté d'une créature que vous pouvez voir à portée et effectuant une attaque de sort de corps à corps contre elle. Vous poursuivez ensuite votre course, vous déplaçant entre les ennemis proches pour attaquer à nouveau, frappant jusqu'à cinq créatures différentes au total. En cas de touche, une cible subit [1].</content>
   <content contentuid="h84a10acdg5e1fgb4f6g3b55g7f5134f52d10" version="1">Pointe mentale</content>
   <content contentuid="h05f1c3ebg02fcg677cga473g464cac2d584f" version="1">Vous enfoncez une pointe d'énergie psionique dans l'esprit d'une créature que vous voyez à portée. La cible effectue un jet de sauvegarde de Sagesse, subissant des dégâts Psychiques en cas d'échec ou la moitié de ces dégâts en cas de réussite. En cas d'échec, vous connaissez également toujours l'emplacement de la cible jusqu'à la fin du sort. Tant que vous avez cette connaissance, la cible ne peut pas se cacher de vous, et si elle a la condition Invisible, elle ne bénéficie pas de cet état contre vous.</content>
-  <content contentuid="hd666f94dg1a88g5b93g7dcbgfbc951360305" version="1">Statique synaptique</content>
+  <content contentuid="hd666f94dg1a88g5b93g7dcbgfbc951360305" version="1">Perturbations synaptiques</content>
   <content contentuid="haddaa3c4ga780gc6c0g5533g2da826d6931f" version="1">Vous faites éclater de l'énergie psychique en un point à portée. Chaque créature dans une Sphère de [1] de rayon centrée sur ce point effectue un jet de sauvegarde d'Intelligence, subissant des dégâts Psychiques en cas d'échec ou la moitié de ces dégâts en cas de réussite.
 
 En cas d'échec, une cible a également des pensées confuses pendant 1 minute. Durant ce temps, elle soustrait 1d6 à tous ses jets d'attaque et tests de caractéristique, ainsi qu'à tout jet de sauvegarde de Constitution pour maintenir la Concentration. La cible effectue un jet de sauvegarde d'Intelligence à la fin de chacun de ses tours, mettant fin à l'effet sur elle-même en cas de réussite.</content>
   <content contentuid="hc29da1ffgb5d5g29c2g97c3g2050946f5a23" version="1">Pointe mentale</content>
   <content contentuid="h3aac9e83g2f2ag85ddgcf84ge7224ea85b8b" version="1">L'emplacement de la créature est toujours connu du lanceur de sorts jusqu'à la fin du sort. La créature ne peut pas se cacher du lanceur de sorts, et si elle a la condition Invisible, elle ne bénéficie pas de cet état contre le lanceur de sorts.</content>
-  <content contentuid="h0eb6a1ccg061cg7757g2ce7gb1ae17ae8a0f" version="1">Statique synaptique</content>
+  <content contentuid="h0eb6a1ccg061cg7757g2ce7gb1ae17ae8a0f" version="1">Perturbations synaptiques</content>
   <content contentuid="h9e56e88cg0481g2c87g52e7g140df577385c" version="1">La créature soustrait 1d6 à tous ses jets d'attaque et tests de caractéristique, ainsi qu'à tout jet de sauvegarde de Constitution qu'elle effectue pour maintenir la Concentration. À la fin de chacun de ses tours, la cible effectue un jet de sauvegarde d'Intelligence, mettant fin à l'effet en cas de réussite.</content>
   <content contentuid="h32658116g9dc9g1364g0f58g311a9cad82b8" version="1">Niveau 3 : Magie mentale</content>
   <content contentuid="h2035dcdeg7b97g47a9gcfb1gb7bc1f9c6cb9" version="2">Comme action Magique, vous pouvez dépenser une utilisation de votre Conduit divin pour manifester vos connaissances magiques. Choisissez un sort du Domaine du savoir ou de l'école de Divination. Dans le cadre de la même action, vous lancez le sort choisi sans dépenser d'emplacement de sort.</content>
@@ -236,9 +236,9 @@ En cas d'échec, une cible a également des pensées confuses pendant 1 minute. 
   <content contentuid="hdd98d6aage020gf00bgcd6fg4be2ad2fd956" version="1">Vous gagnez la maîtrise des jets de sauvegarde d'Intelligence.
 
 Ajoutez la moitié de votre Modificateur de Sagesse aux &lt;LSTag Tooltip="AbilityCheck"&gt;Tests de caractéristique&lt;/LSTag&gt; dans lesquels vous n'êtes pas &lt;LSTag Tooltip="Proficiency"&gt;Compétent&lt;/LSTag&gt;.</content>
-  <content contentuid="hf5d6de51g8683g514bgcfd2gd52016de99fe" version="1">Feu follet étoilé</content>
-  <content contentuid="h9cbc738dgd21bg77f4g2687gd1ac412ca2b4" version="1">Vous lancez une particule de lumière vers une créature ou un objet à portée. Effectuez une attaque de sort à distance contre la cible. En cas de touche, la cible subit des dégâts Radieux, et jusqu'à la fin de votre prochain tour, elle émet une Lumière faible dans un rayon de [1] et ne peut pas bénéficier de l'état Invisible.</content>
-  <content contentuid="h6d4e8665g6567g3bc4gd9f1g206db8efad20" version="1">Luciole stellaire</content>
+  <content contentuid="hf5d6de51g8683g514bgcfd2gd52016de99fe" version="1">Poussière d'étoile</content>
+  <content contentuid="h9cbc738dgd21bg77f4g2687gd1ac412ca2b4" version="1">Vous lancez une particule de lumière vers une créature ou un objet à portée. Effectuez une attaque de sort à distance contre la cible. En cas de touche, la cible subit des dégâts Radiants, et jusqu'à la fin de votre prochain tour, elle émet une Lumière faible dans un rayon de [1] et ne peut pas bénéficier de l'état Invisible.</content>
+  <content contentuid="h6d4e8665g6567g3bc4gd9f1g206db8efad20" version="1">Poussière d'étoile</content>
   <content contentuid="he44a89e4gd251g9a1dg6abagca1e9807a226" version="1">La créature émet une Lumière faible dans un rayon de [1] et ne peut pas bénéficier de l'état Invisible.</content>
   <content contentuid="h8d4a4bb1g65b7g5025g4514gdfa80f1282ba" version="1">Coup de tonnerre</content>
   <content contentuid="h853f3b07gf693g964eg9f97g97a2cfda50ef" version="1">Chaque créature dans une Émanation de [1] prenant sa source en vous doit réussir un jet de sauvegarde de Constitution ou subir des dégâts de Tonnerre.</content>
@@ -247,20 +247,20 @@ Ajoutez la moitié de votre Modificateur de Sagesse aux &lt;LSTag Tooltip="Abili
   <content contentuid="h1193aa13ge0d7ge702g2f85ga0c0527d229d" version="2">Niveau 1 : Ordre primordial : Gardien</content>
   <content contentuid="h236eb2e6g63d1g6008gac03gd13912a2af7b" version="1">Gardien. Entraîné pour le combat, vous obtenez la maîtrise des armes de guerre et l'entraînement avec les armures intermédiaires.</content>
   <content contentuid="hdc66e2feg6dc9g8e0dg69c3g1ac135e77240" version="1">Niveau 1 : Ordre primordial : Assistance</content>
-  <content contentuid="h261201bdgf3e1gc0a9g001bg9f21c4b6eb0b" version="1">Magicien. Vous connaissez un tour de magie supplémentaire de la liste de sorts du Druide. De plus, votre connexion mystique avec la nature vous accorde un bonus à vos tests d'Intelligence (Arcanes ou Nature). Le bonus est égal à votre modificateur de Sagesse (bonus minimum de +1).</content>
+  <content contentuid="h261201bdgf3e1gc0a9g001bg9f21c4b6eb0b" version="1">Magicien. Vous connaissez un sort mineur supplémentaire de la liste de sorts du Druide. De plus, votre connexion mystique avec la nature vous accorde un bonus à vos tests d'Intelligence (Arcanes ou Nature). Le bonus est égal à votre modificateur de Sagesse (bonus minimum de +1).</content>
   <content contentuid="hf498864agc7beg3cdbgca11g269c576f1a01" version="1">Assistance</content>
-  <content contentuid="h4e0c0b74gabceg8644g0a67g8c877d23dd83" version="1">Niveau 1 : Ordre primordial : Jet de poison</content>
-  <content contentuid="h3635dadfgfe4eg55c4g39dfgaf968256d2d8" version="1">Jet de poison</content>
-  <content contentuid="h5307ff13g4736g2ce2ga66fg11f20a990de2" version="2">Niveau 1 : Ordre primordial : Produire une flamme</content>
-  <content contentuid="h5169409cg04adgc907gd30eg09ebe8d3738c" version="1">Produire une flamme</content>
+  <content contentuid="h4e0c0b74gabceg8644g0a67g8c877d23dd83" version="1">Niveau 1 : Ordre primordial : Bouffée de poison</content>
+  <content contentuid="h3635dadfgfe4eg55c4g39dfgaf968256d2d8" version="1">Bouffée de poison</content>
+  <content contentuid="h5307ff13g4736g2ce2ga66fg11f20a990de2" version="2">Niveau 1 : Ordre primordial : Production de flamme</content>
+  <content contentuid="h5169409cg04adgc907gd30eg09ebe8d3738c" version="1">Production de flamme</content>
   <content contentuid="h55c47b09ga380g8cf2g15b8g2bedd46fe8e9" version="2">Niveau 1 : Ordre primordial : Résistance</content>
   <content contentuid="h69ae862bga7a4g2605g04a4gd9317e169763" version="1">Résistance</content>
-  <content contentuid="hd0c364a3g050eg598bgd2fdg4c1b525be149" version="2">Niveau 1 : Ordre primordial : Gourdin naturel</content>
-  <content contentuid="h599263a1g8987g0f3dgf199g149b6068247f" version="1">Gourdin naturel</content>
+  <content contentuid="hd0c364a3g050eg598bgd2fdg4c1b525be149" version="2">Niveau 1 : Ordre primordial : Gourdin magique</content>
+  <content contentuid="h599263a1g8987g0f3dgf199g149b6068247f" version="1">Gourdin magique</content>
   <content contentuid="hab8ea7d9g7419g79d4ge012g86380a295a02" version="3">Niveau 1 : Ordre primordial : Stabilisation</content>
   <content contentuid="hf5a7c07dg5d75g8b41g3ce4g8e350dae85b9" version="1">Stabilisation</content>
-  <content contentuid="hd5bb58c8g9203g4533gc615ga31bea2a2187" version="2">Niveau 1 : Ordre primordial : Luciole stellaire</content>
-  <content contentuid="h8891553bg7ca5g791ag4b95g5a72f6e71ed4" version="1">Luciole stellaire</content>
+  <content contentuid="hd5bb58c8g9203g4533gc615ga31bea2a2187" version="2">Niveau 1 : Ordre primordial : Poussière d'étoile</content>
+  <content contentuid="h8891553bg7ca5g791ag4b95g5a72f6e71ed4" version="1">Poussière d'étoile</content>
   <content contentuid="hc7a0905fg5836g8050gb036gd435c6a53ffd" version="2">Niveau 1 : Ordre primordial : Fouet épineux</content>
   <content contentuid="h1793f9fbgf70agf3acge48bg70b646b51326" version="1">Fouet épineux</content>
   <content contentuid="h566f5dd1g1db3g0d0age62cg0ff1909892ef" version="2">Niveau 1 : Ordre primordial : Coup de tonnerre</content>
@@ -322,7 +322,7 @@ Classe d'armure : Jusqu'à ce que vous quittiez la forme, votre CA est égale à
 
 Points de vie temporaires : Vous gagnez un nombre de Points de vie temporaires égal à trois fois votre niveau de Druide.</content>
   <content contentuid="h50a84c2agc47eg3409gfbf3g8b9efe860b49" version="1">Niveau 7 : Furie élémentaire : Incantation puissante</content>
-  <content contentuid="hdbacd095g40f6g7468g5750g2f164c7506d4" version="1">Incantation puissante. Ajoutez votre modificateur de Sagesse aux dégâts que vous infligez avec un tour de magie de Druide.</content>
+  <content contentuid="hdbacd095g40f6g7468g5750g2f164c7506d4" version="1">Incantation puissante. Ajoutez votre modificateur de Sagesse aux dégâts que vous infligez avec un sort mineur de Druide.</content>
   <content contentuid="h623803a7gceadgfb71gf1d2g9f3e3921f3f2" version="1">Niveau 7 : Furie élémentaire : Frappe primordiale (Froid)</content>
   <content contentuid="h1cfad235g00bdg10bfgf085g60ac289d2534" version="1">Frappe primordiale. Une fois à chacun de vos tours lorsque vous touchez une créature avec un jet d'attaque en utilisant une arme ou l'attaque d'une forme de Bête en Forme sauvage, vous pouvez faire subir à la cible [1] dégâts supplémentaires.</content>
   <content contentuid="he3035afbgf846g4686gf4e6gc39575739bed" version="1">Niveau 7 : Furie élémentaire : Frappe primordiale (Feu)</content>
@@ -335,9 +335,9 @@ Points de vie temporaires : Vous gagnez un nombre de Points de vie temporaires �
   <content contentuid="h8d0f6247g32e9g935cg8e24g277269d5eee0" version="1">Sorts du Cercle de la Lune</content>
   <content contentuid="h97d1904cg83d1gdb83ge2b8gfb2e45881c92" version="1">Vous pouvez lancer des sorts du Cercle de la Lune lorsque vous êtes en Forme sauvage.</content>
   <content contentuid="h81a318d3g7d25ge9f7g6cb8g0d641f9d7d75" version="1">Source de clair de lune</content>
-  <content contentuid="h7133dd62g2ff3g5631g286cgfb7c7edec60f" version="1">Jusqu'à la fin du sort, vous avez la Résistance aux dégâts Radieux, et vos attaques de mêlée infligent [1] dégâts supplémentaires en cas de touche.</content>
+  <content contentuid="h7133dd62g2ff3g5631g286cgfb7c7edec60f" version="1">Jusqu'à la fin du sort, vous avez la Résistance aux dégâts Radiants, et vos attaques de mêlée infligent [1] dégâts supplémentaires en cas de touche.</content>
   <content contentuid="h7a281f4cgfc20gce12g5a55ge741d085a992" version="1">Source de clair de lune</content>
-  <content contentuid="hf0a594f4gbcafg3438g8e4cg19d60ca756cd" version="1">Jusqu'à la fin du sort, vous avez la Résistance aux dégâts Radieux, et vos attaques de mêlée infligent [1] dégâts supplémentaires en cas de touche.</content>
+  <content contentuid="hf0a594f4gbcafg3438g8e4cg19d60ca756cd" version="1">Jusqu'à la fin du sort, vous avez la Résistance aux dégâts Radiants, et vos attaques de mêlée infligent [1] dégâts supplémentaires en cas de touche.</content>
   <content contentuid="hc9501eaeg3c65g8261gbbbegc5a79478ce47" version="1">Source de clair de lune</content>
   <content contentuid="h4d3aa54bg7cf4g12d5g0d79g21d13c55e1c1" version="1">Niveau 6 : Formes du cercle améliorées</content>
   <content contentuid="h25a52b4bg965bga6bdgaee9gb81edcb888e9" version="1">Lorsque vous êtes en forme de Forme sauvage, vous pouvez ajouter votre modificateur de Sagesse à vos jets de sauvegarde de Constitution.</content>
@@ -386,14 +386,14 @@ De plus, immédiatement après avoir infligé un Coup critique, vous pouvez vous
   <content contentuid="h4dfef820g9b72g3d0egde23ga602945eec3c" version="1">Obtenez l'&lt;LSTag Tooltip="Advantage"&gt;Avantage&lt;/LSTag&gt; à votre &lt;LSTag Tooltip="AttackRoll"&gt;jet d'attaque&lt;/LSTag&gt; ou &lt;LSTag Tooltip="SavingThrow"&gt;jet de sauvegarde&lt;/LSTag&gt;.</content>
   <content contentuid="h40d89fa7ga96bgd2a5g9917g93f8ac20286b" version="1">Inspiration héroïque</content>
   <content contentuid="h82e9547dg2a57g3068g6744g22536b77a26f" version="1">Niveau 10 : Frappe mystique</content>
-  <content contentuid="h4f0291dage2acga1e7g22a4ga4748a927a0d" version="1">Attaque supplémentaire 2 (Tour de magie)</content>
+  <content contentuid="h4f0291dage2acga1e7g22a4ga4748a927a0d" version="1">Attaque supplémentaire 2 (Sort mineur)</content>
   <content contentuid="h9a6cdeb9g51d2g4ed0gb4e4gb453d3f8c2e7" version="1">Vous pouvez attaquer trois fois au lieu d'une fois dès lors que vous effectuez l'action Attaquer à votre tour.
 
-De plus, vous pouvez lancer l'un de vos tours de magie dont le temps d'incantation est une action à la place de l'une de ces attaques.</content>
-  <content contentuid="hea3538f1g6d4fgd692gdf5cg16c0c6d70258" version="1">Attaque supplémentaire 2 (Tour de magie)</content>
+De plus, vous pouvez lancer l'un de vos sorts mineurs dont le temps d'incantation est une action à la place de l'une de ces attaques.</content>
+  <content contentuid="hea3538f1g6d4fgd692gdf5cg16c0c6d70258" version="1">Attaque supplémentaire 2 (Sort mineur)</content>
   <content contentuid="hd383ab64gcd01g6437g4439gcce1bcafb30c" version="1">Vous pouvez attaquer trois fois au lieu d'une fois dès lors que vous effectuez l'action Attaquer à votre tour.
 
-De plus, vous pouvez lancer l'un de vos tours de magie dont le temps d'incantation est une action à la place de l'une de ces attaques.</content>
+De plus, vous pouvez lancer l'un de vos sorts mineurs dont le temps d'incantation est une action à la place de l'une de ces attaques.</content>
   <content contentuid="h66ceeddfg85e7gf6e6g45fdgf681167aa694" version="1">Niveau 10 : Supériorité au combat améliorée</content>
   <content contentuid="h1a9ea1d9gcca2gd533gd087g0e05473a8b97" version="1">Niveau 1 : Défense sans armure</content>
   <content contentuid="hb6df1fdbgd732gf839g1534g7c3a49d1d89d" version="1">Tant que vous ne portez pas d'armure et ne maniez pas de bouclier, votre Classe d'armure de base est égale à 10 plus vos modificateurs de Dextérité et de Sagesse.</content>
@@ -451,7 +451,7 @@ Défense patiente et Pas du vent : Lorsque vous dépensez un Point de concentrat
   <content contentuid="hb0d0ae76g515agec5dg8b3fgfef5c6b386f3" version="1">Niveau 10 : Restauration personnelle</content>
   <content contentuid="hb6524b85g7c46g835fg5ec8g505bf3a2d396" version="1">Niveau 10 : Pureté du corps</content>
   <content contentuid="hc41f1b91gbedcg876fg1542g2c46f2f4be27" version="1">Niveau 3 : Arts des ombres</content>
-  <content contentuid="h62e16743gcb72g9068gb2d0gb1a62ea9d321" version="1">Vous avez appris à puiser dans le pouvoir du Féeombre, obtenant les bénéfices suivants.
+  <content contentuid="h62e16743gcb72g9068gb2d0gb1a62ea9d321" version="1">Vous avez appris à puiser dans le pouvoir de la Gisombre, obtenant les bénéfices suivants.
 
 Ténèbres. Vous pouvez dépenser 1 Point de concentration pour lancer le sort Ténèbres sans composantes. Vous pouvez voir à l'intérieur de la zone du sort lorsque vous le lancez grâce à cette capacité. Tant que le sort persiste, vous pouvez déplacer sa zone de Ténèbres vers un espace situé à [1] de vous-même au début de chacun de vos tours.
 Vision dans le noir. Vous obtenez la Vision dans le noir avec une portée de [1]. Si vous avez déjà la Vision dans le noir, sa portée augmente de 18 mètres.
@@ -468,7 +468,7 @@ Frappes élémentaires : Chaque fois que vous touchez avec votre Frappe à mains
   <content contentuid="h5644171bg3f2cg52f1gc8dcgc1e6b38d6a9b" version="1">Syntonisation élémentaire : Feu</content>
   <content contentuid="h60fd53fcgbe77gcb48gd29dg52f09c53ad87" version="1">Syntonisation élémentaire : Foudre</content>
   <content contentuid="h459ce897gc32bgf940g855egc984bd313c7c" version="1">Syntonisation élémentaire : Tonnerre</content>
-  <content contentuid="h5c61ee4bg56f8gfe0fgb3c5g7712a4e3d87e" version="1">Syntonisation élémentaire : Acide</content>
+  <content contentuid="h5c61ee4bg56f8gfe0fgb3c5g7712a4e3d87e" version="2">Syntonisation élémentaire</content>
   <content contentuid="he11f6bc3ga347g550fg0466g52c1a9c5aad4" version="1">Syntonisation élémentaire : Froid</content>
   <content contentuid="hb648df73g12d6gb0b3g24e3g1c88ad261547" version="1">Syntonisation élémentaire : Feu</content>
   <content contentuid="habb49dadg47e5gc5bag6c56g45bf51c0e30c" version="1">Syntonisation élémentaire : Foudre</content>
@@ -634,7 +634,7 @@ Vous ne bénéficiez pas de cette capacité si vous avez l'état Neutralisé.</c
   <content contentuid="h6e517fa0g6790g8599ga038gec0254c7fae0" version="1">Niveau 9 : Visée en mouvement</content>
   <content contentuid="h4ad37d2fg7e63g64e1g0db3g45844045ca7d" version="1">Votre Vitesse n'est pas réduite à 0 par l'utilisation de Visée assurée.</content>
   <content contentuid="he1072514g2359gf4c9g9ab0gf2fd8d2183ce" version="1">Niveau 3 : Mains rapides</content>
-  <content contentuid="h127592e2g23a4gc43cg2c3fgbbf222b3b2d1" version="1">Vous pouvez utiliser Lancer comme Action bonus.</content>
+  <content contentuid="h127592e2g23a4gc43cg2c3fgbbf222b3b2d1" version="1">Vous pouvez utiliser Lancer comme Action bonus. Vous pouvez utiliser un Parchemin de sort comme Action bonus. Les conditions d'utilisation d'un Parchemin de sort restent inchangées.</content>
   <content contentuid="h3cad8c7eg48eeg5692g23c0g79706df73d92" version="1">Niveau 3 : Travail en hauteur</content>
   <content contentuid="h2fc3807bg34e4gbdbeg88f4gb50fa0facd7e" version="1">Lancer : Main rapide</content>
   <content contentuid="h60ea26b2gbcebg085dg4445g8f07a9d3ff4c" version="1">Paladin</content>
@@ -670,9 +670,9 @@ De plus, lorsque votre capacité de Sorcellerie innée est active, votre DD de s
   <content contentuid="h186d2005gce77g5134gd47dgcd1286eb95f5" version="1">Déflagration sorcière</content>
   <content contentuid="hf0be6fffg6e33g9c45g69bdg8f11958d0454" version="2">Vous lancez de l'énergie sorcière vers une créature ou un objet à portée. Effectuez une attaque de sort à distance contre la cible. En cas de touche, la cible subit des dégâts d'un type de votre choix : Acide, Froid, Feu, Foudre, Poison, Psychique ou Tonnerre.
 
-Parfois la magie se déchaîne et inflige des dégâts supplémentaires. La chance d'un emballement magique augmente à chaque fois que les dégâts de ce tour de magie augmentent aux niveaux supérieurs.</content>
+Parfois la magie se déchaîne et inflige des dégâts supplémentaires. La chance d'un emballement magique augmente à chaque fois que les dégâts de ce sort mineur augmentent aux niveaux supérieurs.</content>
   <content contentuid="h1e350658g92b2g40abg4e13g0a0194995e34" version="1">Vigueur arcanique</content>
-  <content contentuid="hfd4a4e4dg3a3eg0bd1g2716gc7e32738a35f" version="1">Vous puisez dans votre force vitale pour vous soigner.</content>
+  <content contentuid="hfd4a4e4dg3a3eg0bd1g2716gc7e32738a35f" version="2">Vous puisez dans votre force vitale pour vous soigner. Lancez [1] de vos Dés de points de vie non dépensés, et récupérez un nombre de Points de vie égal au total du jet plus votre modificateur de caractéristique d'incantation. Ces dés sont alors dépensés.</content>
   <content contentuid="h20d548d9g2600gaf44geda5gd71ed6825255" version="1">Ruse magique</content>
   <content contentuid="h0475c80dgb3d2g65a0g32e3g51e0604b9fae" version="1">Vous pouvez effectuer un rite ésotérique pendant 1 minute. À la fin de celui-ci, vous récupérez des emplacements de sort de Magie du pacte dépensés, mais pas plus que la moitié de votre maximum (arrondi au-dessus). Une fois que vous avez utilisé cette capacité, vous ne pouvez pas la réutiliser avant de terminer un Repos long.</content>
   <content contentuid="hbe38acefg243eg2454ge187g5d1c50d4bb2b" version="2">Niveau 1 : Esprit occulte</content>
@@ -688,10 +688,10 @@ Parfois la magie se déchaîne et inflige des dégâts supplémentaires. La chan
   <content contentuid="ha97e7097gda9cgc3eegbb86g9bf88d36ee68" version="1">Niveau 2 : Bond surnaturel</content>
   <content contentuid="hd47c4e1cg1e7ag651cg8c57g7deb405ec80c" version="1">Niveau 2 : Déflagration repoussante</content>
   <content contentuid="h425487e0g16b7ga256gb63ag56872a5ea672" version="1">Niveau 5 : Châtiment occulte</content>
-  <content contentuid="h4d483577g0d77g722dg50ddga9f231b29ec2" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Gigantesque ou inférieure.</content>
+  <content contentuid="h4d483577g0d77g722dg50ddga9f231b29ec2" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Énorme ou inférieure.</content>
   <content contentuid="hc0ad688dged59g744fgf3e6g1e706f4ee29c" version="1">Niveau 5 : Un avec les ombres</content>
   <content contentuid="hb2501172gdfd6gb7ebg0621ga38a34e3f573" version="1">Niveau 5 : Lame assoiffée</content>
-  <content contentuid="ha794dab4gf433ga08bg7d82gda68964c691c" version="1">Vous gagnez la capacité Attaque supplémentaire pour votre arme de pacte uniquement. Avec cette capacité, vous pouvez attaquer deux fois avec l'arme au lieu d'une lorsque vous effectuez l'action Attaque à votre tour.</content>
+  <content contentuid="ha794dab4gf433ga08bg7d82gda68964c691c" version="1">Vous gagnez la capacité Attaque supplémentaire pour votre arme de pacte uniquement. Avec cette capacité, vous pouvez attaquer deux fois avec l'arme au lieu d'une lorsque vous effectuez l'action Attaquer à votre tour.</content>
   <content contentuid="h0c1dba3ag239egef50g0d52g47241e4e6016" version="1">Niveau 5 : Investissement du maître de la chaîne</content>
   <content contentuid="he5f3196agc9ccg5177gedd9ged594f4d1f5a" version="1">Niveau 5 : Don des profondeurs</content>
   <content contentuid="h307a5339gff1ag9485g5387gfb0813a818b3" version="1">Niveau 7 : Chuchotements de la tombe</content>
@@ -733,24 +733,24 @@ Parfois la magie se déchaîne et inflige des dégâts supplémentaires. La chan
   <content contentuid="h5ebc0953g6724g72fageab4g7f5682f9fb32" version="1">Niveau 9 : Serviteurs du chaos</content>
   <content contentuid="hf1a63187g9766gc5aeg0b86g693324a45025" version="1">Prérequis : Niveau 9+ Occultiste</content>
   <content contentuid="h3098d03bg9b76gd04eg7ef8g689022ec62ad" version="1">Invocation : Don des protecteurs</content>
-  <content contentuid="had9ee1e5g5369g47b5g65c4g37b956523a59" version="1">Éclat mental</content>
+  <content contentuid="had9ee1e5g5369g47b5g65c4g37b956523a59" version="1">Piqûre mentale</content>
   <content contentuid="h3f49f302g9b29g72f7g25f0g2f3ff3297c48" version="1">Vous tentez de fragmenter temporairement l'esprit d'une créature que vous voyez à portée. La cible doit réussir un jet de sauvegarde d'Intelligence ou subir des dégâts Psychiques et soustraire 1d4 au prochain jet de sauvegarde qu'elle effectue avant la fin de votre prochain tour.</content>
-  <content contentuid="h1be8ef4cg573bg9247g8bf7gbe003418678b" version="1">Les tours de magie d'Occultiste qui infligent des dégâts et ont une portée voient leur portée multipliée par 1,5 lorsque vous les lancez.</content>
-  <content contentuid="h92b0f41cg7222g57a1gf293g5f9b67f6c76a" version="1">Tours de magie d'Occultiste qui nécessitent un jet d'attaque : lorsque vous touchez une créature de taille Grande ou inférieure avec un tel tour de magie, vous pouvez pousser la créature jusqu'à [1] directement à l'écart de vous.</content>
+  <content contentuid="h1be8ef4cg573bg9247g8bf7gbe003418678b" version="1">Les sorts mineurs d'Occultiste qui infligent des dégâts et ont une portée voient leur portée multipliée par 1,5 lorsque vous les lancez.</content>
+  <content contentuid="h92b0f41cg7222g57a1gf293g5f9b67f6c76a" version="1">Sorts mineurs d'Occultiste qui nécessitent un jet d'attaque : lorsque vous touchez une créature de taille Grande ou inférieure avec un tel sort mineur, vous pouvez pousser la créature jusqu'à [1] directement à l'écart de vous.</content>
   <content contentuid="h63854322g2981gf688g3b17g3be3eb3cbaea" version="1">Déflagration occulte</content>
   <content contentuid="h5821657eg6a48gdd10gb380ga906788793a5" version="1">Invoquez [1] rayon(s) d'énergie crépitante.</content>
   <content contentuid="ha82b5e6dgb4b1gb2a1g8b53g475515ffec20" version="1">Lame retentissante</content>
   <content contentuid="h0e37672dgdb7bg5838g12bcg8e96a88d3d98" version="1">Frappez avec votre arme, infligeant à votre ennemi une résonance qui lui inflige [1] dégâts lorsqu'il se déplace.</content>
-  <content contentuid="hde7eade7g981dg355bg6e30g0089c6fe0377" version="1">Frappe assurée (Corps à corps)</content>
+  <content contentuid="hde7eade7g981dg355bg6e30g0089c6fe0377" version="1">Coup au but (Corps à corps)</content>
   <content contentuid="hfc5b991fgffcdgbc3bgbe4eg4bbb47637ce8" version="2">Guidé par un éclair de perspicacité magique, vous effectuez une attaque avec l'arme utilisée pour lancer le sort. L'attaque utilise votre caractéristique d'incantation pour les jets d'attaque et de dégâts au lieu de la Force ou de la Dextérité. Si l'attaque inflige des dégâts, ils peuvent être de type Radiant ou du type normal de l'arme (à votre choix).</content>
-  <content contentuid="hc48575fbg3411gc50ag88aeg18f05fb53a0f" version="1">Frappe assurée (À distance)</content>
+  <content contentuid="hc48575fbg3411gc50ag88aeg18f05fb53a0f" version="1">Coup au but (À distance)</content>
   <content contentuid="he4de88abg8ba4g6afeg8c45g9069fad18699" version="2">Guidé par un éclair de perspicacité magique, vous effectuez une attaque avec l'arme utilisée pour lancer le sort. L'attaque utilise votre caractéristique d'incantation pour les jets d'attaque et de dégâts au lieu de la Force ou de la Dextérité. Si l'attaque inflige des dégâts, ils peuvent être de type Radiant ou du type normal de l'arme (à votre choix).</content>
   <content contentuid="h573020b3g1241g8748g5cccgf1a7c580e5d4" version="2">Guidé par un éclair de perspicacité magique, vous effectuez une attaque avec l'arme utilisée pour lancer le sort. L'attaque utilise votre caractéristique d'incantation pour les jets d'attaque et de dégâts au lieu de la Force ou de la Dextérité. Si l'attaque inflige des dégâts, ils peuvent être de type Radiant ou du type normal de l'arme (à votre choix).</content>
   <content contentuid="h17b4c239g8209gd0fbg57b8gadfb6d1e2826" version="1">Votre &lt;LSTag Type="Spell" Tooltip="Target_FindFamiliar"&gt;familier&lt;/LSTag&gt; gagne une Attaque supplémentaire.</content>
   <content contentuid="h170d4635g2a45gd51dg6f7cg0cc6d58ae805" version="1">Vous pouvez lancer &lt;LSTag Type="Spell" Tooltip="Target_AnimateDead"&gt;Animation des morts&lt;/LSTag&gt;, &lt;LSTag Type="Spell" Tooltip="Target_Haste"&gt;Hâte&lt;/LSTag&gt;, et &lt;LSTag Type="Spell" Tooltip="Target_CallLightning"&gt;Appel de la foudre&lt;/LSTag&gt; une fois chacun par Repos long.</content>
   <content contentuid="h1b185049g69f6gd479g03c1g85c564525648" version="1">Châtiment occulte</content>
   <content contentuid="h3793d1a6gc4b8g72a7geb63gdab6620030e7" version="1">Châtiment occulte</content>
-  <content contentuid="h39dbb752g7bd1g7b6fgad55gb007b398ba91" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Gigantesque ou inférieure.</content>
+  <content contentuid="h39dbb752g7bd1g7b6fgad55gb007b398ba91" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Énorme ou inférieure.</content>
   <content contentuid="h96af7feag9483ge79egf274ga41eefe9ae04" version="1">Châtiment occulte</content>
   <content contentuid="h94488385g3579gb95bga59ag7e9114cbe4d1" version="1">Châtiment occulte : Réaction</content>
   <content contentuid="hecfe0232g690bg7d4cg4846gf2a7cf8ec8c8" version="1">Châtiment occulte : Réaction</content>
@@ -758,29 +758,29 @@ Parfois la magie se déchaîne et inflige des dégâts supplémentaires. La chan
   <content contentuid="h90aeb23egee85gab21g41b9g52b42e64cb53" version="1">Châtiment occulte : Réaction</content>
   <content contentuid="h736c0facgf8fdg1f25g787bg0dc22143c55e" version="1">Châtiment occulte : Réaction</content>
   <content contentuid="hccbfc687g197cgaf11g2e5cg2aa9a4c51ef2" version="1">Châtiment occulte : Réaction</content>
-  <content contentuid="h7b469932gb9a1gf6f4gdaa5g2804016be6b3" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Gigantesque ou inférieure.</content>
-  <content contentuid="h2ed3d6d2g203agef73ge378g989ea6dc9107" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Gigantesque ou inférieure.</content>
-  <content contentuid="hd1e4fce8gbccbg813cgdb6bgcf29cb502ca1" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Gigantesque ou inférieure.</content>
-  <content contentuid="h2fae1edegb1eege388gf87cg39ad6381ae22" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Gigantesque ou inférieure.</content>
-  <content contentuid="h2c6eccdeg66d4g0163gd637g573e9b7a1610" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Gigantesque ou inférieure.</content>
-  <content contentuid="h801bf2a6g08cfgac63gc48fgdc1a93297403" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Gigantesque ou inférieure.</content>
-  <content contentuid="heb8d0bd4gf518g09cbgdf04g875209dd858a" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Gigantesque ou inférieure.</content>
-  <content contentuid="hd23c4cc6g5a99gc62eg7220ge0f7cee47aba" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Gigantesque ou inférieure.</content>
+  <content contentuid="h7b469932gb9a1gf6f4gdaa5g2804016be6b3" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Énorme ou inférieure.</content>
+  <content contentuid="h2ed3d6d2g203agef73ge378g989ea6dc9107" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Énorme ou inférieure.</content>
+  <content contentuid="hd1e4fce8gbccbg813cgdb6bgcf29cb502ca1" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Énorme ou inférieure.</content>
+  <content contentuid="h2fae1edegb1eege388gf87cg39ad6381ae22" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Énorme ou inférieure.</content>
+  <content contentuid="h2c6eccdeg66d4g0163gd637g573e9b7a1610" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Énorme ou inférieure.</content>
+  <content contentuid="h801bf2a6g08cfgac63gc48fgdc1a93297403" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Énorme ou inférieure.</content>
+  <content contentuid="heb8d0bd4gf518g09cbgdf04g875209dd858a" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Énorme ou inférieure.</content>
+  <content contentuid="hd23c4cc6g5a99gc62eg7220ge0f7cee47aba" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Énorme ou inférieure.</content>
   <content contentuid="h24650f10g65f0gdad5g30cdg3e4777297c7c" version="1">Niveau 2 : Érudit</content>
-  <content contentuid="h32ed567egee36g91e1g2accgb992c0f4d730" version="1">En étudiant la magie, vous vous êtes également spécialisé dans un autre domaine d'étude. Choisissez l'une des compétences suivantes dans laquelle vous avez la maîtrise : Arcanes, Histoire, Investigation, Médecine, Nature ou Religion. Vous avez la Maîtrise approfondie dans la compétence choisie.</content>
-  <content contentuid="h2f5671feg10a3g6221g9db1gcd1af3a88f5b" version="1">Niveau 2 : Maîtrise approfondie</content>
-  <content contentuid="h9e315a90g0705gb2c6g1a8eg13de362924de" version="1">Vous gagnez la Maîtrise approfondie (voir le glossaire des règles) dans deux de vos maîtrises de compétence de votre choix. Représentation et Persuasion sont recommandées si vous en avez la maîtrise.
+  <content contentuid="h32ed567egee36g91e1g2accgb992c0f4d730" version="1">En étudiant la magie, vous vous êtes également spécialisé dans un autre domaine d'étude. Choisissez l'une des compétences suivantes dans laquelle vous avez la maîtrise : Arcanes, Histoire, Investigation, Médecine, Nature ou Religion. Vous avez l'Expertise dans la compétence choisie.</content>
+  <content contentuid="h2f5671feg10a3g6221g9db1gcd1af3a88f5b" version="1">Niveau 2 : Expertise</content>
+  <content contentuid="h9e315a90g0705gb2c6g1a8eg13de362924de" version="1">Vous gagnez l'Expertise (voir le glossaire des règles) dans deux de vos maîtrises de compétence de votre choix. Représentation et Persuasion sont recommandées si vous en avez la maîtrise.
 
-Au niveau 9 de Barde, vous gagnez la Maîtrise approfondie dans deux autres de vos maîtrises de compétence de votre choix.</content>
+Au niveau 9 de Barde, vous gagnez l'Expertise dans deux autres de vos maîtrises de compétence de votre choix.</content>
   <content contentuid="h1d573d0cg0ef8gc58cg5d87gf7b0ce7fc23d" version="1">Niveau 10 : Secrets magiques</content>
   <content contentuid="hd5715a4dge184g890agee7ag4f904fb90c6b" version="1">Vous avez appris des secrets de diverses traditions magiques. Chaque fois que vous atteignez un niveau de Barde (y compris ce niveau) et que le nombre de Sorts préparés dans le tableau des capacités de Barde augmente, vous pouvez choisir l'un de vos nouveaux sorts préparés parmi les listes de sorts du Barde, du Clerc, du Druide et du Magicien, et les sorts choisis comptent comme des sorts de Barde pour vous. De plus, chaque fois que vous remplacez un sort préparé pour cette classe, vous pouvez le remplacer par un sort de ces listes.</content>
   <content contentuid="hd4f3b039g6204g1bbagd21fgb72f806b54d8" version="1">Niveau 3 : Inspiration de combat</content>
   <content contentuid="hd0e61f8bg955fgda33g3e08gc99c259c8a16" version="1">Niveau 3 : Bénédictions du savoir</content>
-  <content contentuid="hc9341211ge6c1g1fd9gddbeg13315817fedb" version="1">Vous gagnez la maîtrise de deux des compétences suivantes de votre choix : Arcanes, Histoire, Nature ou Religion. Vous avez la Maîtrise approfondie dans ces deux compétences.</content>
-  <content contentuid="ha8b64524g7467g0f1eg9214gbd3da8ce6302" version="1">Niveau 1 : Maîtrise approfondie</content>
-  <content contentuid="h75d54fe5g6285g141fgd2b8gca722e196ecc" version="1">Vous gagnez la Maîtrise approfondie dans deux de vos maîtrises de compétence de votre choix. Tour de passe-passe et Discrétion sont recommandées si vous en avez la maîtrise.
+  <content contentuid="hc9341211ge6c1g1fd9gddbeg13315817fedb" version="1">Vous gagnez la maîtrise de deux des compétences suivantes de votre choix : Arcanes, Histoire, Nature ou Religion. Vous avez l'Expertise dans ces deux compétences.</content>
+  <content contentuid="ha8b64524g7467g0f1eg9214gbd3da8ce6302" version="1">Niveau 1 : Expertise</content>
+  <content contentuid="h75d54fe5g6285g141fgd2b8gca722e196ecc" version="1">Vous gagnez l'Expertise dans deux de vos maîtrises de compétence de votre choix. Tour de passe-passe et Discrétion sont recommandées si vous en avez la maîtrise.
 
-Au niveau 6 de Roublard, vous gagnez la Maîtrise approfondie dans deux autres de vos maîtrises de compétence de votre choix.</content>
+Au niveau 6 de Roublard, vous gagnez l'Expertise dans deux autres de vos maîtrises de compétence de votre choix.</content>
   <content contentuid="hac07bd19g5886gc2efgf8dfgb838d23ca0bd" version="1">Niveau 5 : Frappe rusée</content>
   <content contentuid="h4c3e9164gb5c2g35d0g405dgb887921e3e3a" version="1">Vous avez développé des moyens rusés d'utiliser votre Attaque sournoise. Lorsque vous infligez des dégâts d'Attaque sournoise, vous pouvez ajouter l'un des effets de Frappe rusée suivants.
 
@@ -805,54 +805,127 @@ Si un effet de Frappe rusée nécessite un jet de sauvegarde, le DD est égal à
 
 Vous avez consacré votre vie au service d'un temple, apprenant des rites sacrés et offrant des sacrifices au(x) dieu(x) que vous vénérez. Servir les dieux et découvrir leurs œuvres sacrées vous guidera vers la grandeur.</content>
   <content contentuid="hd660fd06g45aeg25f4g7e9dg6fd338c66f83" version="1">Don d'origine : Initiation à la magie (Clerc)</content>
-  <content contentuid="ha980b3fbg98dcgc88eg9edbg89be32a4b191" version="2">Initiation à la magie (Clerc) : Tour de magie</content>
-  <content contentuid="hd57d4d53gfb82gc5e5ge39eg18ccf99d11ac" version="1">Initiation à la magie (Clerc) : Tour de magie 2</content>
-  <content contentuid="hee720882g4ca7g0c82g0f6dgda96a14a144e" version="2">Le mode d'apprentissage de tours de magie est actif. Tous les tours de magie de Clerc sont ajoutés à votre liste de sorts.
+  <content contentuid="ha980b3fbg98dcgc88eg9edbg89be32a4b191" version="2">Initiation à la magie (Clerc) : Sort mineur</content>
+  <content contentuid="hd57d4d53gfb82gc5e5ge39eg18ccf99d11ac" version="1">Initiation à la magie (Clerc) : Sort mineur 2</content>
+  <content contentuid="hee720882g4ca7g0c82g0f6dgda96a14a144e" version="3">Le mode d'apprentissage de sorts mineurs est actif. Tous les sorts mineurs de Clerc sont ajoutés à votre liste de sorts.
 
-Lorsque vous lancez un tour de magie, vous l'apprenez définitivement.
+Sélectionner un sort mineur à lancer vous l'apprend définitivement et immédiatement — vous n'avez pas besoin d'une cible valide ni de terminer son incantation.
 
-Après avoir sélectionné deux tours de magie différents, ce mode se termine.</content>
-  <content contentuid="h7d1ae2c1g95b6g5a3dgc067g1baf8491753f" version="2">Le mode d'apprentissage de tours de magie est actif. Tous les tours de magie de Clerc sont ajoutés à votre liste de sorts.
+Après avoir sélectionné deux sorts mineurs différents, ce mode prend fin.</content>
+  <content contentuid="h7d1ae2c1g95b6g5a3dgc067g1baf8491753f" version="3">Le mode d'apprentissage de sorts mineurs est actif. Tous les sorts mineurs de Clerc sont ajoutés à votre liste de sorts.
 
-Lorsque vous lancez un tour de magie, vous l'apprenez définitivement.
+Sélectionner un sort mineur à lancer vous l'apprend définitivement et immédiatement — vous n'avez pas besoin d'une cible valide ni de terminer son incantation.
 
-Après avoir sélectionné deux tours de magie différents, ce mode se termine.</content>
-  <content contentuid="he64b4a45gba6eg30a6g9703gb0f13f9230e8" version="1">Initiation à la magie (Clerc) : Tour de magie</content>
-  <content contentuid="hd21b5377g2221gaafdga39bgea72f3a697d1" version="1">Initiation à la magie (Druide) : Tour de magie</content>
+Après avoir sélectionné deux sorts mineurs différents, ce mode prend fin.</content>
+  <content contentuid="he64b4a45gba6eg30a6g9703gb0f13f9230e8" version="1">Initiation à la magie (Clerc) : Sort mineur</content>
+  <content contentuid="hd21b5377g2221gaafdga39bgea72f3a697d1" version="1">Initiation à la magie (Druide) : Sort mineur</content>
   <content contentuid="h3522b895gaf8eg23c8ge2a5g19305a3832ce" version="1">Don d'origine : Initiation à la magie (Druide)</content>
-  <content contentuid="h3be2808fgdf36g2f49g651dgd7072fe1c369" version="1">Initiation à la magie (Druide) : Tour de magie</content>
-  <content contentuid="hcf7beb3cg8662gd7d0ga3aag9f047d9b8897" version="1">Initiation à la magie (Magicien) : Tour de magie</content>
-  <content contentuid="h7fd3e98dg8cddgd47cg0aeag9f03355feaaa" version="1">Deux tours de magie. Vous apprenez deux tours de magie de votre choix dans les listes de sorts du Clerc, du Druide ou du Magicien. Lorsque vous sélectionnez ce don, choisissez Intelligence, Sagesse ou Charisme comme caractéristique d'incantation pour ces sorts.
+  <content contentuid="h3be2808fgdf36g2f49g651dgd7072fe1c369" version="1">Initiation à la magie (Druide) : Sort mineur</content>
+  <content contentuid="hcf7beb3cg8662gd7d0ga3aag9f047d9b8897" version="1">Initiation à la magie (Magicien) : Sort mineur</content>
+  <content contentuid="h7fd3e98dg8cddgd47cg0aeag9f03355feaaa" version="1">Deux sorts mineurs. Vous apprenez deux sorts mineurs de votre choix dans les listes de sorts du Clerc, du Druide ou du Magicien. Lorsque vous sélectionnez ce don, choisissez Intelligence, Sagesse ou Charisme comme caractéristique d'incantation pour ces sorts.
 
-Sort de niveau 1. Choisissez un sort de niveau 1 de la même liste que celle choisie pour vos tours de magie. Vous avez toujours ce sort préparé, et vous gagnez un emplacement de sort de niveau 1 pour le lancer.</content>
-  <content contentuid="hb18213feg1443g46dfg66c8g43152a53cf75" version="2">Le mode d'apprentissage de tours de magie est actif. Tous les tours de magie de Druide sont ajoutés à votre liste de sorts.
+Sort de niveau 1. Choisissez un sort de niveau 1 de la même liste que celle choisie pour vos sorts mineurs. Vous avez toujours ce sort préparé, et vous gagnez un emplacement de sort de niveau 1 pour le lancer.</content>
+  <content contentuid="hb18213feg1443g46dfg66c8g43152a53cf75" version="3">Le mode d'apprentissage de sorts mineurs est actif. Tous les sorts mineurs de Druide sont ajoutés à votre liste de sorts.
 
-Lorsque vous lancez un tour de magie, vous l'apprenez définitivement.
+Sélectionner un sort mineur à lancer vous l'apprend définitivement et immédiatement — vous n'avez pas besoin d'une cible valide ni de terminer son incantation.
 
-Après avoir sélectionné deux tours de magie différents, ce mode se termine.</content>
-  <content contentuid="hd31cacc2g7f81g20c3gc487gec7d06e97e53" version="2">Le mode d'apprentissage de tours de magie est actif. Tous les tours de magie de Magicien sont ajoutés à votre liste de sorts.
+Après avoir sélectionné deux sorts mineurs différents, ce mode prend fin.</content>
+  <content contentuid="hd31cacc2g7f81g20c3gc487gec7d06e97e53" version="3">Le mode d'apprentissage de sorts mineurs est actif. Tous les sorts mineurs de Magicien sont ajoutés à votre liste de sorts.
 
-Lorsque vous lancez un tour de magie, vous l'apprenez définitivement.
+Sélectionner un sort mineur à lancer vous l'apprend définitivement et immédiatement — vous n'avez pas besoin d'une cible valide ni de terminer son incantation.
 
-Après avoir sélectionné deux tours de magie différents, ce mode se termine.</content>
+Après avoir sélectionné deux sorts mineurs différents, ce mode prend fin.</content>
   <content contentuid="h948ef541g3485gbf64g5f3ag0b03af06a06a" version="1">Initiation à la magie (Clerc) : Sort</content>
-  <content contentuid="h0452adf6gbffcga716g8490gdad124c18bb6" version="2">Le mode d'apprentissage de sorts est actif. Tous les sorts de Clerc sont ajoutés à votre liste de sorts.
+  <content contentuid="h0452adf6gbffcga716g8490gdad124c18bb6" version="3">Le mode d'apprentissage de sorts est actif. Tous les sorts de Clerc sont ajoutés à votre liste de sorts.
 
-Lorsque vous lancez un sort, vous l'apprenez définitivement.
+Sélectionner un sort à lancer vous l'apprend définitivement et immédiatement — vous n'avez pas besoin d'une cible valide ni de terminer son incantation.
 
-Après avoir sélectionné un sort, ce mode se termine.</content>
+Après avoir sélectionné un sort, ce mode prend fin.</content>
   <content contentuid="hc1a2947cg6d72g0cb9g22eagc5ff105e4237" version="1">Initiation à la magie (Druide) : Sort</content>
-  <content contentuid="he3771dbcg23f0g570dg2d5egf79cec30d589" version="2">Le mode d'apprentissage de sorts est actif. Tous les sorts de Druide sont ajoutés à votre liste de sorts.
+  <content contentuid="he3771dbcg23f0g570dg2d5egf79cec30d589" version="3">Le mode d'apprentissage de sorts est actif. Tous les sorts de Druide sont ajoutés à votre liste de sorts.
 
-Lorsque vous lancez un sort, vous l'apprenez définitivement.
+Sélectionner un sort à lancer vous l'apprend définitivement et immédiatement — vous n'avez pas besoin d'une cible valide ni de terminer son incantation.
 
-Après avoir sélectionné un sort, ce mode se termine.</content>
+Après avoir sélectionné un sort, ce mode prend fin.</content>
   <content contentuid="hc6335af1g4129g0308g8518g3cb980ec4a55" version="1">Initiation à la magie (Magicien) : Sort</content>
-  <content contentuid="hffa4fb6cg516eg4f17g0656geecaebcd5045" version="2">Le mode d'apprentissage de sorts est actif. Tous les sorts de Magicien sont ajoutés à votre liste de sorts.
+  <content contentuid="hffa4fb6cg516eg4f17g0656geecaebcd5045" version="3">Le mode d'apprentissage de sorts est actif. Tous les sorts de Magicien sont ajoutés à votre liste de sorts.
 
-Lorsque vous lancez un sort, vous l'apprenez définitivement.
+Sélectionner un sort à lancer vous l'apprend définitivement et immédiatement — vous n'avez pas besoin d'une cible valide ni de terminer son incantation.
 
-Après avoir sélectionné un sort, ce mode se termine.</content>
+Après avoir sélectionné un sort, ce mode prend fin.</content>
+  <content contentuid="h711b7815g70c9g4712ga219g0ff6e0b8c207" version="1">Initiation à la magie : Aspersion acide</content>
+  <content contentuid="h70fd1410g49a4g44d1g9f8eg7f6bc1c21fea" version="1">Initiation à la magie : Amis</content>
+  <content contentuid="ha6ce862fg4edeg49f7g9320gb8580541d70a" version="1">Initiation à la magie : Trait de feu</content>
+  <content contentuid="h97d2ab9cgaaf9g4bd4gb544g5862fb5d10b9" version="1">Initiation à la magie : Lumières dansantes</content>
+  <content contentuid="hc5fa63acg91f7g498fg8be8g4f77f6e608e1" version="1">Initiation à la magie : Contact glacial</content>
+  <content contentuid="h8cab8439g423ag41e7ga45bg7c1a4c23cde3" version="1">Initiation à la magie : Tendon éclaté</content>
+  <content contentuid="h4def798ag029dg4d00g8d1eg8929e03098d6" version="1">Initiation à la magie : Lame retentissante</content>
+  <content contentuid="h83dc6116g533dg4e65g8c4ag7f3230f15b56" version="1">Initiation à la magie : Protection contre les armes</content>
+  <content contentuid="hc43d9642g1590g42d6gbab6ga3dc6574eb50" version="1">Initiation à la magie : Assistance</content>
+  <content contentuid="haada0dc8gc767g45e4g98c2g6c5644d040c1" version="1">Initiation à la magie : Lame aux flammes vertes</content>
+  <content contentuid="h1e7a31c9g35c0g4b54g8f69g25b327a4c999" version="1">Initiation à la magie : Lumière</content>
+  <content contentuid="hee3244d3g6916g4229gb4b7gd98a4f519f8e" version="1">Initiation à la magie : Main du mage</content>
+  <content contentuid="hd455a5aag6fb4g48ccgbec8gdf13c11a88ab" version="1">Initiation à la magie : Piqûre mentale</content>
+  <content contentuid="h965b7dc5ga4acg4b60g9e4bgcd236212e8b4" version="1">Initiation à la magie : Illusion mineure</content>
+  <content contentuid="hcb1e67e1g69e7g4710g9cd5ga81a12763305" version="1">Initiation à la magie : Bouffée de poison</content>
+  <content contentuid="hf6e4b463g8945g4e41g8f63g065eb4ecdd0b" version="1">Initiation à la magie : Production de flamme</content>
+  <content contentuid="h4f7e0ea1g2ff6g48b2g937bg7cc4f590d0e7" version="1">Initiation à la magie : Prestidigitation</content>
+  <content contentuid="h893b82a7g6490g43ebg981ag9315af05142b" version="1">Initiation à la magie : Rayon de givre</content>
+  <content contentuid="heda822d9g6ca8g4d69g862cg8e593ceb6f22" version="1">Initiation à la magie : Résistance</content>
+  <content contentuid="h04241b75g4f7eg40dagbac2g1acb8e2326f5" version="1">Initiation à la magie : Flamme sacrée</content>
+  <content contentuid="hdd5d9c2cg059eg4e76gb6b6g01e4d851171d" version="1">Initiation à la magie : Gourdin magique</content>
+  <content contentuid="h4527bdb1gf97cg4adcg9003g64255fe6abdf" version="1">Initiation à la magie : Poigne électrique</content>
+  <content contentuid="h29d6991cg8d76g4e4bga787g7f988a72fe15" version="1">Initiation à la magie : Stabilisation</content>
+  <content contentuid="hb163e2e9gb2d2g4adeg8801g80dbb2b50492" version="1">Initiation à la magie : Poussière d'étoile</content>
+  <content contentuid="h9f283e92g10dfg43b6g837dg39ee82977d4b" version="1">Initiation à la magie : Éruption de lames</content>
+  <content contentuid="h66c0ac32gf014g42dag9841g3b01a76087d3" version="1">Initiation à la magie : Thaumaturgie</content>
+  <content contentuid="hc3c05220gcdefg4521g8152g4898ef5b675d" version="1">Initiation à la magie : Fouet épineux</content>
+  <content contentuid="h663fe553g789ag4344gba16g9856c5fe1f6c" version="1">Initiation à la magie : Coup de tonnerre</content>
+  <content contentuid="h8a1afdf9g8010g4ad9gbda9ged21cac57381" version="1">Initiation à la magie : Glas</content>
+  <content contentuid="hfc64fd6bgba50g4748gaa9fg22adb16ff81b" version="1">Initiation à la magie : Coup au but</content>
+  <content contentuid="hc24e0712g664bg4e59gad6fg394d985f4bfb" version="1">Initiation à la magie : Lame vengeresse</content>
+  <content contentuid="he02ce6f7gdbe0g4af4g8e20g9e0b3c31c653" version="1">Initiation à la magie : Mot de radiance</content>
+  <content contentuid="hb0e3941dgfac2g426ag9ccdgee197b362bd8" version="1">Initiation à la magie : Mot sacré</content>
+  <content contentuid="h749a56acgdc0fg4869g9757g0be1a08703ea" version="1">Initiation à la magie : Sursaut d'effroi</content>
+  <content contentuid="h21645e9ag9d9cg418aga245g6a9015289552" version="1">Initiation à la magie : Amitié avec les animaux</content>
+  <content contentuid="hdf583f63gea12g4423g9944g3daa981713d3" version="1">Initiation à la magie : Création ou destruction d'eau</content>
+  <content contentuid="hcc29c239gc13fg4023gb368g06aa956b1eb2" version="1">Initiation à la magie : Injonction</content>
+  <content contentuid="hce902b37g2b1fg4c69gb496g34f99e16b2db" version="1">Initiation à la magie : Couleurs dansantes</content>
+  <content contentuid="hc3ea7a0bg4a33g447egab4cg59b3544f61a4" version="1">Initiation à la magie : Linceul d'ombre</content>
+  <content contentuid="h20d0eed4gb780g487cg8ab2g2a8f0df204ec" version="1">Initiation à la magie : Orbe chromatique</content>
+  <content contentuid="hbcff1db6g661fg44b2gaa19ge984fa1cedb3" version="1">Initiation à la magie : Charme-personne</content>
+  <content contentuid="h32091888g9007g441cgb899gf48ab4745ec0" version="1">Initiation à la magie : Mains brûlantes</content>
+  <content contentuid="hb964961egd956g43e4gb1f4gbbd5199911f7" version="1">Initiation à la magie : Bénédiction</content>
+  <content contentuid="hcf286fcbga673g4b58g9ca2g7cb218338271" version="1">Initiation à la magie : Imprécation</content>
+  <content contentuid="h40603322g7144g4076ga600g816c1a3bf347" version="1">Initiation à la magie : Soin des blessures</content>
+  <content contentuid="h21dc2164g914fg40f1g96f0g6370fd2112f5" version="1">Initiation à la magie : Enchevêtrement</content>
+  <content contentuid="h1b472549g17edg4c6bgac27gf0b44463bc4c" version="1">Initiation à la magie : Repli expéditif</content>
+  <content contentuid="hffc26135gf1a3g4a40ga837gc93edb478e30" version="1">Initiation à la magie : Lueurs féériques</content>
+  <content contentuid="h4ded108bga017g4608gbf95g21aa64af5306" version="1">Initiation à la magie : Simulacre de vie</content>
+  <content contentuid="haba60ef6g99aag4749g96b9g8d1f04316129" version="1">Initiation à la magie : Feuille morte</content>
+  <content contentuid="h38f40cc0g5620g4711g8d56gdd9c138dc7bf" version="1">Initiation à la magie : Appel de familier</content>
+  <content contentuid="hf8e02fcbgdb8bg4268gb21cg13293d623b07" version="1">Initiation à la magie : Nappe de brouillard</content>
+  <content contentuid="h7fe00d2bgea8ag4b0fgbbacgdbf44e74157c" version="1">Initiation à la magie : Baies nourricières</content>
+  <content contentuid="hc6e80bc7gdc11g4a8egafadg36b0c70eecad" version="1">Initiation à la magie : Graisse</content>
+  <content contentuid="h06ce1335g4a93g488eg9ce8g7f24e3f055ce" version="1">Initiation à la magie : Rayon traçant</content>
+  <content contentuid="h050d8dc6gbc79g42dbg906dg75bd310a68ea" version="1">Initiation à la magie : Mot de guérison</content>
+  <content contentuid="h3ea7727eg6fb7g4437g8abfg5b8b01c08404" version="1">Initiation à la magie : Fou rire</content>
+  <content contentuid="hdc5cb67eg6726g4f71ga0a5g19d3f916892d" version="1">Initiation à la magie : Couteau de glace</content>
+  <content contentuid="h86f50d94gf85eg4f54g9043g7300025a6b85" version="1">Initiation à la magie : Blessure</content>
+  <content contentuid="h57c34580gbbf4g41acgbcb6g5f4b946ba3e2" version="1">Initiation à la magie : Saut</content>
+  <content contentuid="h931b6d31gbc0cg42a0ga0fdg6bf79513d2f8" version="1">Initiation à la magie : Grande foulée</content>
+  <content contentuid="h3cb9ecd6gc656g434eg9178g4828fbd9e74c" version="1">Initiation à la magie : Armure de mage</content>
+  <content contentuid="hc12ab9b5ga37dg4463g97c9gcfaef383ed25" version="1">Initiation à la magie : Projectile magique</content>
+  <content contentuid="h7380d024gd726g4ecbgaf7bg7053d764150b" version="1">Initiation à la magie : Protection contre le mal et le bien</content>
+  <content contentuid="h8ec3e1ffgcbf4g4037g9bc0g84441c8fa842" version="1">Initiation à la magie : Rayon empoisonné</content>
+  <content contentuid="h124523e9g22fbg4ef6g9eadg44197da47bfb" version="1">Initiation à la magie : Sanctuaire</content>
+  <content contentuid="h2cd9127cg7278g4d0fgb936g380f15ea9889" version="1">Initiation à la magie : Bouclier</content>
+  <content contentuid="h2ad87388g142dg4348gbbedg0e1f69d37af7" version="1">Initiation à la magie : Bouclier de la foi</content>
+  <content contentuid="h11e7e65ag5981g4ae2g8c38gc618d023f94b" version="1">Initiation à la magie : Sommeil</content>
+  <content contentuid="hcacff426g1d0ag44e6g9598gd4e780c75798" version="1">Initiation à la magie : Communication avec les animaux</content>
+  <content contentuid="h5aa03de7gf337g42a1gb453ge89a6f671278" version="1">Initiation à la magie : Vague tonnante</content>
+  <content contentuid="h4a25b113gd59eg4b37gb1fag1d64b4e65972" version="1">Initiation à la magie : Répulsion</content>
+  <content contentuid="h4a465394gc707g4e0bga071g165709a73a35" version="1">Initiation à la magie : Arc électrique</content>
   <content contentuid="hb75003cbgf00cga299gd802g14c70c5d2869" version="1">Charlatan</content>
   <content contentuid="hcc3c36c6gd341g9ef3g75a6gd57375a199cd" version="3">Don : Compétent
 
@@ -952,23 +1025,23 @@ Un moment, une personne ou une chose maléfique que l'on ne peut tuer par l'ép�
   <content contentuid="h6406ffe0g3bf9g37c9g6ad7g2ba1f01b1075" version="1">Don d'origine : Bagarreur de taverne</content>
   <content contentuid="h1f7fcfe8g6d82ga644g381cg16c2d77b873e" version="1">Lorsque vous effectuez des attaques à mains nues, vous lancez vos dés de dégâts deux fois et utilisez le résultat le plus élevé.</content>
   <content contentuid="h2d1c35beg6336gdd1eg258dg69afd0b6b19f" version="1">Athlète</content>
-  <content contentuid="he017d973g0291gbe65g86dbgfc62954d6af5" version="3">Se relever. Tant que vous avez la condition À terre, vous pouvez vous relever en ne dépensant que 5 pieds de mouvement.
+  <content contentuid="he017d973g0291gbe65g86dbgfc62954d6af5" version="3">Se relever. Tant que vous avez la condition À terre, vous pouvez vous relever en ne dépensant que 1,50 mètre de mouvement.
 
-Saut. Une fois par tour, vous pouvez effectuer un Saut en ne dépensant que 10 pieds de mouvement.</content>
+Saut. Une fois par tour, vous pouvez effectuer un Saut en ne dépensant que 3 mètres de mouvement.</content>
   <content contentuid="h4fa37f8dgea0ag8e9eg9222g12cdf8ef50af" version="1">Don : Athlète</content>
-  <content contentuid="hac8cf59bgb29dg6896g2a11g689bf333570e" version="3">Se relever. Tant que vous avez la condition À terre, vous pouvez vous relever en ne dépensant que 5 pieds de mouvement.
+  <content contentuid="hac8cf59bgb29dg6896g2a11g689bf333570e" version="3">Se relever. Tant que vous avez la condition À terre, vous pouvez vous relever en ne dépensant que 1,50 mètre de mouvement.
 
-Saut. Une fois par tour, vous pouvez effectuer un Saut en ne dépensant que 10 pieds de mouvement.</content>
+Saut. Une fois par tour, vous pouvez effectuer un Saut en ne dépensant que 3 mètres de mouvement.</content>
   <content contentuid="hf57c9070gd267g0022g18deg38ad134018ab" version="1">Chargeur</content>
-  <content contentuid="h9ed109c6ga680g6d73gce1ag6e136e676cb2" version="2">Foncer amélioré. Lorsque vous prenez l'action Foncer, votre Vitesse augmente de 10 pieds pour cette action.
+  <content contentuid="h9ed109c6ga680g6d73gce1ag6e136e676cb2" version="2">Foncer amélioré. Lorsque vous prenez l'action Foncer, votre Vitesse augmente de 3 mètres pour cette action.
 
-Attaque de charge. Si vous vous déplacez d'au moins 10 pieds en ligne droite vers une cible immédiatement avant de la toucher avec un jet d'attaque de corps à corps dans le cadre de l'action Attaque, choisissez l'un des effets suivants : gagnez un bonus de 1d8 au jet de dégâts de l'attaque, ou poussez la cible jusqu'à 10 pieds si elle n'est pas plus d'une catégorie de taille supérieure à vous. Vous ne pouvez utiliser ce bénéfice qu'une fois par tour.</content>
+Attaque de charge. Si vous vous déplacez d'au moins 3 mètres en ligne droite vers une cible immédiatement avant de la toucher avec un jet d'attaque de corps à corps dans le cadre de l'action Attaquer, choisissez l'un des effets suivants : gagnez un bonus de 1d8 au jet de dégâts de l'attaque, ou poussez la cible jusqu'à 3 mètres si elle n'est pas plus d'une catégorie de taille supérieure à vous. Vous ne pouvez utiliser ce bénéfice qu'une fois par tour.</content>
   <content contentuid="hbc6e4744g6835g4d25g3453g224b9eed2a70" version="1">Don : Chargeur</content>
-  <content contentuid="h4e972de5g72bbgc7d9gfda3g1c89f2af41d0" version="2">Foncer amélioré. Lorsque vous prenez l'action Foncer, votre Vitesse augmente de 10 pieds pour cette action.
+  <content contentuid="h4e972de5g72bbgc7d9gfda3g1c89f2af41d0" version="2">Foncer amélioré. Lorsque vous prenez l'action Foncer, votre Vitesse augmente de 3 mètres pour cette action.
 
-Attaque de charge. Si vous vous déplacez d'au moins 10 pieds en ligne droite vers une cible immédiatement avant de la toucher avec un jet d'attaque de corps à corps dans le cadre de l'action Attaque, choisissez l'un des effets suivants : gagnez un bonus de 1d8 au jet de dégâts de l'attaque, ou poussez la cible jusqu'à 10 pieds si elle n'est pas plus d'une catégorie de taille supérieure à vous. Vous ne pouvez utiliser ce bénéfice qu'une fois par tour.</content>
+Attaque de charge. Si vous vous déplacez d'au moins 3 mètres en ligne droite vers une cible immédiatement avant de la toucher avec un jet d'attaque de corps à corps dans le cadre de l'action Attaquer, choisissez l'un des effets suivants : gagnez un bonus de 1d8 au jet de dégâts de l'attaque, ou poussez la cible jusqu'à 3 mètres si elle n'est pas plus d'une catégorie de taille supérieure à vous. Vous ne pouvez utiliser ce bénéfice qu'une fois par tour.</content>
   <content contentuid="hafd66c3cg4becg70e3gdeb1g96e635182645" version="1">Expert en arbalète</content>
-  <content contentuid="hc7b891e9gd9c0g1617g0233ga492c5e47dc7" version="2">Tir en mêlée. Le fait d'être à 5 pieds ou moins d'un ennemi n'impose pas le Désavantage à vos jets d'attaque avec les arbalètes.
+  <content contentuid="hc7b891e9gd9c0g1617g0233ga492c5e47dc7" version="2">Tir en mêlée. Le fait d'être à 1,50 mètre ou moins d'un ennemi n'impose pas le Désavantage à vos jets d'attaque avec les arbalètes.
 
 Carreau blessant. Lorsque vous touchez une créature avec une attaque à distance, elle a une chance de recevoir la condition &lt;LSTag Type="Status" Tooltip="GAPING_WOUND"&gt;Plaies béantes&lt;/LSTag&gt;.</content>
   <content contentuid="h2b11e796g7a1fga346gb3e4g85e96274b6ef" version="1">Don : Expert en arbalète (Blessant)</content>
@@ -979,7 +1052,7 @@ Carreau blessant. Lorsque vous touchez une créature avec une attaque à distanc
   <content contentuid="h208b7de3g5f3cge001gfe82gdd2940dee59c" version="1">Don : Duelliste défensif</content>
   <content contentuid="hfd0b3091g52f6g2cd7ga7cbg9c61332d3252" version="1">Si vous tenez une arme de Finesse et qu'une autre créature vous touche avec une attaque de corps à corps, vous pouvez utiliser une Réaction pour ajouter votre Bonus de maîtrise à votre Classe d'armure, faisant potentiellement rater l'attaque. Vous gagnez ce bonus à votre CA contre les attaques de corps à corps jusqu'au début de votre prochain tour.</content>
   <content contentuid="hfa2c5254ge5fag62b7gffb6g392787c61974" version="1">Combattant à deux armes</content>
-  <content contentuid="h2d809685g28ffge26ag3e6ag5fa20f63c9e3" version="7">Vous pouvez utiliser le Combat à deux armes même si vos armes ne sont pas &lt;LSTag Tooltip="Light"&gt;Légères&lt;/LSTag&gt;. Vous ne pouvez pas manier simultanément des armes &lt;LSTag Tooltip="TwoHanded"&gt;à deux mains&lt;/LSTag&gt;.&lt;br&gt;&lt;br&gt;Lorsque vous prenez l'action Attaque à votre tour et attaquez avec une arme de corps à corps, vous pouvez effectuer une Attaque en main secondaire comme Action bonus plus tard au même tour. Si vous maîtrisez la propriété Entaille et avez une arme Entaille équipée en main secondaire, vous pouvez effectuer jusqu'à deux Attaques en main secondaire par tour.</content>
+  <content contentuid="h2d809685g28ffge26ag3e6ag5fa20f63c9e3" version="7">Vous pouvez utiliser le Combat à deux armes même si vos armes ne sont pas &lt;LSTag Tooltip="Light"&gt;Légères&lt;/LSTag&gt;. Vous ne pouvez pas manier simultanément des armes &lt;LSTag Tooltip="TwoHanded"&gt;à deux mains&lt;/LSTag&gt;.&lt;br&gt;&lt;br&gt;Lorsque vous prenez l'action Attaquer à votre tour et attaquez avec une arme de corps à corps, vous pouvez effectuer une Attaque en main secondaire comme Action bonus plus tard au même tour. Si vous maîtrisez la propriété Entaille et avez une arme Entaille équipée en main secondaire, vous pouvez effectuer jusqu'à deux Attaques en main secondaire par tour.</content>
   <content contentuid="h720a62a8g5de9g9909gb1cagf61131cf2df9" version="1">Don : Combattant à deux armes (Attaque bonus)</content>
   <content contentuid="h5cc813aagcb96gf7f3g42e4g17b7234b86eb" version="1">Vous pouvez effectuer une attaque en main secondaire sans dépenser d'action ni d'Action bonus. Vous ne pouvez utiliser ce bénéfice qu'une fois par tour.</content>
   <content contentuid="h7ed3574cg898aga3cage4bcg72bfa5e60a5c" version="1">Don : Combattant à deux armes</content>
@@ -993,13 +1066,13 @@ Vous pouvez voir dans le noir.</content>
   <content contentuid="h3e8e3421g4852g1a98g9d7cgf3947ee60a89" version="1">Résistant</content>
   <content contentuid="h6299a92eg8049g117bga5b7g17d26b0619d6" version="2">Défier la mort. Vous avez l'Avantage aux Jets de sauvegarde contre la mort.
 
-Récupération rapide. Vous regagnez le maximum de points de vie possible lorsque vous êtes soigné.</content>
+Récupération rapide. Vous regagnez le maximum de &lt;LSTag Tooltip="HitPoints"&gt;points de vie&lt;/LSTag&gt; possible lorsque vous êtes soigné.</content>
   <content contentuid="h3f1eb96eg51f4gaf8cg5396g435ffda2161a" version="1">Maître des grandes armes</content>
-  <content contentuid="h00f044d5gf4edgc900g397bgca53d410bdad" version="2">Maîtrise des armes lourdes. Lorsque vous touchez une créature avec une arme ayant la propriété Lourde dans le cadre de l'action Attaque à votre tour, vous pouvez faire en sorte que l'arme inflige des dégâts supplémentaires à la cible. Les dégâts supplémentaires sont égaux à votre Bonus de maîtrise.
+  <content contentuid="h00f044d5gf4edgc900g397bgca53d410bdad" version="2">Maîtrise des armes lourdes. Lorsque vous touchez une créature avec une arme ayant la propriété Lourde dans le cadre de l'action Attaquer à votre tour, vous pouvez faire en sorte que l'arme inflige des dégâts supplémentaires à la cible. Les dégâts supplémentaires sont égaux à votre Bonus de maîtrise.
 
 Abattre. Immédiatement après avoir réussi un Coup critique avec une arme de corps à corps ou avoir réduit une créature à 0 Point de vie avec une telle arme, vous pouvez effectuer une attaque avec la même arme comme Action bonus.</content>
   <content contentuid="h349877e7geb40gb92agf0ebg6d7a8824b88d" version="1">Don : Maître des grandes armes</content>
-  <content contentuid="hf5c74f9cg9d34g5f2dgb774g506b6adf6782" version="1">Maîtrise des armes lourdes. Lorsque vous touchez une créature avec une arme ayant la propriété Lourde dans le cadre de l'action Attaque à votre tour, vous pouvez faire en sorte que l'arme inflige des dégâts supplémentaires à la cible. Les dégâts supplémentaires sont égaux à votre Bonus de maîtrise.
+  <content contentuid="hf5c74f9cg9d34g5f2dgb774g506b6adf6782" version="1">Maîtrise des armes lourdes. Lorsque vous touchez une créature avec une arme ayant la propriété Lourde dans le cadre de l'action Attaquer à votre tour, vous pouvez faire en sorte que l'arme inflige des dégâts supplémentaires à la cible. Les dégâts supplémentaires sont égaux à votre Bonus de maîtrise.
 
 Abattre. Immédiatement après avoir réussi un Coup critique avec une arme de corps à corps ou avoir réduit une créature à 0 Point de vie avec une telle arme, vous pouvez effectuer une attaque avec la même arme comme Action bonus.</content>
   <content contentuid="h3b239dc5gf9c8g1abcgc84eg956c665ab218" version="1">Don : Armure lourde</content>
@@ -1014,11 +1087,11 @@ Abattre. Immédiatement après avoir réussi un Coup critique avec une arme de c
   <content contentuid="h1bf3ecc0g938dg39f4g8e16gfe946978878f" version="1">Entraînement aux armures. Vous gagnez l'entraînement avec les Armures légères et les Boucliers.</content>
   <content contentuid="h97c3576bg651bg7e79g4da8g9dde54eb141f" version="1">Don : Armure légère</content>
   <content contentuid="hd9e3a2b4g854eg51fcg7859gb22843f1ee76" version="1">Entraînement aux armures. Vous gagnez l'entraînement avec les Armures légères et les Boucliers.</content>
-  <content contentuid="heb622813gde8ag8560g8db8ga20dd3f55a1c" version="1">Tueur de mages</content>
+  <content contentuid="heb622813gde8ag8560g8db8ga20dd3f55a1c" version="1">Fléau des mages</content>
   <content contentuid="h97c2a4b1gf596g1516g285eg988549b0ed6f" version="1">Brise-concentration. Lorsque vous infligez des dégâts à une créature qui se concentre, elle a le Désavantage au jet de sauvegarde qu'elle effectue pour maintenir sa Concentration.
 
 Esprit protégé. Si vous ratez un jet de sauvegarde d'Intelligence, de Sagesse ou de Charisme, vous pouvez décider de le réussir à la place. Une fois que vous avez utilisé ce bénéfice, vous ne pouvez plus l'utiliser avant de terminer un Repos court ou long.</content>
-  <content contentuid="h686b506cg3f99g1c96gdcfcgfd54e5d46f19" version="1">Don : Tueur de mages</content>
+  <content contentuid="h686b506cg3f99g1c96gdcfcgfd54e5d46f19" version="1">Don : Fléau des mages</content>
   <content contentuid="hfc9071adg34ddg859egdda4g444a72c4713f" version="1">Brise-concentration. Lorsque vous infligez des dégâts à une créature qui se concentre, elle a le Désavantage au jet de sauvegarde qu'elle effectue pour maintenir sa Concentration.
 
 Esprit protégé. Si vous ratez un jet de sauvegarde d'Intelligence, de Sagesse ou de Charisme, vous pouvez décider de le réussir à la place. Une fois que vous avez utilisé ce bénéfice, vous ne pouvez plus l'utiliser avant de terminer un Repos court ou long.</content>
@@ -1027,7 +1100,7 @@ Esprit protégé. Si vous ratez un jet de sauvegarde d'Intelligence, de Sagesse 
   <content contentuid="hf3cb4188g698ag0e09ge5b7g7087f12e55e8" version="1">Don : Adepte martial</content>
   <content contentuid="h8c96ebffgfa30ge6e9g2670ge4e2af8fb180" version="1">Don : Maître des armures intermédiaires</content>
   <content contentuid="h9f345cf4g20e3g3adbg0568g4c6d7a467ed6" version="2">Véloce</content>
-  <content contentuid="h9aba9e0ag4af1g9f8fg922ag7e65e5b8a86b" version="2">Augmentation de la Vitesse. Votre Vitesse augmente de 10 pieds.
+  <content contentuid="h9aba9e0ag4af1g9f8fg922ag7e65e5b8a86b" version="2">Augmentation de la Vitesse. Votre Vitesse augmente de 3 mètres.
 
 Foncer sur terrain difficile. Lorsque vous prenez l'action Foncer à votre tour, le Terrain difficile ne vous coûte pas de mouvement supplémentaire pour le reste de ce tour.
 
@@ -1035,7 +1108,7 @@ Mouvement agile. Les Attaques d'opportunité ont le Désavantage contre vous.</c
   <content contentuid="h8eacabe1gf4e0g46a9g32adg16f61a4b3530" version="1">Armure intermédiaire</content>
   <content contentuid="h9683622cg2b30ga13egcae5g1c9525ef5014" version="1">Vous gagnez la &lt;LSTag Tooltip="ArmourProficiency"&gt;Maîtrise des armures&lt;/LSTag&gt; avec les Armures intermédiaires et les boucliers, et votre &lt;LSTag Tooltip="Strength"&gt;Force&lt;/LSTag&gt; ou &lt;LSTag Tooltip="Dexterity"&gt;Dextérité&lt;/LSTag&gt; augmente de 1, jusqu'à un maximum de 20.</content>
   <content contentuid="h064d8f79g7d9eg262fg76e0g2d04ce1515a6" version="2">Don : Véloce</content>
-  <content contentuid="h1ea9a52fg1499gbdd8g9ab4g8e8ff63c7f3f" version="1">Augmentation de la Vitesse. Votre Vitesse augmente de 10 pieds.
+  <content contentuid="h1ea9a52fg1499gbdd8g9ab4g8e8ff63c7f3f" version="1">Augmentation de la Vitesse. Votre Vitesse augmente de 3 mètres.
 
 Foncer sur terrain difficile. Lorsque vous prenez l'action Foncer à votre tour, le Terrain difficile ne vous coûte pas de mouvement supplémentaire pour le reste de ce tour.
 
@@ -1052,11 +1125,11 @@ Chant d'encouragement. Lorsque vous terminez un Repos court ou long, vous pouvez
   <content contentuid="hb4c3b9b7g429bg1543gc57cg6b3b5b25dd7e" version="1">Bagarreur de taverne</content>
   <content contentuid="h77c6e22dg906bge2b2g1f89ged91e34c41a3" version="1">Lorsque vous effectuez des attaques à mains nues, vous lancez vos dés de dégâts deux fois et utilisez le résultat le plus élevé.</content>
   <content contentuid="h3cebc5b8g1e08g6174g4093gbb24e545e462" version="1">Maître des armes d'hast</content>
-  <content contentuid="h215cfcadg8e38gf1d3g5cbfgf68a823d6955" version="1">Coup de hampe. Immédiatement après avoir pris l'action Attaque et attaqué avec un Bâton de quartier, une Lance ou une arme possédant les propriétés Lourde et Allonge, vous pouvez utiliser une Action bonus pour effectuer une attaque de corps à corps avec l'autre extrémité de l'arme. L'arme inflige des dégâts Contondants, et le dé de dégâts de l'arme pour cette attaque est un d4.
+  <content contentuid="h215cfcadg8e38gf1d3g5cbfgf68a823d6955" version="1">Coup de hampe. Immédiatement après avoir pris l'action Attaquer et attaqué avec un Bâton de quartier, une Lance ou une arme possédant les propriétés Lourde et Allonge, vous pouvez utiliser une Action bonus pour effectuer une attaque de corps à corps avec l'autre extrémité de l'arme. L'arme inflige des dégâts Contondants, et le dé de dégâts de l'arme pour cette attaque est un d4.
 
 Frappe réactive. Tant que vous tenez un Bâton de quartier, une Lance ou une arme possédant les propriétés Lourde et Allonge, vous pouvez utiliser une Réaction pour effectuer une attaque de corps à corps contre une créature qui entre à portée de cette arme.</content>
   <content contentuid="h0e159707gedcdgecceg7084geda7d6596f4b" version="1">Don : Maître des armes d'hast</content>
-  <content contentuid="h3dd5e7b4g4865gbd7bged74gd82f6e53d20d" version="1">Coup de hampe. Immédiatement après avoir pris l'action Attaque et attaqué avec un Bâton de quartier, une Lance ou une arme possédant les propriétés Lourde et Allonge, vous pouvez utiliser une Action bonus pour effectuer une attaque de corps à corps avec l'autre extrémité de l'arme. L'arme inflige des dégâts Contondants, et le dé de dégâts de l'arme pour cette attaque est un d4.
+  <content contentuid="h3dd5e7b4g4865gbd7bged74gd82f6e53d20d" version="1">Coup de hampe. Immédiatement après avoir pris l'action Attaquer et attaqué avec un Bâton de quartier, une Lance ou une arme possédant les propriétés Lourde et Allonge, vous pouvez utiliser une Action bonus pour effectuer une attaque de corps à corps avec l'autre extrémité de l'arme. L'arme inflige des dégâts Contondants, et le dé de dégâts de l'arme pour cette attaque est un d4.
 
 Frappe réactive. Tant que vous tenez un Bâton de quartier, une Lance ou une arme possédant les propriétés Lourde et Allonge, vous pouvez utiliser une Réaction pour effectuer une attaque de corps à corps contre une créature qui entre à portée de cette arme.</content>
   <content contentuid="h8279b78cg9f64gf40egab20gf3b5ab80bc72" version="2">Don : Résistant (Charisme)</content>
@@ -1076,21 +1149,21 @@ Vous gagnez l'&lt;LSTag Tooltip="Advantage"&gt;Avantage&lt;/LSTag&gt; aux &lt;LS
   <content contentuid="h90887d29g0a12g4a4eg7f87ga23f7765f7dc" version="1">Tireur d'élite</content>
   <content contentuid="h5b4e785ag06afgf727gca99g7e0aa28facda" version="3">Ignorer le couvert. Vos &lt;LSTag Tooltip="RangedWeaponAttack"&gt;attaques avec une arme à distance&lt;/LSTag&gt; ne reçoivent pas de pénalités des &lt;LSTag Tooltip="HighGroundRules"&gt;Règles de terrain élevé&lt;/LSTag&gt;.
 
-Tir en mêlée. Le fait d'être à 5 pieds ou moins d'un ennemi n'impose pas le Désavantage à vos jets d'attaque avec les armes à Distance.
+Tir en mêlée. Le fait d'être à 1,50 mètre ou moins d'un ennemi n'impose pas le Désavantage à vos jets d'attaque avec les armes à Distance.
 
-Tirs longue portée. Attaquer avec une arme à distance à deux mains augmente sa portée normale à 90 pieds.</content>
+Tirs longue portée. Attaquer avec une arme à distance à deux mains augmente sa portée normale à 27 mètres.</content>
   <content contentuid="ha55fe95cgd504gfcc1gb585g1162cb7cffcc" version="1">Don : Tireur d'élite</content>
   <content contentuid="hb219036fg4365gffedg71d5g938331069179" version="2">Ignorer le couvert. Vos &lt;LSTag Tooltip="RangedWeaponAttack"&gt;attaques avec une arme à distance&lt;/LSTag&gt; ne reçoivent pas de pénalités des &lt;LSTag Tooltip="HighGroundRules"&gt;Règles de terrain élevé&lt;/LSTag&gt;.
 
-Tir en mêlée. Le fait d'être à 5 pieds ou moins d'un ennemi n'impose pas le Désavantage à vos jets d'attaque avec les armes à Distance.
+Tir en mêlée. Le fait d'être à 1,50 mètre ou moins d'un ennemi n'impose pas le Désavantage à vos jets d'attaque avec les armes à Distance.
 
-Tirs longue portée. Attaquer avec une arme à distance à deux mains augmente sa portée normale à 90 pieds.</content>
+Tirs longue portée. Attaquer avec une arme à distance à deux mains augmente sa portée normale à 27 mètres.</content>
   <content contentuid="hcf7e607eg1421g2fc9g4205gd10b92961b19" version="1">Maître du bouclier</content>
-  <content contentuid="he75553c3gd15ag322eg1dcega59ac6593319" version="4">Coup de bouclier. Si vous attaquez une créature à 5 pieds ou moins de vous dans le cadre de l'action Attaque et touchez avec une arme de corps à corps, vous pouvez immédiatement frapper la cible avec votre Bouclier s'il est équipé, la forçant à effectuer un jet de sauvegarde de Force (DD 8 plus votre modificateur de Force et votre Bonus de maîtrise). En cas d'échec, vous poussez la cible à 5 pieds de vous ou lui imposez la condition À terre (votre choix). Vous ne pouvez utiliser ce bénéfice qu'une fois par tour.
+  <content contentuid="he75553c3gd15ag322eg1dcega59ac6593319" version="4">Coup de bouclier. Si vous attaquez une créature à 1,50 mètre ou moins de vous dans le cadre de l'action Attaquer et touchez avec une arme de corps à corps, vous pouvez immédiatement frapper la cible avec votre Bouclier s'il est équipé, la forçant à effectuer un jet de sauvegarde de Force (DD 8 plus votre modificateur de Force et votre Bonus de maîtrise). En cas d'échec, vous poussez la cible à 1,50 mètre de vous ou lui imposez la condition À terre (votre choix). Vous ne pouvez utiliser ce bénéfice qu'une fois par tour.
 
 Interposition du bouclier. Si vous êtes soumis à un effet qui vous permet d'effectuer un jet de sauvegarde de Dextérité pour ne subir que la moitié des dégâts, vous pouvez utiliser une Réaction pour ne subir aucun dégât si vous réussissez le jet et tenez un Bouclier.</content>
   <content contentuid="h99a1f866g5649g1e74gc90fgd29c50fa0426" version="1">Don : Maître du bouclier</content>
-  <content contentuid="h5752835cge17egb9e8g58cdgb5e2500ab72d" version="3">Coup de bouclier. Si vous attaquez une créature à 5 pieds ou moins de vous dans le cadre de l'action Attaque et touchez avec une arme de corps à corps, vous pouvez immédiatement frapper la cible avec votre Bouclier s'il est équipé, la forçant à effectuer un jet de sauvegarde de Force (DD 8 plus votre modificateur de Force et votre Bonus de maîtrise). En cas d'échec, vous poussez la cible à 5 pieds de vous ou lui imposez la condition À terre (votre choix). Vous ne pouvez utiliser ce bénéfice qu'une fois par tour.
+  <content contentuid="h5752835cge17egb9e8g58cdgb5e2500ab72d" version="3">Coup de bouclier. Si vous attaquez une créature à 1,50 mètre ou moins de vous dans le cadre de l'action Attaquer et touchez avec une arme de corps à corps, vous pouvez immédiatement frapper la cible avec votre Bouclier s'il est équipé, la forçant à effectuer un jet de sauvegarde de Force (DD 8 plus votre modificateur de Force et votre Bonus de maîtrise). En cas d'échec, vous poussez la cible à 1,50 mètre de vous ou lui imposez la condition À terre (votre choix). Vous ne pouvez utiliser ce bénéfice qu'une fois par tour.
 
 Interposition du bouclier. Si vous êtes soumis à un effet qui vous permet d'effectuer un jet de sauvegarde de Dextérité pour ne subir que la moitié des dégâts, vous pouvez utiliser une Réaction pour ne subir aucun dégât si vous réussissez le jet et tenez un Bouclier.</content>
   <content contentuid="h7703cd86g07afg9672g1765g96366fbc1138" version="1">Coup de bouclier : Bousculer</content>
@@ -1100,7 +1173,7 @@ Interposition du bouclier. Si vous êtes soumis à un effet qui vous permet d'ef
   <content contentuid="hc89bef70gb4acgcaf4g1bd4gc4db62830233" version="1">Tireur de sorts</content>
   <content contentuid="hd2aeaec7g64f4g180fg4fc9g91918a557c3c" version="2">Ignorer le couvert. Vos attaques de sort à distance ne reçoivent pas de pénalités des &lt;LSTag Tooltip="HighGroundRules"&gt;Règles de terrain élevé&lt;/LSTag&gt;.
 
-Lancer en mêlée. Le fait d'être à 5 pieds ou moins d'un ennemi n'impose pas le Désavantage à vos jets d'attaque avec les sorts.
+Lancer en mêlée. Le fait d'être à 1,50 mètre ou moins d'un ennemi n'impose pas le Désavantage à vos jets d'attaque avec les sorts.
 
 Portée accrue. Augmentez la portée des sorts de 50 %.</content>
   <content contentuid="h83a93112gc496g26f6g27f3ge5d63171ca0b" version="2">Don : Tireur de sorts (À distance)</content>
@@ -1110,33 +1183,33 @@ Portée accrue. Augmentez la portée des sorts de 50 %.</content>
   <content contentuid="hdfe62e0fgf3abgc70ag0019g4af2fcfb5109" version="1">Guerrier mage</content>
   <content contentuid="haea51e98gfb73g894eg965bg2978e243f5e4" version="1">Vous gagnez l'&lt;LSTag Tooltip="Advantage"&gt;Avantage&lt;/LSTag&gt; aux &lt;LSTag Tooltip="SavingThrow"&gt;Jets de sauvegarde&lt;/LSTag&gt; pour maintenir la &lt;LSTag Tooltip="Concentration"&gt;Concentration&lt;/LSTag&gt; sur un sort.
 
-Vous pouvez également utiliser une &lt;LSTag Type="ActionResource" Tooltip="ReactionActionPoint"&gt;réaction&lt;/LSTag&gt; pour lancer &lt;LSTag Type="Spell" Tooltip="Target_ShockingGrasp"&gt;Choc électrique&lt;/LSTag&gt; contre une cible qui quitte la portée de corps à corps.</content>
+Vous pouvez également utiliser une &lt;LSTag Type="ActionResource" Tooltip="ReactionActionPoint"&gt;réaction&lt;/LSTag&gt; pour lancer &lt;LSTag Type="Spell" Tooltip="Target_ShockingGrasp"&gt;Poigne électrique&lt;/LSTag&gt; contre une cible qui quitte la portée de corps à corps.</content>
   <content contentuid="h1e8be1d2gda52g488egf12aga4dbd08a8b2c" version="1">Maître des armes</content>
   <content contentuid="h71ada843g58a3g712bgd82agc840de1595e5" version="2">Vous gagnez la &lt;LSTag Tooltip="Proficiency"&gt;Maîtrise&lt;/LSTag&gt; des armes de guerre.
 
 Vous gagnez deux propriétés de maîtrise d'arme de votre choix.</content>
   <content contentuid="h70813330g91cdg841fgd506g43cca562e934" version="1">Don : Tireur de sorts (Corps à corps)</content>
-  <content contentuid="hd8edfd84g6945ged2dg5a75gac1ea9cf87c7" version="1">Lancer en mêlée. Le fait d'être à 5 pieds ou moins d'un ennemi n'impose pas le Désavantage à vos jets d'attaque avec les sorts.</content>
+  <content contentuid="hd8edfd84g6945ged2dg5a75gac1ea9cf87c7" version="1">Lancer en mêlée. Le fait d'être à 1,50 mètre ou moins d'un ennemi n'impose pas le Désavantage à vos jets d'attaque avec les sorts.</content>
   <content contentuid="he811ea2cg5f7ega90cgc208g301ddc5eb96c" version="1">Don : Guerrier mage</content>
   <content contentuid="h2d86c838g5e8cg8763gdf9bgaeb1290ded87" version="1">Vous avez l'&lt;LSTag Tooltip="Advantage"&gt;Avantage&lt;/LSTag&gt; aux &lt;LSTag Tooltip="SavingThrow"&gt;Jets de sauvegarde&lt;/LSTag&gt; pour maintenir la &lt;LSTag Tooltip="Concentration"&gt;Concentration&lt;/LSTag&gt; sur un sort.
 
-Vous pouvez utiliser une &lt;LSTag Type="ActionResource" Tooltip="ReactionActionPoint"&gt;réaction&lt;/LSTag&gt; pour lancer &lt;LSTag Type="Spell" Tooltip="Target_ShockingGrasp"&gt;Choc électrique&lt;/LSTag&gt; contre une cible qui quitte la portée de corps à corps.</content>
+Vous pouvez utiliser une &lt;LSTag Type="ActionResource" Tooltip="ReactionActionPoint"&gt;réaction&lt;/LSTag&gt; pour lancer &lt;LSTag Type="Spell" Tooltip="Target_ShockingGrasp"&gt;Poigne électrique&lt;/LSTag&gt; contre une cible qui quitte la portée de corps à corps.</content>
   <content contentuid="h6f27cfe3g88f5geb3eg8790gd6ce157dfac9" version="1">Don : Maître des armes</content>
   <content contentuid="hba5a50e4g4e44gccaag18b0ga7d653029db5" version="3">Vous gagnez la &lt;LSTag Tooltip="Proficiency"&gt;Maîtrise&lt;/LSTag&gt; des armes de guerre.
 
 Vous gagnez deux propriétés de maîtrise d'arme de votre choix.</content>
-  <content contentuid="hed4fadaag2f33gc2b5g10bcg877f54981719" version="3">Arbre-monde</content>
+  <content contentuid="hed4fadaag2f33gc2b5g10bcg877f54981719" version="4">Voie de l'Arbre-monde</content>
   <content contentuid="h07ac58a7gdc95gd7d3g0b48g2015e769d0d0" version="1">Les Barbares qui suivent la Voie de l'Arbre-monde se connectent à l'arbre cosmique Yggdrasil par leur Rage. Cet arbre pousse parmi les Plans Extérieurs, les reliant entre eux et au Plan Matériel. Ces Barbares puisent dans la magie de l'arbre pour leur vitalité et comme moyen de voyage dimensionnel.</content>
   <content contentuid="h7f11fde8g7022gc624gc07cg0bf0afe43eb0" version="1">Niveau 3 : Vitalité de l'arbre</content>
   <content contentuid="h17806188g48eag72daga9fag423961387d39" version="1">Votre Rage puise dans la force vitale de l'Arbre-monde. Vous gagnez les bénéfices suivants.
 
 Élan vital. Lorsque vous activez votre Rage, vous gagnez un nombre de Points de vie temporaires égal à votre niveau de Barbare.
 
-Force vivifiante. Au début de chacun de vos tours tandis que votre Rage est active, vous pouvez choisir une autre créature à 10 pieds ou moins de vous pour lui faire gagner des Points de vie temporaires. Pour déterminer le nombre de Points de vie temporaires, lancez un nombre de d6 égal à votre bonus de Dégâts de Rage et additionnez-les. Si des Points de vie temporaires restent lorsque votre Rage se termine, ils disparaissent.</content>
+Force vivifiante. Au début de chacun de vos tours tandis que votre Rage est active, vous pouvez choisir une autre créature à 3 mètres ou moins de vous pour lui faire gagner des Points de vie temporaires. Pour déterminer le nombre de Points de vie temporaires, lancez un nombre de d6 égal à votre bonus de Dégâts de Rage et additionnez-les. Si des Points de vie temporaires restent lorsque votre Rage se termine, ils disparaissent.</content>
   <content contentuid="h39e02d12g9361g9427gcabbg9c625c015d9e" version="1">Niveau 6 : Branches de l'arbre</content>
-  <content contentuid="hc973bce4g12d2g5a53g43a8g98cefe571124" version="2">Tant que votre Rage est active, vous pouvez utiliser votre Réaction pour cingler avec les branches spectrales de l'Arbre-monde et attirer une créature que vous pouvez voir à 30 pieds ou moins de vous. La cible doit réussir un jet de sauvegarde de Force (DD 8 + votre modificateur de Force + votre Bonus de maîtrise) ou être attirée jusqu'à 20 pieds directement vers vous. Après avoir attiré la cible, vous pouvez réduire sa Vitesse à 0 jusqu'au début de votre prochain tour.</content>
+  <content contentuid="hc973bce4g12d2g5a53g43a8g98cefe571124" version="2">Tant que votre Rage est active, vous pouvez utiliser votre Réaction pour cingler avec les branches spectrales de l'Arbre-monde et attirer une créature que vous pouvez voir à 9 mètres ou moins de vous. La cible doit réussir un jet de sauvegarde de Force (DD 8 + votre modificateur de Force + votre Bonus de maîtrise) ou être attirée jusqu'à 6 mètres directement vers vous. Après avoir attiré la cible, vous pouvez réduire sa Vitesse à 0 jusqu'au début de votre prochain tour.</content>
   <content contentuid="h73b80082g2131g52abg5e7bg5ef03ffa6906" version="1">Niveau 10 : Racines assaillantes</content>
-  <content contentuid="h26a9d040g90ffg7098gc158g401ddd420d2e" version="1">Lors de votre tour, votre portée est accrue de 10 pieds avec toute arme de corps à corps possédant la propriété Lourde ou Polyvalente, tandis que des vrilles de l'Arbre-monde s'étendent de vous. Lorsque vous touchez avec une telle arme à votre tour, vous pouvez activer la propriété de maîtrise Pousser ou Renverser en plus d'une autre propriété de maîtrise que vous utilisez avec cette arme.</content>
+  <content contentuid="h26a9d040g90ffg7098gc158g401ddd420d2e" version="1">Lors de votre tour, votre portée est accrue de 3 mètres avec toute arme de corps à corps possédant la propriété Lourde ou Polyvalente, tandis que des vrilles de l'Arbre-monde s'étendent de vous. Lorsque vous touchez avec une telle arme à votre tour, vous pouvez activer la propriété de maîtrise Pousser ou Renverser en plus d'une autre propriété de maîtrise que vous utilisez avec cette arme.</content>
   <content contentuid="h460429dfgc912g3f17g81b4g0b1e6420baf6" version="1">Élan vital</content>
   <content contentuid="hcc3ad546g16bcgfa68g23a7g1b2b0bcd4801" version="1">Lorsque vous activez votre Rage, vous gagnez un nombre de Points de vie temporaires égal à votre niveau de Barbare.</content>
   <content contentuid="haa81c0f2ge2b2gd7b9gc090gd87edfd50eab" version="1">Élan vital</content>
@@ -1148,15 +1221,15 @@ Force vivifiante. Au début de chacun de vos tours tandis que votre Rage est act
   <content contentuid="hf26f1c7dg99f2g62d7g6798gaf1e5640053f" version="1">Racines assaillantes : Pousser</content>
   <content contentuid="hd109b0dbg19e8ga1d2g4826gc3978e7b2e7f" version="1">Racines assaillantes : Renverser</content>
   <content contentuid="hacfddf65g2ec1gdb58g7ef1g360e33d3d696" version="1">Vous pouvez également appliquer la propriété de maîtrise Renverser à cette attaque.</content>
-  <content contentuid="h21000e09gdda6g7a5fg404eg1458b9ccd985" version="2">Au début de chacun de vos tours tandis que votre Rage est active, vous pouvez choisir une autre créature à 10 pieds ou moins de vous pour lui faire gagner des Points de vie temporaires. Pour déterminer le nombre de Points de vie temporaires, lancez un nombre de d6 égal à votre bonus de Dégâts de Rage et additionnez-les. Si des Points de vie temporaires restent lorsque votre Rage se termine, ils disparaissent.</content>
-  <content contentuid="h1d68851cgda5ag5482g75f2gc0f7b6817b16" version="3">Tant que votre Rage est active, vous pouvez utiliser votre Réaction pour cingler avec les branches spectrales de l'Arbre-monde et attirer une créature que vous pouvez voir à 30 pieds ou moins de vous. La cible doit réussir un jet de sauvegarde de Force (DD 8 + votre modificateur de Force + votre Bonus de maîtrise) ou être attirée jusqu'à 20 pieds directement vers vous. Après avoir attiré la cible, vous pouvez réduire sa Vitesse à 0 jusqu'au début de votre prochain tour.</content>
+  <content contentuid="h21000e09gdda6g7a5fg404eg1458b9ccd985" version="2">Au début de chacun de vos tours tandis que votre Rage est active, vous pouvez choisir une autre créature à 3 mètres ou moins de vous pour lui faire gagner des Points de vie temporaires. Pour déterminer le nombre de Points de vie temporaires, lancez un nombre de d6 égal à votre bonus de Dégâts de Rage et additionnez-les. Si des Points de vie temporaires restent lorsque votre Rage se termine, ils disparaissent.</content>
+  <content contentuid="h1d68851cgda5ag5482g75f2gc0f7b6817b16" version="3">Tant que votre Rage est active, vous pouvez utiliser votre Réaction pour cingler avec les branches spectrales de l'Arbre-monde et attirer une créature que vous pouvez voir à 9 mètres ou moins de vous. La cible doit réussir un jet de sauvegarde de Force (DD 8 + votre modificateur de Force + votre Bonus de maîtrise) ou être attirée jusqu'à 6 mètres directement vers vous. Après avoir attiré la cible, vous pouvez réduire sa Vitesse à 0 jusqu'au début de votre prochain tour.</content>
   <content contentuid="hbc51a963g20c5g876cgc0b3g1fda844b3830" version="1">Force vivifiante</content>
   <content contentuid="h0742adb9g8528gcb3ag3596ge883d9faa6ab" version="1">Branches de l'arbre</content>
   <content contentuid="hb477d444g2e4egabe4g8bd0g64d34fe959ee" version="1">Niveau 3 : Furie divine</content>
   <content contentuid="h8561dec8g58feg3afcgc909g7b495a11aeec" version="1">Niveau 3 : Guerrier des dieux</content>
   <content contentuid="h37bdd6afg8377ga414g06b2gd12131f14c73" version="1">Niveau 6 : Concentration fanatique</content>
   <content contentuid="h9ac99198g4fe0gd34bg57a0g52acb98ed35f" version="1">Niveau 10 : Présence zélée</content>
-  <content contentuid="hfa0367c5gd524g439egbb91gf1d01da462a1" version="3">Zélote</content>
+  <content contentuid="hfa0367c5gd524g439egbb91gf1d01da462a1" version="4">Voie du Zélote</content>
   <content contentuid="h0e363cf3g0162gc215g7872g2aa8512bdbd6" version="1">Les Barbares qui empruntent la Voie du Zélote reçoivent des faveurs d'un dieu ou d'un panthéon. Ces Barbares vivent leur Rage comme un épisode extatique d'union divine qui les imprègne de puissance. Ils sont souvent alliés aux prêtres et autres fidèles de leur dieu ou panthéon.</content>
   <content contentuid="h15b91354gf2d6ga550g86cag97a1796054d7" version="1">Vous pouvez canaliser le pouvoir divin dans vos frappes. À chacun de vos tours tandis que votre Rage est active, la première créature que vous touchez avec une arme ou une Attaque à mains nues subit des dégâts supplémentaires égaux à 1d6 plus la moitié de votre niveau de Barbare (arrondi à l'inférieur). Les dégâts supplémentaires sont Nécrotiques ou Radieux ; vous choisissez le type chaque fois que vous infligez ces dégâts.</content>
   <content contentuid="hc4c144a0g2e9bg6166g297cg8829f3a2bd83" version="1">Une entité divine veille à ce que vous puissiez continuer le combat. Vous disposez d'un réservoir de quatre d12 que vous pouvez dépenser pour vous soigner. En tant qu'Action bonus, vous pouvez dépenser des dés du réservoir, les lancer et regagner un nombre de Points de vie égal au total.
@@ -1165,9 +1238,9 @@ Votre réservoir regagne tous les dés dépensés lorsque vous terminez un Repos
 
 Le nombre maximum de dés du réservoir augmente de un lorsque vous atteignez les niveaux de Barbare 6 (5 dés), 12 (6 dés) et 17 (7 dés).</content>
   <content contentuid="h9416ea15g9b17g07abg6c06gd6905fe706ed" version="1">Tant que votre Rage est active, vous ajoutez un bonus égal à votre bonus de Dégâts de Rage à vos jets de sauvegarde.</content>
-  <content contentuid="hd421ade2g497bg2094g6654geebf64ed20f1" version="2">Une fois par Repos court, en tant qu'Action bonus, vous poussez un cri de guerre imprégné d'énergie divine ; les créatures de votre choix à 60 pieds ou moins de vous gagnent l'Avantage aux jets d'attaque et aux jets de sauvegarde jusqu'au début de votre prochain tour.</content>
+  <content contentuid="hd421ade2g497bg2094g6654geebf64ed20f1" version="2">Une fois par Repos court, en tant qu'Action bonus, vous poussez un cri de guerre imprégné d'énergie divine ; les créatures de votre choix à 18 mètres ou moins de vous gagnent l'Avantage aux jets d'attaque et aux jets de sauvegarde jusqu'au début de votre prochain tour.</content>
   <content contentuid="h3e0f83eag20c7gefccg3505g67e905536f9c" version="1">Furie divine : Radieux</content>
-  <content contentuid="hd5d65420g6479g285bg4c8ag03e208bc40e5" version="1">Tant que votre Rage est active, la première créature que vous touchez à chacun de vos tours avec une arme ou une Attaque à mains nues subit des dégâts Radieux supplémentaires égaux à 1d6 plus la moitié de votre niveau de Barbare (arrondi à l'inférieur).</content>
+  <content contentuid="hd5d65420g6479g285bg4c8ag03e208bc40e5" version="1">Tant que votre Rage est active, la première créature que vous touchez à chacun de vos tours avec une arme ou une Attaque à mains nues subit des dégâts Radiants supplémentaires égaux à 1d6 plus la moitié de votre niveau de Barbare (arrondi à l'inférieur).</content>
   <content contentuid="hc0013b90g841eg2935g8b77g5e53735b98a6" version="1">Furie divine : Nécrotique</content>
   <content contentuid="h47b388afge0d2g2240g7d34g00c0f0fbd7f3" version="1">Tant que votre Rage est active, la première créature que vous touchez à chacun de vos tours avec une arme ou une Attaque à mains nues subit des dégâts Nécrotiques supplémentaires égaux à 1d6 plus la moitié de votre niveau de Barbare (arrondi à l'inférieur).</content>
   <content contentuid="hf168720fgd4dbgc575ge2c3g9a0841c3efc9" version="1">Guerrier des dieux</content>
@@ -1181,7 +1254,7 @@ Le nombre maximum de dés du réservoir augmente de un lorsque vous atteignez le
   <content contentuid="hdefa5de2gb9bfgc136gf8e6gf90eb2739837" version="1">Concentration fanatique</content>
   <content contentuid="he4612c48gfd84gd95cg77b9g94667cfad8a4" version="1">Tant que votre Rage est active, vous ajoutez un bonus égal à votre bonus de Dégâts de Rage à vos jets de sauvegarde.</content>
   <content contentuid="hf40dc054gd469gf99cg895bgc27babafe771" version="1">Présence zélée</content>
-  <content contentuid="h2a819702g2758g04dcg200age5456cbe7459" version="1">Une fois par Repos court, en tant qu'Action bonus, vous poussez un cri de guerre imprégné d'énergie divine ; les créatures de votre choix à 60 pieds ou moins de vous gagnent l'Avantage aux jets d'attaque et aux jets de sauvegarde jusqu'au début de votre prochain tour.</content>
+  <content contentuid="h2a819702g2758g04dcg200age5456cbe7459" version="1">Une fois par Repos court, en tant qu'Action bonus, vous poussez un cri de guerre imprégné d'énergie divine ; les créatures de votre choix à 18 mètres ou moins de vous gagnent l'Avantage aux jets d'attaque et aux jets de sauvegarde jusqu'au début de votre prochain tour.</content>
   <content contentuid="h509f959fg0fe6gec34gedb0gc6a719773d5b" version="1">Présence zélée</content>
   <content contentuid="h6e8236c2g9105gb794g70b2g706f0958f778" version="1">Gagnez l'Avantage aux jets d'attaque et aux jets de sauvegarde jusqu'au début du prochain tour du Barbare.</content>
   <content contentuid="h284201cfg7ef2g3386g799dgb94060c50b96" version="1">Niveau 3 : Pas éblouissants</content>
@@ -1195,9 +1268,9 @@ Frappes agiles. Lorsque vous dépensez une utilisation de votre Inspiration bard
 
 Dégâts bardiques. Vous pouvez utiliser la Dextérité à la place de la Force pour les jets d'attaque de vos Attaques à mains nues. Lorsque vous infligez des dégâts avec une Attaque à mains nues, vous pouvez infliger des dégâts Contondants égaux à un lancer de votre dé d'Inspiration bardique plus votre modificateur de Dextérité, au lieu des dégâts normaux de la frappe. Ce lancer ne dépense pas le dé.</content>
   <content contentuid="h75cac7b5gabc0ge6d4gcf1bg66c77bcb1d31" version="1">Niveau 6 : Mouvement inspirant</content>
-  <content contentuid="h2ad23fb9gc206g78bagd3d1g8369951939b3" version="2">Vous pouvez utiliser une Réaction et dépenser une utilisation de votre Inspiration bardique pour vous déplacer jusqu'à la moitié de votre Vitesse. Ensuite, un allié de votre choix à 30 pieds ou moins de vous peut également se déplacer jusqu'à la moitié de sa Vitesse. Aucun des déplacements liés à cette capacité ne provoque d'Attaques d'opportunité.</content>
+  <content contentuid="h2ad23fb9gc206g78bagd3d1g8369951939b3" version="2">Vous pouvez utiliser une Réaction et dépenser une utilisation de votre Inspiration bardique pour vous déplacer jusqu'à la moitié de votre Vitesse. Ensuite, un allié de votre choix à 9 mètres ou moins de vous peut également se déplacer jusqu'à la moitié de sa Vitesse. Aucun des déplacements liés à cette capacité ne provoque d'Attaques d'opportunité.</content>
   <content contentuid="h1af76b4dg4b9cga7cdgf8e7g353530ee4ff9" version="1">Niveau 6 : Pas en tandem</content>
-  <content contentuid="h22f95eb6g9866gb41fg1f08gece44a7945f9" version="1">Vous pouvez dépenser une utilisation de votre Inspiration bardique pour encourager les alliés à 30 pieds ou moins de vous. Un allié encouragé gagne un bonus de +5 à son prochain jet d'Initiative.</content>
+  <content contentuid="h22f95eb6g9866gb41fg1f08gece44a7945f9" version="1">Vous pouvez dépenser une utilisation de votre Inspiration bardique pour encourager les alliés à 9 mètres ou moins de vous. Un allié encouragé gagne un bonus de +5 à son prochain jet d'Initiative.</content>
   <content contentuid="h5336df21g7ddfg1231gfc57ga39ec7e78e9d" version="1">Frappes agiles</content>
   <content contentuid="h6d7a7de1g2c02gc8bbgcf20g79bdbdc08374" version="1">Lorsque vous dépensez une utilisation de votre Inspiration bardique dans le cadre d'une action, d'une Action bonus ou d'une Réaction, vous pouvez effectuer une Attaque à mains nues dans le cadre de cette action, Action bonus ou Réaction.</content>
   <content contentuid="heb20c7adg4399g29d8g90d1g05ee938a1427" version="1">Collège de la Danse</content>
@@ -1207,15 +1280,15 @@ Dégâts bardiques. Vous pouvez utiliser la Dextérité à la place de la Force 
   <content contentuid="h16eb0ddag455fgabbag65b4g954af483e6b1" version="1">Frappes agiles</content>
   <content contentuid="h3838231fg4eb9g1855g186cg2e9b9e1e45e6" version="1">Lorsque vous dépensez une utilisation de votre Inspiration bardique dans le cadre d'une action, d'une Action bonus ou d'une Réaction, vous pouvez effectuer une Attaque à mains nues dans le cadre de cette action, Action bonus ou Réaction.</content>
   <content contentuid="h02d0f03dgbaeegc343ge0f3gc9b59d3458f4" version="1">Mouvement inspirant</content>
-  <content contentuid="hc0c004d2g6411g3244g9901gb849e25f434f" version="4">Un allié de votre choix à 30 pieds ou moins de vous peut se déplacer jusqu'à la moitié de sa Vitesse. Ce déplacement ne provoque pas d'Attaques d'opportunité.</content>
+  <content contentuid="hc0c004d2g6411g3244g9901gb849e25f434f" version="4">Un allié de votre choix à 9 mètres ou moins de vous peut se déplacer jusqu'à la moitié de sa Vitesse. Ce déplacement ne provoque pas d'Attaques d'opportunité.</content>
   <content contentuid="h5c2fd98dg730eg0f81g45d9g556839f62f6a" version="1">Mouvement inspirant</content>
   <content contentuid="h40405809g5c4fgdea3g37aag18b85b437b5f" version="1">Vous pouvez également vous déplacer jusqu'à la moitié de votre Vitesse. Ce déplacement ne provoque pas d'Attaques d'opportunité.</content>
   <content contentuid="hdd7ddd39gf7b8g5306g8adcg34646c6a8890" version="1">Pas en tandem</content>
   <content contentuid="h9c848dbfg9142g2e12g3ccagbc63f31bc4aa" version="1">Il gagne un bonus de +5 à son prochain jet d'Initiative.</content>
   <content contentuid="h92f7f7b1gd3ccg8bd7gc59bgddaff5a65f29" version="1">Mouvement inspirant</content>
-  <content contentuid="h9565b8f9gf2e2g563ag5bc6g05137c600621" version="1">Vous pouvez utiliser une Réaction et dépenser une utilisation de votre Inspiration bardique pour vous déplacer jusqu'à la moitié de votre Vitesse. Ensuite, un allié de votre choix à 30 pieds ou moins de vous peut également se déplacer jusqu'à la moitié de sa Vitesse. Aucun des déplacements liés à cette capacité ne provoque d'Attaques d'opportunité.</content>
+  <content contentuid="h9565b8f9gf2e2g563ag5bc6g05137c600621" version="1">Vous pouvez utiliser une Réaction et dépenser une utilisation de votre Inspiration bardique pour vous déplacer jusqu'à la moitié de votre Vitesse. Ensuite, un allié de votre choix à 9 mètres ou moins de vous peut également se déplacer jusqu'à la moitié de sa Vitesse. Aucun des déplacements liés à cette capacité ne provoque d'Attaques d'opportunité.</content>
   <content contentuid="h7fda03e0g1c44gfb83gc8c5g36e83d6dc3c8" version="1">Pas en tandem</content>
-  <content contentuid="h22dd46abgbee6g491bg8b3eg17ea18400639" version="1">Vous pouvez dépenser une utilisation de votre Inspiration bardique pour encourager les alliés à 30 pieds ou moins de vous. Un allié encouragé gagne un bonus de +5 à son prochain jet d'Initiative.</content>
+  <content contentuid="h22dd46abgbee6g491bg8b3eg17ea18400639" version="1">Vous pouvez dépenser une utilisation de votre Inspiration bardique pour encourager les alliés à 9 mètres ou moins de vous. Un allié encouragé gagne un bonus de +5 à son prochain jet d'Initiative.</content>
   <content contentuid="h928f834egd673g4226g8299gfefdeb81958c" version="3">Voleur de sorts</content>
   <content contentuid="h93fb8ea9gaf06g47b8ga01agebf185b6ef4f" version="3">Un frisson de magie s'écoule de cet arc dans votre main — comme une promesse.</content>
   <content contentuid="h01dfd531g605ag4c72gb4edg3846ab351eae" version="2">Arc long de chasse</content>
@@ -1238,7 +1311,7 @@ Dégâts bardiques. Vous pouvez utiliser la Dextérité à la place de la Force 
   <content contentuid="hbb6b628eg2a57g6250g3b13g87d1d2155d94" version="1">Tant qu'une créature effectue un jet d'attaque contre vous avant la fin du sort, l'attaquant soustrait 1d4 du jet d'attaque.</content>
   <content contentuid="h9272c5c1g1dc9g193fg385dg4ccea106a7ad" version="1">Tant qu'une créature effectue un jet d'attaque contre vous avant la fin du sort, l'attaquant soustrait 1d4 du jet d'attaque.</content>
   <content contentuid="h4405cd9eg35f5g6fa4g01c6g020ed526c1e0" version="1">Tant qu'une créature effectue un jet d'attaque contre vous avant la fin du sort, l'attaquant soustrait 1d4 du jet d'attaque.</content>
-  <content contentuid="h6bbeea0cgfb9cg7197g9d87gc41ed5911b46" version="1">Garde de lame</content>
+  <content contentuid="h6bbeea0cgfb9cg7197g9d87gc41ed5911b46" version="1">Protection contre les armes</content>
   <content contentuid="h6ad2bdeag8e58g6b4fg3462g9aff44485001" version="1">La Faucheuse manifestée</content>
   <content contentuid="h8ccd7ec2g9ed6g29bdgcacfg269b2a087595" version="1">%%% EMPTY</content>
   <content contentuid="h2bed4266gaf46g07f6g40a0gfb3ed759c291" version="1">Imperturbable</content>
@@ -1264,27 +1337,27 @@ Dans le Plan Éthéré, l'entité ne peut pas se déplacer ni interagir avec quo
   <content contentuid="hb2960ca9g49d7g3639g1356g1d818e28a64a" version="1">Orbe chromatique : Tonnerre</content>
   <content contentuid="h98e647d7g3e90gc1ebg704eg55fb50319328" version="1">Projetez une sphère d'énergie tonitruante.</content>
   <content contentuid="h3f315172g0ecag6f6ag14c9g3d5db880a811" version="1">Nuage de dagues</content>
-  <content contentuid="h8a7a7954g6da6g0f9cgced3g9dfea486d831" version="2">Vous invoquez des dagues tourbillonnantes dans un Cylindre de 5 pieds de rayon et 40 pieds de hauteur centré sur un point à portée. Chaque créature dans cette zone subit des dégâts Tranchants. Une créature subit également ces dégâts si elle termine son tour dans la zone ou si le Cylindre se déplace dans son espace. Une créature ne subit ces dégâts qu'une fois par tour.
+  <content contentuid="h8a7a7954g6da6g0f9cgced3g9dfea486d831" version="2">Vous invoquez des dagues tourbillonnantes dans un Cylindre de 1,50 mètre de rayon et 12 mètres de hauteur centré sur un point à portée. Chaque créature dans cette zone subit des dégâts Tranchants. Une créature subit également ces dégâts si elle termine son tour dans la zone ou si le Cylindre se déplace dans son espace. Une créature ne subit ces dégâts qu'une fois par tour.
 
-Lors de vos tours suivants, vous pouvez prendre une action Magique pour déplacer le Cylindre jusqu'à 30 pieds.</content>
+Lors de vos tours suivants, vous pouvez prendre une action Magique pour déplacer le Cylindre jusqu'à 9 mètres.</content>
   <content contentuid="h81c2ba2bgde76gcf4dgb0feg9c1e82f5c048" version="1">Déplacer le nuage de dagues</content>
-  <content contentuid="h397f04c0gccd3gd295ga021g620c652c55a6" version="1">Prenez une action Magique pour téléporter les dagues jusqu'à 30 pieds.</content>
+  <content contentuid="h397f04c0gccd3gd295ga021g620c652c55a6" version="1">Prenez une action Magique pour téléporter les dagues jusqu'à 9 mètres.</content>
   <content contentuid="h933efb07gb6d9g6ac3g1616gcb30169f9ef8" version="1">Déplacer le nuage de dagues</content>
-  <content contentuid="hdc6544c3gfdf8g7fbeg01beg66ea43bb6f3b" version="1">Prenez une action Magique pour téléporter les dagues jusqu'à 30 pieds.</content>
+  <content contentuid="hdc6544c3gfdf8g7fbeg01beg66ea43bb6f3b" version="1">Prenez une action Magique pour téléporter les dagues jusqu'à 9 mètres.</content>
   <content contentuid="hf9903a34g76c3gfdf1g4be2g6ded0a0cde47" version="1">Déplacer le nuage de dagues</content>
-  <content contentuid="h32b22995g2857gfa18gcd1cg50ffda0195dd" version="1">Prenez une action Magique pour téléporter les dagues jusqu'à 30 pieds.</content>
+  <content contentuid="h32b22995g2857gfa18gcd1cg50ffda0195dd" version="1">Prenez une action Magique pour téléporter les dagues jusqu'à 9 mètres.</content>
   <content contentuid="h91d412b9gc3c1g03ddg9d69g14b5660c1d16" version="1">Déplacer le nuage de dagues</content>
-  <content contentuid="ha97083f1g4db3gf664gd422g662591619c09" version="1">Prenez une action Magique pour téléporter les dagues jusqu'à 30 pieds.</content>
+  <content contentuid="ha97083f1g4db3gf664gd422g662591619c09" version="1">Prenez une action Magique pour téléporter les dagues jusqu'à 9 mètres.</content>
   <content contentuid="haaf05dcegc1c7g957cg76bagbacf907adfb7" version="1">Déplacer le nuage de dagues</content>
-  <content contentuid="h80951a8egaf3eg2e55g487ag32eaf1d2ca05" version="1">Prenez une action Magique pour téléporter les dagues jusqu'à 30 pieds.</content>
-  <content contentuid="h37831829g4ea6g1feeg1915gea8f0fa699b7" version="1">Jet de couleurs</content>
+  <content contentuid="h80951a8egaf3eg2e55g487ag32eaf1d2ca05" version="1">Prenez une action Magique pour téléporter les dagues jusqu'à 9 mètres.</content>
+  <content contentuid="h37831829g4ea6g1feeg1915gea8f0fa699b7" version="1">Couleurs dansantes</content>
   <content contentuid="h3e1a2984ge2d3ge837gff22gc2ac69bcf687" version="1">&lt;LSTag Type="Status" Tooltip="COLOR_SPRAY"&gt;Aveugler&lt;/LSTag&gt; des créatures jusqu'à un total de [1].</content>
-  <content contentuid="h36775801gf2edg8e9egebabg494ae7137454" version="1">Jet de couleurs</content>
-  <content contentuid="h42379051g6231g2155g0496gf8997d265fb7" version="1">Jet de couleurs</content>
-  <content contentuid="h26b3432cgad7cgf53ag486dg94a645b313b6" version="1">Jet de couleurs</content>
-  <content contentuid="h8071e9a3ge1f2gc3ceg9e5cgfe38c1049dda" version="1">Jet de couleurs</content>
-  <content contentuid="hddcc10f2gfedfg2db7g09f0g30494e6b25b9" version="1">Jet de couleurs</content>
-  <content contentuid="hb0efd2ceg0833g9420g8355ge424da379f9e" version="2">Vous projetez un éblouissant torrent de lumières vives et colorées. Chaque créature dans un Cône de 15 pieds partant de vous doit réussir un jet de sauvegarde de Constitution ou être affectée par la condition Aveuglé jusqu'à la fin de votre prochain tour.</content>
+  <content contentuid="h36775801gf2edg8e9egebabg494ae7137454" version="1">Couleurs dansantes</content>
+  <content contentuid="h42379051g6231g2155g0496gf8997d265fb7" version="1">Couleurs dansantes</content>
+  <content contentuid="h26b3432cgad7cgf53ag486dg94a645b313b6" version="1">Couleurs dansantes</content>
+  <content contentuid="h8071e9a3ge1f2gc3ceg9e5cgfe38c1049dda" version="1">Couleurs dansantes</content>
+  <content contentuid="hddcc10f2gfedfg2db7g09f0g30494e6b25b9" version="1">Couleurs dansantes</content>
+  <content contentuid="hb0efd2ceg0833g9420g8355ge424da379f9e" version="2">Vous projetez un éblouissant torrent de lumières vives et colorées. Chaque créature dans un Cône de 4,50 mètres partant de vous doit réussir un jet de sauvegarde de Constitution ou être affectée par la condition Aveuglé jusqu'à la fin de votre prochain tour.</content>
   <content contentuid="h5b521bc0g991ag1509g1532g7a7432c14232" version="1">Cône de froid</content>
   <content contentuid="h59b9e3afg4467g5a79gf262g265bd2bcb18d" version="1">Faites jaillir de vos mains un tourbillon de givre, d'air vif et de cristaux de neige condensés.</content>
   <content contentuid="hdc0383dag5a23gd42dg0b27g00f90507d3e4" version="1">Contagion : Cécité morbide</content>
@@ -1431,9 +1504,9 @@ Lors de vos tours suivants, vous pouvez prendre une action Magique pour déplace
   <content contentuid="h5d17bbf7gb793g42b6gacefg8a899ba5c4ab" version="1">Maléfice</content>
   <content contentuid="h65f3ea14g5c79g6cdag91a8g8747542a090c" version="1">Faites en sorte que vos attaques infligent [1] dégâts supplémentaires à la cible et lui donnent le &lt;LSTag Tooltip="Disadvantage"&gt;Désavantage&lt;/LSTag&gt; dans une &lt;LSTag Tooltip="Abilities"&gt;caractéristique&lt;/LSTag&gt; de votre choix.</content>
   <content contentuid="hce562dddgafdeg09c2gfcbfgfbdf120f983f" version="1">Si la cible meurt avant la fin du sort, vous pouvez lancer Maléfice sur une nouvelle créature sans dépenser d'&lt;LSTag Tooltip="SpellSlot"&gt;emplacement de sort&lt;/LSTag&gt;.</content>
-  <content contentuid="hc421c06eg7266g8444g3e70g03d5b5fcf166" version="2">Au moment où votre attaque touche ou rate la cible, l'arme ou la munition que vous utilisez se transforme en éclair. Au lieu de subir des dégâts ou autres effets de l'attaque, la cible subit 4d8 dégâts de Foudre en cas de toucher, ou la moitié en cas d'échec. Chaque créature à 10 pieds ou moins de la cible subit 2d8 dégâts de Foudre.</content>
-  <content contentuid="hbc4b3cdeg1f95g6b65gad88g180de678c0b5" version="1">Au moment où votre attaque touche ou rate la cible, l'arme ou la munition que vous utilisez se transforme en éclair. Au lieu de subir des dégâts ou autres effets de l'attaque, la cible subit 4d8 dégâts de Foudre en cas de toucher, ou la moitié en cas d'échec. Chaque créature à 10 pieds ou moins de la cible subit 2d8 dégâts de Foudre.</content>
-  <content contentuid="h13cf2c9bg80e6g0163g3e81g9d59cc051df8" version="1">Au moment où votre attaque touche ou rate la cible, l'arme ou la munition que vous utilisez se transforme en éclair. Au lieu de subir des dégâts ou autres effets de l'attaque, la cible subit 4d8 dégâts de Foudre en cas de toucher, ou la moitié en cas d'échec. Chaque créature à 10 pieds ou moins de la cible subit 2d8 dégâts de Foudre.</content>
+  <content contentuid="hc421c06eg7266g8444g3e70g03d5b5fcf166" version="2">Au moment où votre attaque touche ou rate la cible, l'arme ou la munition que vous utilisez se transforme en éclair. Au lieu de subir des dégâts ou autres effets de l'attaque, la cible subit 4d8 dégâts de Foudre en cas de toucher, ou la moitié en cas d'échec. Chaque créature à 3 mètres ou moins de la cible subit 2d8 dégâts de Foudre.</content>
+  <content contentuid="hbc4b3cdeg1f95g6b65gad88g180de678c0b5" version="1">Au moment où votre attaque touche ou rate la cible, l'arme ou la munition que vous utilisez se transforme en éclair. Au lieu de subir des dégâts ou autres effets de l'attaque, la cible subit 4d8 dégâts de Foudre en cas de toucher, ou la moitié en cas d'échec. Chaque créature à 3 mètres ou moins de la cible subit 2d8 dégâts de Foudre.</content>
+  <content contentuid="h13cf2c9bg80e6g0163g3e81g9d59cc051df8" version="1">Au moment où votre attaque touche ou rate la cible, l'arme ou la munition que vous utilisez se transforme en éclair. Au lieu de subir des dégâts ou autres effets de l'attaque, la cible subit 4d8 dégâts de Foudre en cas de toucher, ou la moitié en cas d'échec. Chaque créature à 3 mètres ou moins de la cible subit 2d8 dégâts de Foudre.</content>
   <content contentuid="hc07eac86g7983g1b9eg4f6bg629a0e86b214" version="1">Le bonus passe à +2 avec un emplacement de sort de niveau 3 à 5. Le bonus passe à +3 avec un emplacement de sort de niveau 6 ou supérieur.</content>
   <content contentuid="hf3454d49ga887g5e0fg8d2agc0bbd2b7d8f1" version="1">Vous touchez une arme non magique. Jusqu'à la fin du sort, cette arme devient une arme magique avec un bonus de +[1] aux jets d'attaque et aux jets de dégâts. Le sort se termine prématurément si vous le lancez à nouveau.</content>
   <content contentuid="h3de4daa5g270dgd865g3b17g917d23d9331c" version="1">Vous touchez une arme non magique. Jusqu'à la fin du sort, cette arme devient une arme magique avec un bonus de +[1] aux jets d'attaque et aux jets de dégâts. Le sort se termine prématurément si vous le lancez à nouveau.</content>
@@ -1483,12 +1556,22 @@ Lorsque vous êtes monté sur le destrier et subissez 4 dégâts ou plus, vous d
 
 
 Seul un joueur au cœur pur peut voir le destrier.</content>
-  <content contentuid="h5f226a79g1b15g405cgf870gf64805e10151" version="1">La cible subit le Désavantage aux Tests de D20 basés sur la Force pendant la durée. Pendant ce temps, elle soustrait également 1d8 à tous ses jets de dégâts. La cible recommence le jet de sauvegarde à la fin de chacun de ses tours, mettant fin au sort en cas de réussite.</content>
-  <content contentuid="h204f9579g57ceg19e1g0cd5g863a58542053" version="1">La cible subit le Désavantage aux Tests de D20 basés sur la Force pendant la durée. Pendant ce temps, elle soustrait également 1d8 à tous ses jets de dégâts. La cible recommence le jet de sauvegarde à la fin de chacun de ses tours, mettant fin au sort en cas de réussite.</content>
-  <content contentuid="h58d34c7bgba94g21d5gf05ag4ed5c0aea0ab" version="1">La cible subit le Désavantage aux Tests de D20 basés sur la Force pendant la durée. Pendant ce temps, elle soustrait également 1d8 à tous ses jets de dégâts. La cible recommence le jet de sauvegarde à la fin de chacun de ses tours, mettant fin au sort en cas de réussite.</content>
-  <content contentuid="h0b14dd67gb5f5gc96dg4d31g57097dbedd01" version="1">La cible subit le Désavantage aux Tests de D20 basés sur la Force pendant la durée. Pendant ce temps, elle soustrait également 1d8 à tous ses jets de dégâts. La cible recommence le jet de sauvegarde à la fin de chacun de ses tours, mettant fin au sort en cas de réussite.</content>
-  <content contentuid="h2eb3007dg66b1g256cg24e5g51538a8f09c9" version="1">La cible subit le Désavantage aux Tests de D20 basés sur la Force pendant la durée. Pendant ce temps, elle soustrait également 1d8 à tous ses jets de dégâts. La cible recommence le jet de sauvegarde à la fin de chacun de ses tours, mettant fin au sort en cas de réussite.</content>
-  <content contentuid="h07724cb8g58c2g9aaag313cg5be5871047e1" version="1">La cible subit le Désavantage aux Tests de D20 basés sur la Force pendant la durée. Pendant ce temps, elle soustrait également 1d8 à tous ses jets de dégâts. La cible recommence le jet de sauvegarde à la fin de chacun de ses tours, mettant fin au sort en cas de réussite.</content>
+  <content contentuid="h5f226a79g1b15g405cgf870gf64805e10151" version="2">Un rayon d'énergie débilitante jaillit de vous vers une créature à portée. La cible doit effectuer un jet de sauvegarde de Constitution. En cas de réussite, la cible a le Désavantage au prochain jet d'attaque qu'elle effectue jusqu'au début de votre prochain tour.
+
+En cas d'échec, la cible a le Désavantage aux Tests de D20 basés sur la Force pendant la durée. Pendant ce temps, elle soustrait également 1d8 à tous ses jets de dégâts. La cible répète le jet de sauvegarde à la fin de chacun de ses tours, mettant fin au sort en cas de réussite.</content>
+  <content contentuid="h204f9579g57ceg19e1g0cd5g863a58542053" version="2">Un rayon d'énergie débilitante jaillit de vous vers une créature à portée. La cible doit effectuer un jet de sauvegarde de Constitution. En cas de réussite, la cible a le Désavantage au prochain jet d'attaque qu'elle effectue jusqu'au début de votre prochain tour.</content>
+  <content contentuid="h58d34c7bgba94g21d5gf05ag4ed5c0aea0ab" version="2">Un rayon d'énergie débilitante jaillit de vous vers une créature à portée. La cible doit effectuer un jet de sauvegarde de Constitution. En cas de réussite, la cible a le Désavantage au prochain jet d'attaque qu'elle effectue jusqu'au début de votre prochain tour.
+
+En cas d'échec, la cible a le Désavantage aux Tests de D20 basés sur la Force pendant la durée. Pendant ce temps, elle soustrait également 1d8 à tous ses jets de dégâts. La cible répète le jet de sauvegarde à la fin de chacun de ses tours, mettant fin au sort en cas de réussite.</content>
+  <content contentuid="h0b14dd67gb5f5gc96dg4d31g57097dbedd01" version="2">Un rayon d'énergie débilitante jaillit de vous vers une créature à portée. La cible doit effectuer un jet de sauvegarde de Constitution. En cas de réussite, la cible a le Désavantage au prochain jet d'attaque qu'elle effectue jusqu'au début de votre prochain tour.
+
+En cas d'échec, la cible a le Désavantage aux Tests de D20 basés sur la Force pendant la durée. Pendant ce temps, elle soustrait également 1d8 à tous ses jets de dégâts. La cible répète le jet de sauvegarde à la fin de chacun de ses tours, mettant fin au sort en cas de réussite.</content>
+  <content contentuid="h2eb3007dg66b1g256cg24e5g51538a8f09c9" version="2">Un rayon d'énergie débilitante jaillit de vous vers une créature à portée. La cible doit effectuer un jet de sauvegarde de Constitution. En cas de réussite, la cible a le Désavantage au prochain jet d'attaque qu'elle effectue jusqu'au début de votre prochain tour.
+
+En cas d'échec, la cible a le Désavantage aux Tests de D20 basés sur la Force pendant la durée. Pendant ce temps, elle soustrait également 1d8 à tous ses jets de dégâts. La cible répète le jet de sauvegarde à la fin de chacun de ses tours, mettant fin au sort en cas de réussite.</content>
+  <content contentuid="h07724cb8g58c2g9aaag313cg5be5871047e1" version="2">Un rayon d'énergie débilitante jaillit de vous vers une créature à portée. La cible doit effectuer un jet de sauvegarde de Constitution. En cas de réussite, la cible a le Désavantage au prochain jet d'attaque qu'elle effectue jusqu'au début de votre prochain tour.
+
+En cas d'échec, la cible a le Désavantage aux Tests de D20 basés sur la Force pendant la durée. Pendant ce temps, elle soustrait également 1d8 à tous ses jets de dégâts. La cible répète le jet de sauvegarde à la fin de chacun de ses tours, mettant fin au sort en cas de réussite.</content>
   <content contentuid="h6f9f97e3gf464g5501g588eg5db8ef9b538f" version="1">Subit le Désavantage aux Tests de D20 basés sur la Force pendant la durée. Pendant ce temps, elle soustrait également 1d8 à tous ses jets de dégâts. La cible recommence le jet de sauvegarde à la fin de chacun de ses tours, mettant fin au sort en cas de réussite.</content>
   <content contentuid="h62840b59g871cgdf70gec31g5bda4b8858d2" version="1">&lt;LSTag Type="Status" Tooltip="POISONED"&gt;Empoisonne&lt;/LSTag&gt; la cible.</content>
   <content contentuid="h0a0c0a89gc109g1dfega8b7g644a8b3a0f9d" version="1">&lt;LSTag Type="Status" Tooltip="POISONED"&gt;Empoisonne&lt;/LSTag&gt; la cible.</content>
@@ -1503,33 +1586,33 @@ Seul un joueur au cœur pur peut voir le destrier.</content>
   <content contentuid="hb291dd01gaa36gf848g9cb2g11776f6a95ba" version="1">Vous touchez une créature consentante. Lorsque la créature subit des dégâts avant la fin du sort, elle réduit le total des dégâts subis de 1d4. Une créature ne peut bénéficier de ce sort qu'une fois par tour.</content>
   <content contentuid="h9d6a4e32g87edg4607g6cd5g19197e4e0034" version="1">Lorsque la créature subit des dégâts avant la fin du sort, elle réduit le total des dégâts subis de 1d4. Une créature ne peut bénéficier de ce sort qu'une fois par tour.</content>
   <content contentuid="h1e40a51eg6772g87d3ga8a6gd8b5dcc5e0f0" version="1">Lorsque la créature subit des dégâts avant la fin du sort, elle réduit le total des dégâts subis de 1d4. Une créature ne peut bénéficier de ce sort qu'une fois par tour.</content>
-  <content contentuid="h0fb46065g45fege74age2e5g0f1ff68942df" version="2">Chaque créature de votre choix dans une Sphère de 5 pieds de rayon centrée sur un point à portée doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Neutralisé jusqu'à la fin de son prochain tour, moment auquel elle doit répéter le jet. Si la cible rate le second jet, elle a la condition Inconscient pendant la durée. Le sort se termine sur une cible si elle subit des dégâts ou si quelqu'un à 5 pieds d'elle prend une action pour la sortir de l'effet du sort.</content>
-  <content contentuid="h4fcec4c9gde1eg19b6gebddg9af35fef4ff5" version="2">Chaque créature de votre choix dans une Sphère de 5 pieds de rayon centrée sur un point à portée doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Neutralisé jusqu'à la fin de son prochain tour, moment auquel elle doit répéter le jet. Si la cible rate le second jet, elle a la condition Inconscient pendant la durée. Le sort se termine sur une cible si elle subit des dégâts ou si quelqu'un à 5 pieds d'elle prend une action pour la sortir de l'effet du sort.</content>
-  <content contentuid="h2ba0acdeg33d2g33c7g5f83gb4c34e1444c0" version="2">Chaque créature de votre choix dans une Sphère de 5 pieds de rayon centrée sur un point à portée doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Neutralisé jusqu'à la fin de son prochain tour, moment auquel elle doit répéter le jet. Si la cible rate le second jet, elle a la condition Inconscient pendant la durée. Le sort se termine sur une cible si elle subit des dégâts ou si quelqu'un à 5 pieds d'elle prend une action pour la sortir de l'effet du sort.</content>
-  <content contentuid="ha765fffag4904gfe52g8d54gd4472a83f8fc" version="2">Chaque créature de votre choix dans une Sphère de 5 pieds de rayon centrée sur un point à portée doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Neutralisé jusqu'à la fin de son prochain tour, moment auquel elle doit répéter le jet. Si la cible rate le second jet, elle a la condition Inconscient pendant la durée. Le sort se termine sur une cible si elle subit des dégâts ou si quelqu'un à 5 pieds d'elle prend une action pour la sortir de l'effet du sort.</content>
-  <content contentuid="h804ad0f1g6cb1ge2ecg1066g91b9c7f2effa" version="2">Chaque créature de votre choix dans une Sphère de 5 pieds de rayon centrée sur un point à portée doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Neutralisé jusqu'à la fin de son prochain tour, moment auquel elle doit répéter le jet. Si la cible rate le second jet, elle a la condition Inconscient pendant la durée. Le sort se termine sur une cible si elle subit des dégâts ou si quelqu'un à 5 pieds d'elle prend une action pour la sortir de l'effet du sort.</content>
-  <content contentuid="h47a0106cg9a69g79a5g7f31g8c859cf2dd61" version="2">Chaque créature de votre choix dans une Sphère de 5 pieds de rayon centrée sur un point à portée doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Neutralisé jusqu'à la fin de son prochain tour, moment auquel elle doit répéter le jet. Si la cible rate le second jet, elle a la condition Inconscient pendant la durée. Le sort se termine sur une cible si elle subit des dégâts ou si quelqu'un à 5 pieds d'elle prend une action pour la sortir de l'effet du sort.</content>
+  <content contentuid="h0fb46065g45fege74age2e5g0f1ff68942df" version="2">Chaque créature de votre choix dans une Sphère de 1,50 mètre de rayon centrée sur un point à portée doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Neutralisé jusqu'à la fin de son prochain tour, moment auquel elle doit répéter le jet. Si la cible rate le second jet, elle a la condition Inconscient pendant la durée. Le sort se termine sur une cible si elle subit des dégâts ou si quelqu'un à 1,50 mètre d'elle prend une action pour la sortir de l'effet du sort.</content>
+  <content contentuid="h4fcec4c9gde1eg19b6gebddg9af35fef4ff5" version="2">Chaque créature de votre choix dans une Sphère de 1,50 mètre de rayon centrée sur un point à portée doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Neutralisé jusqu'à la fin de son prochain tour, moment auquel elle doit répéter le jet. Si la cible rate le second jet, elle a la condition Inconscient pendant la durée. Le sort se termine sur une cible si elle subit des dégâts ou si quelqu'un à 1,50 mètre d'elle prend une action pour la sortir de l'effet du sort.</content>
+  <content contentuid="h2ba0acdeg33d2g33c7g5f83gb4c34e1444c0" version="2">Chaque créature de votre choix dans une Sphère de 1,50 mètre de rayon centrée sur un point à portée doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Neutralisé jusqu'à la fin de son prochain tour, moment auquel elle doit répéter le jet. Si la cible rate le second jet, elle a la condition Inconscient pendant la durée. Le sort se termine sur une cible si elle subit des dégâts ou si quelqu'un à 1,50 mètre d'elle prend une action pour la sortir de l'effet du sort.</content>
+  <content contentuid="ha765fffag4904gfe52g8d54gd4472a83f8fc" version="2">Chaque créature de votre choix dans une Sphère de 1,50 mètre de rayon centrée sur un point à portée doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Neutralisé jusqu'à la fin de son prochain tour, moment auquel elle doit répéter le jet. Si la cible rate le second jet, elle a la condition Inconscient pendant la durée. Le sort se termine sur une cible si elle subit des dégâts ou si quelqu'un à 1,50 mètre d'elle prend une action pour la sortir de l'effet du sort.</content>
+  <content contentuid="h804ad0f1g6cb1ge2ecg1066g91b9c7f2effa" version="2">Chaque créature de votre choix dans une Sphère de 1,50 mètre de rayon centrée sur un point à portée doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Neutralisé jusqu'à la fin de son prochain tour, moment auquel elle doit répéter le jet. Si la cible rate le second jet, elle a la condition Inconscient pendant la durée. Le sort se termine sur une cible si elle subit des dégâts ou si quelqu'un à 1,50 mètre d'elle prend une action pour la sortir de l'effet du sort.</content>
+  <content contentuid="h47a0106cg9a69g79a5g7f31g8c859cf2dd61" version="2">Chaque créature de votre choix dans une Sphère de 1,50 mètre de rayon centrée sur un point à portée doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Neutralisé jusqu'à la fin de son prochain tour, moment auquel elle doit répéter le jet. Si la cible rate le second jet, elle a la condition Inconscient pendant la durée. Le sort se termine sur une cible si elle subit des dégâts ou si quelqu'un à 1,50 mètre d'elle prend une action pour la sortir de l'effet du sort.</content>
   <content contentuid="h36a49c70g93aeg56fag31d6g861694b3eca0" version="1">Durcissez la chair d'une créature comme de la pierre. Elle ne subit que la &lt;LSTag Tooltip="Resistant"&gt;moitié des dégâts&lt;/LSTag&gt; Contondants, Perforants et Tranchants.</content>
   <content contentuid="hbd15ec06ga1begd062g730ega5c6e100ec6f" version="1">Durcissez la chair d'une créature comme de la pierre. Elle ne subit que la &lt;LSTag Tooltip="Resistant"&gt;moitié des dégâts&lt;/LSTag&gt; Contondants, Perforants et Tranchants.</content>
   <content contentuid="h901059e2g5cefg4bbbg2e95g491ea1dbb812" version="1">Durcissez la chair d'une créature comme de la pierre. Elle ne subit que la &lt;LSTag Tooltip="Resistant"&gt;moitié des dégâts&lt;/LSTag&gt; Contondants, Perforants et Tranchants.</content>
   <content contentuid="h138ad957g4e4cgf396gebd4g8ad15a605ba6" version="1">Durcissez la chair d'une créature comme de la pierre. Elle ne subit que la &lt;LSTag Tooltip="Resistant"&gt;moitié des dégâts&lt;/LSTag&gt; Contondants, Perforants et Tranchants.</content>
   <content contentuid="h9bcb3486gd911g3c9fgace0g779c9bda1aa7" version="1">Possède la &lt;LSTag Tooltip="Resistant"&gt;Résistance&lt;/LSTag&gt; aux dégâts Contondants, Perforants et Tranchants.</content>
   <content contentuid="h017b9fabgf86fg784ag16d2g0ce3617ead28" version="1">Nuée de boules de neige de Snilloc</content>
-  <content contentuid="h1d1a9875g453ag1a74g99c0g7c41137717d6" version="1">Vous lancez [1] boules de neige vers un point de votre choix à portée. Chaque boule de neige affecte les créatures dans une sphère de 5 pieds de rayon centrée sur ce point. Chaque créature dans la zone doit réussir un jet de sauvegarde de Dextérité, subissant [2] par boule de neige en cas d'échec, ou la moitié en cas de réussite.</content>
+  <content contentuid="h1d1a9875g453ag1a74g99c0g7c41137717d6" version="1">Vous lancez [1] boules de neige vers un point de votre choix à portée. Chaque boule de neige affecte les créatures dans une sphère de 1,50 mètre de rayon centrée sur ce point. Chaque créature dans la zone doit réussir un jet de sauvegarde de Dextérité, subissant [2] par boule de neige en cas d'échec, ou la moitié en cas de réussite.</content>
   <content contentuid="hd9de5da7g002ag9970g205agdaf99dc1ddd9" version="1">Nuée de boules de neige de Snilloc</content>
-  <content contentuid="hc1cce658gb841g21b6gb82bgc5fddc780327" version="1">Vous lancez [1] boules de neige vers un point de votre choix à portée. Chaque boule de neige affecte les créatures dans une sphère de 5 pieds de rayon centrée sur ce point. Chaque créature dans la zone doit réussir un jet de sauvegarde de Dextérité, subissant [2] par boule de neige en cas d'échec, ou la moitié en cas de réussite.</content>
+  <content contentuid="hc1cce658gb841g21b6gb82bgc5fddc780327" version="1">Vous lancez [1] boules de neige vers un point de votre choix à portée. Chaque boule de neige affecte les créatures dans une sphère de 1,50 mètre de rayon centrée sur ce point. Chaque créature dans la zone doit réussir un jet de sauvegarde de Dextérité, subissant [2] par boule de neige en cas d'échec, ou la moitié en cas de réussite.</content>
   <content contentuid="h2bbc0ae7ged33gb46fg82a1ge5f25d92f4a0" version="1">Sphère vitrioleuse</content>
-  <content contentuid="hea231ad3g2d3cg3aedge6d0ge22e99d5107a" version="1">Vous désignez un endroit à portée, et une boule d'acide luisante de 30 cm de diamètre y fonce et explose dans une Sphère de 20 pieds de rayon. Chaque créature dans cette zone effectue un jet de sauvegarde de Dextérité. En cas d'échec, une créature subit [1] et [2] supplémentaires à la fin de son prochain tour. En cas de réussite, une créature ne subit que la moitié des dégâts initiaux.</content>
+  <content contentuid="hea231ad3g2d3cg3aedge6d0ge22e99d5107a" version="1">Vous désignez un endroit à portée, et une boule d'acide luisante de 30 cm de diamètre y fonce et explose dans une Sphère de 6 mètres de rayon. Chaque créature dans cette zone effectue un jet de sauvegarde de Dextérité. En cas d'échec, une créature subit [1] et [2] supplémentaires à la fin de son prochain tour. En cas de réussite, une créature ne subit que la moitié des dégâts initiaux.</content>
   <content contentuid="hbdd2851fgaad9g9c74g84a7g3b02ca7cb05a" version="1">Sphère vitrioleuse</content>
   <content contentuid="h50b099e6g73f6g882bg67ffge23cefdbcb29" version="1">Subit [1] à la fin de son tour.</content>
   <content contentuid="h520061aagfd3bg1e64g6e2dg7bfb16deeec1" version="1">Fouet mental de Tasha</content>
   <content contentuid="hac6a3cd4g227dg6382g6388g92a7edb553be" version="2">Vous assaillez psychiquement une créature que vous pouvez voir à portée. La cible doit réussir un jet de sauvegarde d'Intelligence. En cas d'échec, la cible subit des dégâts psychiques et ne peut pas utiliser de réaction jusqu'à la fin de son prochain tour. De plus, à son prochain tour, elle doit choisir entre une action et une action bonus ; elle n'en obtient qu'une seule. En cas de réussite, la cible subit la moitié des dégâts et ne subit aucun des autres effets du sort.</content>
   <content contentuid="h045ce8b1g3aa7gda4dgce76ge7dd467da035" version="1">Fouet mental de Tasha</content>
   <content contentuid="hc474f769g4628g2168g1fd4gbc21c1c9e1d5" version="2">Ne peut pas utiliser de réaction jusqu'à la fin de son prochain tour. De plus, à son prochain tour, elle doit choisir entre une action et une action bonus ; elle n'en obtient qu'une seule.</content>
-  <content contentuid="h3729f6f3g8054gfc05g7817g8f510f005496" version="1">Lame à flamme verte</content>
-  <content contentuid="h61a4b68fgff5eg7169g07bfg95aab5c70a68" version="1">Vous brandissez l'arme utilisée lors de l'incantation du sort et effectuez une attaque de corps à corps avec elle contre une créature à 5 pieds ou moins de vous. En cas de toucher, la cible subit les effets normaux de l'attaque avec l'arme, et vous pouvez faire jaillir une flamme verte de la cible vers une autre créature que vous pouvez voir à 5 pieds d'elle. La seconde créature subit [1].</content>
-  <content contentuid="h959cb550g10b0g1785ga0e3gd4203b55f7b8" version="1">Explosion de lames</content>
-  <content contentuid="h650ea344gc449g2751g4692g5f60cf3d64d3" version="1">Vous créez un cercle momentané de lames spectrales qui tourbillonnent autour de vous. Toutes les autres créatures à 5 pieds ou moins de vous doivent réussir un jet de sauvegarde de Dextérité ou subir [1].</content>
+  <content contentuid="h3729f6f3g8054gfc05g7817g8f510f005496" version="1">Lame aux flammes vertes</content>
+  <content contentuid="h61a4b68fgff5eg7169g07bfg95aab5c70a68" version="1">Vous brandissez l'arme utilisée lors de l'incantation du sort et effectuez une attaque de corps à corps avec elle contre une créature à 1,50 mètre ou moins de vous. En cas de toucher, la cible subit les effets normaux de l'attaque avec l'arme, et vous pouvez faire jaillir une flamme verte de la cible vers une autre créature que vous pouvez voir à 1,50 mètre d'elle. La seconde créature subit [1].</content>
+  <content contentuid="h959cb550g10b0g1785ga0e3gd4203b55f7b8" version="1">Éruption de lames</content>
+  <content contentuid="h650ea344gc449g2751g4692g5f60cf3d64d3" version="1">Vous créez un cercle momentané de lames spectrales qui tourbillonnent autour de vous. Toutes les autres créatures à 1,50 mètre ou moins de vous doivent réussir un jet de sauvegarde de Dextérité ou subir [1].</content>
   <content contentuid="h8155116dgb434g017cg6396g666179cd6bbd" version="1">Don : Lanceur de rituels</content>
   <content contentuid="h81682b22g3da3g86c5g11f5gbebe41d25951" version="1">Vous avez appris trois &lt;LSTag Tooltip="RitualSpell"&gt;sorts rituels&lt;/LSTag&gt; de votre choix.</content>
   <content contentuid="hca029b39g4097g0379g6a74gd52bb5fd4a04" version="1">Don : Explorateur de donjons</content>
@@ -1541,10 +1624,10 @@ Vous pouvez voir dans le noir jusqu'à [1].</content>
   <content contentuid="h1e93417ag9497g58f3ge9aag2e54d8ba4076" version="1">Don : Résistant</content>
   <content contentuid="hf12dc8a9g3079g890agb1ffgdf7b91f3c03d" version="2">Défier la mort. Vous avez l'Avantage aux Jets de sauvegarde contre la mort.
 
-Récupération rapide. Vous regagnez le maximum de points de vie possible lorsque vous êtes soigné.</content>
+Récupération rapide. Vous regagnez le maximum de &lt;LSTag Tooltip="HitPoints"&gt;points de vie&lt;/LSTag&gt; possible lorsque vous êtes soigné.</content>
   <content contentuid="h566e69efg081cg4f88g70abg51276f90b3b7" version="1">Niveau 2 : Expert en rituels</content>
   <content contentuid="h1edea2d1ga8eeg0549g7c32g5718c99dd110" version="1">Aux niveaux 2, 4 et 7 du Magicien, vous ajoutez un sort rituel de votre choix à votre grimoire, et il est toujours préparé.</content>
-  <content contentuid="h7e928dcfg9f9cg0dd6g966egff06f62b9e21" version="2">Niveau 3 : Tour de magie puissant</content>
+  <content contentuid="h7e928dcfg9f9cg0dd6g966egff06f62b9e21" version="2">Niveau 3 : Sort mineur puissant</content>
   <content contentuid="h480dcb8bge39dg992bgfa3bg9f0cf957ce9c" version="1">Niveau 6 : Façonner les sorts</content>
   <content contentuid="h4df2acb8g6e7eg6b07ga5afg05bc5f965277" version="1">Niveau 10 : Évocation renforcée</content>
   <content contentuid="haf5be1bagceecg0615g9988g0af66eb534ad" version="1">Évocateur</content>
@@ -1579,7 +1662,7 @@ Soins. Chaque fois que vous restaurez des Points de vie à une créature, elle r
   <content contentuid="h871f4affg0f96gce2fg8f99g76c6d4b04da1" version="2">Manuel des joueurs : Dons d'origine</content>
   <content contentuid="hc54d8cd4g6034g8a1ag1af3g0f14cef04940" version="2">Manuel des joueurs : Dons généraux</content>
   <content contentuid="hd28472dcg3ccag8ba5g3424g645e17f370db" version="1">Don : Briseur</content>
-  <content contentuid="h9ac2c1d5gd0dcga37bgf4d5gb17546182f77" version="3">Repoussée. Lorsque vous touchez une créature avec une attaque qui inflige des dégâts Contondants, vous pouvez la déplacer de 5 pieds vers un espace inoccupé si la cible est au maximum d'une catégorie de taille plus grande que vous.
+  <content contentuid="h9ac2c1d5gd0dcga37bgf4d5gb17546182f77" version="3">Repoussée. Lorsque vous touchez une créature avec une attaque qui inflige des dégâts Contondants, vous pouvez la déplacer de 1,50 mètre vers un espace inoccupé si la cible est au maximum d'une catégorie de taille plus grande que vous.
 
 Critique amélioré. Lorsque vous obtenez un Coup critique infligeant des dégâts Contondants à une créature, les jets d'attaque contre cette créature ont l'Avantage jusqu'au début de votre prochain tour.</content>
   <content contentuid="h0f24fc73ge6b5g8e1fg0b3eg4216fa3191e9" version="1">Don : Perceur</content>
@@ -1587,19 +1670,19 @@ Critique amélioré. Lorsque vous obtenez un Coup critique infligeant des dégâ
 
 Critique amélioré. Lorsque vous obtenez un Coup critique infligeant des dégâts Perforants à une créature, vous pouvez lancer un dé de dégâts supplémentaire pour déterminer les dégâts Perforants supplémentaires que la cible subit.</content>
   <content contentuid="h540810fdg8dc8g2211g0121gd8e6f4397c51" version="1">Don : Trancheur</content>
-  <content contentuid="hfd222472gd8acg6b69g6068g2840b34f0315" version="4">Jarret coupé. Lorsque vous touchez une créature avec une attaque qui inflige des dégâts Tranchants, vous pouvez réduire la Vitesse de cette créature de 10 pieds jusqu'au début de votre prochain tour.
+  <content contentuid="hfd222472gd8acg6b69g6068g2840b34f0315" version="4">Jarret coupé. Lorsque vous touchez une créature avec une attaque qui inflige des dégâts Tranchants, vous pouvez réduire la Vitesse de cette créature de 3 mètres jusqu'au début de votre prochain tour.
 
 Critique amélioré. Lorsque vous obtenez un Coup critique infligeant des dégâts Tranchants à une créature, elle a le Désavantage aux jets d'attaque jusqu'au début de votre prochain tour.</content>
   <content contentuid="h02827ffcg5d6bg438bg7f75g9b6516ac3842" version="1">Briseur</content>
   <content contentuid="hdd11c1e7geb40g6616g906dgcfc584d52dda" version="1">Perceur</content>
   <content contentuid="h538ab943g74c6g0712gaaccgc23a7c3fb624" version="1">Trancheur</content>
-  <content contentuid="he62f99bbgc9f2g862dg2430gdefa25e39624" version="2">Repoussée. Une fois par tour, lorsque vous touchez une créature avec une attaque qui inflige des dégâts Contondants, vous pouvez la déplacer de 5 pieds vers un espace inoccupé si la cible est au maximum d'une catégorie de taille plus grande que vous.
+  <content contentuid="he62f99bbgc9f2g862dg2430gdefa25e39624" version="2">Repoussée. Une fois par tour, lorsque vous touchez une créature avec une attaque qui inflige des dégâts Contondants, vous pouvez la déplacer de 1,50 mètre vers un espace inoccupé si la cible est au maximum d'une catégorie de taille plus grande que vous.
 
 Critique amélioré. Lorsque vous obtenez un Coup critique infligeant des dégâts Contondants à une créature, les jets d'attaque contre cette créature ont l'Avantage jusqu'au début de votre prochain tour.</content>
   <content contentuid="hf202d0a0gaaf3ge15bgc2f1g94f60d8193aa" version="2">Perforation. Une fois par tour, lorsque vous touchez une créature avec une attaque qui inflige des dégâts Perforants, vous pouvez relancer l'un des dés de dégâts de l'attaque, et vous devez utiliser le nouveau résultat.
 
 Critique amélioré. Lorsque vous obtenez un Coup critique infligeant des dégâts Perforants à une créature, vous pouvez lancer un dé de dégâts supplémentaire pour déterminer les dégâts Perforants supplémentaires que la cible subit.</content>
-  <content contentuid="he322b215g4b74g107eg1abfg1d7e848abd23" version="2">Jarret coupé. Une fois par tour lorsque vous touchez une créature avec une attaque qui inflige des dégâts Tranchants, vous pouvez réduire la Vitesse de cette créature de 10 pieds jusqu'au début de votre prochain tour.
+  <content contentuid="he322b215g4b74g107eg1abfg1d7e848abd23" version="2">Jarret coupé. Une fois par tour lorsque vous touchez une créature avec une attaque qui inflige des dégâts Tranchants, vous pouvez réduire la Vitesse de cette créature de 3 mètres jusqu'au début de votre prochain tour.
 
 Critique amélioré. Lorsque vous obtenez un Coup critique infligeant des dégâts Tranchants à une créature, elle a le Désavantage aux jets d'attaque jusqu'au début de votre prochain tour.</content>
   <content contentuid="h2bcebb1fgce9aga6edgfb96gb1208491f0c1" version="1">Don : Combattant monté</content>
@@ -1675,7 +1758,7 @@ Si vous choisissez Terre tropicale, vous avez préparé Aspersion acide, Rayon d
   <content contentuid="h59bddf9bg3094g2868gce0dgb0fbfbb3fdd4" version="1">Furie élémentaire</content>
   <content contentuid="h22eae394ga5fbg653egff67gee9e5b542914" version="1">La puissance des éléments coule en vous. Vous gagnez l'une des options suivantes de votre choix.</content>
   <content contentuid="h2b54832cgd102gec1dg521dgc5239b16c5b9" version="1">Aide de la Terre</content>
-  <content contentuid="h7d366d57g2abcg334egec99gd574e5abbc31" version="1">En tant qu'action de Magie, vous pouvez dépenser une utilisation de votre Forme sauvage et choisir un point à 60 pieds ou moins de vous. Des fleurs vivifiantes et des épines drainant la vie apparaissent brièvement dans une Sphère de 10 pieds de rayon centrée sur ce point. Les créatures ennemies dans la Sphère subissent 2d6 dégâts Nécrotiques. Les créatures dans la zone qui ne sont pas vos ennemies récupèrent 2d6 Points de vie.
+  <content contentuid="h7d366d57g2abcg334egec99gd574e5abbc31" version="1">En tant qu'action de Magie, vous pouvez dépenser une utilisation de votre Forme sauvage et choisir un point à 18 mètres ou moins de vous. Des fleurs vivifiantes et des épines drainant la vie apparaissent brièvement dans une Sphère de 3 mètres de rayon centrée sur ce point. Les créatures ennemies dans la Sphère subissent 2d6 dégâts Nécrotiques. Les créatures dans la zone qui ne sont pas vos ennemies récupèrent 2d6 Points de vie.
 
 Les dégâts et les soins augmentent chacun de 1d6 lorsque vous atteignez le niveau 5 du Druide (3d6) et le niveau 10 (4d6).</content>
   <content contentuid="h971b2780g3870g87c7g5557ge1126bfcc79b" version="1">Niveau 10 : Gardien de la nature</content>
@@ -1683,17 +1766,17 @@ Les dégâts et les soins augmentent chacun de 1d6 lorsque vous atteignez le niv
   <content contentuid="h993714a3gef7eg3fa3g8208g34aa994bdb90" version="1">Cercle de la Mer</content>
   <content contentuid="h620c69f6g5443g20cdg6ba6g742691ee6c08" version="1">Les Druides du Cercle de la Mer puisent dans les forces tumultueuses des océans et des tempêtes. Certains se considèrent comme des incarnations de la colère de la nature, cherchant vengeance contre ceux qui la souillent. D'autres recherchent une unité mystique avec la nature en s'accordant au flux et reflux des marées, en suivant le courant des eaux et des vagues, et en écoutant les murmures insondables et les rugissements des vents.</content>
   <content contentuid="h098af219gb42agf6c9gb202g7d21b599c435" version="1">Niveau 3 : Courroux de la Mer</content>
-  <content contentuid="he83b406cg6857g3e88gd60dg2ef8a8d31d88" version="2">En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Forme sauvage pour manifester une Émanation de 5 pieds qui prend la forme d'embruns marins qui vous entourent. Elle se termine prématurément si vous la dissipez (aucune action requise), la manifestez à nouveau, ou avez la condition Neutralisé.
+  <content contentuid="he83b406cg6857g3e88gd60dg2ef8a8d31d88" version="2">En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Forme sauvage pour manifester une Émanation de 1,50 mètre qui prend la forme d'embruns marins qui vous entourent. Elle se termine prématurément si vous la dissipez (aucune action requise), la manifestez à nouveau, ou avez la condition Neutralisé.
 
-Lorsque vous manifestez l'Émanation et en tant qu'Action bonus lors de vos tours suivants, vous pouvez choisir une autre créature que vous pouvez voir dans l'Émanation. La cible doit réussir un jet de sauvegarde de Constitution contre votre DD de sorts ou subir des dégâts de Froid et, si la créature est de taille Grande ou plus petite, être repoussée jusqu'à 15 pieds de vous. Pour déterminer ces dégâts, lancez un nombre de d6 égal à votre modificateur de Sagesse.</content>
+Lorsque vous manifestez l'Émanation et en tant qu'Action bonus lors de vos tours suivants, vous pouvez choisir une autre créature que vous pouvez voir dans l'Émanation. La cible doit réussir un jet de sauvegarde de Constitution contre votre DD de sorts ou subir des dégâts de Froid et, si la créature est de taille Grande ou plus petite, être repoussée jusqu'à 4,50 mètres de vous. Pour déterminer ces dégâts, lancez un nombre de d6 égal à votre modificateur de Sagesse.</content>
   <content contentuid="hf1921250gb124g8471g9413g503117f1b821" version="1">Forme sauvage : Mer</content>
-  <content contentuid="h57810054gfe7fgd3feg857agf79b5362dc6c" version="1">En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Forme sauvage pour manifester une Émanation de 5 pieds qui prend la forme d'embruns marins qui vous entourent. Elle se termine prématurément si vous la dissipez (aucune action requise), la manifestez à nouveau, ou avez la condition Neutralisé.</content>
+  <content contentuid="h57810054gfe7fgd3feg857agf79b5362dc6c" version="1">En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Forme sauvage pour manifester une Émanation de 1,50 mètre qui prend la forme d'embruns marins qui vous entourent. Elle se termine prématurément si vous la dissipez (aucune action requise), la manifestez à nouveau, ou avez la condition Neutralisé.</content>
   <content contentuid="h2441e241g48f9g90deg04f4gc1d4278870d3" version="1">Forme sauvage : Mer</content>
-  <content contentuid="hf8470c53gc4a7gf584g96f0g33c340603191" version="1">En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Forme sauvage pour manifester une Émanation de 5 pieds qui prend la forme d'embruns marins qui vous entourent. Elle se termine prématurément si vous la dissipez (aucune action requise), la manifestez à nouveau, ou avez la condition Neutralisé.</content>
+  <content contentuid="hf8470c53gc4a7gf584g96f0g33c340603191" version="1">En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Forme sauvage pour manifester une Émanation de 1,50 mètre qui prend la forme d'embruns marins qui vous entourent. Elle se termine prématurément si vous la dissipez (aucune action requise), la manifestez à nouveau, ou avez la condition Neutralisé.</content>
   <content contentuid="h3c20f33cgc7dag94d0ge8cag9a5b89fd4b90" version="1">Courroux de la Mer</content>
-  <content contentuid="hfce3b1a5gd494ge7ddge2b2gaa37f42771ce" version="1">La cible doit réussir un jet de sauvegarde de Constitution contre votre DD de sorts ou subir des dégâts de Froid et, si la créature est de taille Grande ou plus petite, être repoussée jusqu'à 15 pieds de vous. Pour déterminer ces dégâts, lancez un nombre de d6 égal à votre modificateur de Sagesse.</content>
+  <content contentuid="hfce3b1a5gd494ge7ddge2b2gaa37f42771ce" version="1">La cible doit réussir un jet de sauvegarde de Constitution contre votre DD de sorts ou subir des dégâts de Froid et, si la créature est de taille Grande ou plus petite, être repoussée jusqu'à 4,50 mètres de vous. Pour déterminer ces dégâts, lancez un nombre de d6 égal à votre modificateur de Sagesse.</content>
   <content contentuid="hb8de1b6fge14agdb53gd966gfe3270131b62" version="1">Niveau 6 : Affinité aquatique</content>
-  <content contentuid="h8e98b937g68e2gbad3g7b1ag31a19750c163" version="1">La taille de l'Émanation créée par votre Courroux de la Mer passe à 10 pieds.</content>
+  <content contentuid="h8e98b937g68e2gbad3g7b1ag31a19750c163" version="1">La taille de l'Émanation créée par votre Courroux de la Mer passe à 3 mètres.</content>
   <content contentuid="h52d70b1eg7be8gdc25g22fcg6446989e556c" version="1">Niveau 10 : Enfant de la tempête</content>
   <content contentuid="hcd9d1097ga19dg7c70g4d29gc5f6d7f4a948" version="1">Votre Courroux de la Mer confère deux avantages supplémentaires lorsqu'il est actif, comme détaillé ci-dessous.
 
@@ -1707,7 +1790,7 @@ Résistance. Vous avez la Résistance aux dégâts de Froid, de Foudre et de Ton
   <content contentuid="h25af72e1gf482g34a9g529cg6374b4fb3326" version="1">Serment de gloire</content>
   <content contentuid="haa96615cga522gdeb1ga810g8bef49c9c9e6" version="1">Les Paladins qui prêtent le Serment de gloire croient que leurs compagnons et eux sont destinés à atteindre la gloire par des actes d'héroïsme. Ils s'entraînent avec diligence et encouragent leurs compagnons afin d'être tous prêts quand le destin les appelle.</content>
   <content contentuid="h7448ea4fg8ab9g8b26gf04dg6a7767cae2dd" version="1">Vagabond féerique</content>
-  <content contentuid="h60b4a6b6g2c59g4b4cgb657g5872fb1a68d4" version="1">Un mystère féerique vous entoure, grâce à la faveur d'un archifée ou d'un lieu dans la Féerie qui vous a transformé. Quelle que soit la façon dont vous avez acquis la magie féerique, vous êtes désormais un Vagabond féerique. Votre rire joyeux éclaire le cœur des opprimés, et votre prouesse martiale sème la terreur chez vos ennemis, car grande est la gaieté des fées et redoutable est leur fureur.</content>
+  <content contentuid="h60b4a6b6g2c59g4b4cgb657g5872fb1a68d4" version="1">Un mystère féerique vous entoure, grâce à la faveur d'un archifée ou d'un lieu dans la Féérie sauvage qui vous a transformé. Quelle que soit la façon dont vous avez acquis la magie féerique, vous êtes désormais un Vagabond féerique. Votre rire joyeux éclaire le cœur des opprimés, et votre prouesse martiale sème la terreur chez vos ennemis, car grande est la gaieté des fées et redoutable est leur fureur.</content>
   <content contentuid="h2c7c5414g15dagaf08gfc1fg11fb9d066b49" version="2">Lame d'âme</content>
   <content contentuid="h9d72f0d7g2c0egb1bbgde11g3864f11ceed2" version="2">Un Lame d'âme frappe avec l'esprit, tranchant à travers les barrières physiques et psychiques. Ces Roublards découvrent en eux un pouvoir psionique et le canalisent pour accomplir leur travail de roublard. En tant que Lame d'âme, vos capacités psioniques ont peut-être hanté votre enfance, ne révélant tout leur potentiel qu'au contact du stress de l'aventure. Ou bien vous avez peut-être recherché un ordre d'adeptes psychiques et passé des années à apprendre à manifester votre pouvoir.</content>
   <content contentuid="hba0867adg6296gbd1cg160cg13de0e01f398" version="1">Niveau 3 : Pouvoir psionique</content>
@@ -1717,11 +1800,11 @@ Toutes les fonctionnalités de cette sous-classe qui utilisent un Dé d'énergie
 
 Vous récupérez un de vos Dés d'énergie psionique dépensés lorsque vous terminez un Repos court, et vous les récupérez tous lorsque vous terminez un Repos long.
 
-Champ protecteur. Lorsque vous ou une autre créature que vous pouvez voir à 30 pieds ou moins de vous subissez des dégâts, vous pouvez utiliser votre Réaction pour dépenser un Dé d'énergie psionique, le lancer et réduire les dégâts reçus du résultat plus votre modificateur d'Intelligence (réduction minimum de 1), en créant un bouclier momentané de force télékinésique.
+Champ protecteur. Lorsque vous ou une autre créature que vous pouvez voir à 9 mètres ou moins de vous subissez des dégâts, vous pouvez utiliser votre Réaction pour dépenser un Dé d'énergie psionique, le lancer et réduire les dégâts reçus du résultat plus votre modificateur d'Intelligence (réduction minimum de 1), en créant un bouclier momentané de force télékinésique.
 
-Frappe psionique. Vous pouvez propulser vos armes avec une force psionique. Une fois à chacun de vos tours, immédiatement après avoir touché une cible à 30 pieds ou moins de vous avec une attaque et lui avoir infligé des dégâts avec une arme, vous pouvez dépenser un Dé d'énergie psionique, le lancer et infliger des dégâts de Force à la cible égaux au résultat plus votre modificateur d'Intelligence.
+Frappe psionique. Vous pouvez propulser vos armes avec une force psionique. Une fois à chacun de vos tours, immédiatement après avoir touché une cible à 9 mètres ou moins de vous avec une attaque et lui avoir infligé des dégâts avec une arme, vous pouvez dépenser un Dé d'énergie psionique, le lancer et infliger des dégâts de Force à la cible égaux au résultat plus votre modificateur d'Intelligence.
 
-Mouvement télékinésique. Vous pouvez déplacer un objet ou une créature avec votre esprit. En tant qu'action de Magie, choisissez une cible que vous pouvez voir à 30 pieds ou moins de vous ; la cible doit être un objet libre de taille Grande ou plus petite ou une créature consentante autre que vous. Vous transportez la cible jusqu'à 30 pieds vers un espace inoccupé que vous pouvez voir. Alternativement, si la cible est un objet de taille Minuscule, vous pouvez la transporter vers ou depuis votre main.</content>
+Mouvement télékinésique. Vous pouvez déplacer un objet ou une créature avec votre esprit. En tant qu'action de Magie, choisissez une cible que vous pouvez voir à 9 mètres ou moins de vous ; la cible doit être un objet libre de taille Grande ou plus petite ou une créature consentante autre que vous. Vous transportez la cible jusqu'à 9 mètres vers un espace inoccupé que vous pouvez voir. Alternativement, si la cible est un objet de taille Minuscule, vous pouvez la transporter vers ou depuis votre main.</content>
   <content contentuid="hb9f5892dg60a5g8c87g7282g224efd74a6fb" version="1">Niveau 1 : Second souffle</content>
   <content contentuid="he3bdd368gcf28g40aag8743gc422e859a060" version="1">Vous disposez d'un puits limité d'endurance physique et mentale auquel vous pouvez puiser. En tant qu'Action bonus, vous pouvez l'utiliser pour récupérer des Points de vie égaux à 1d10 plus votre niveau de Guerrier.
 
@@ -1729,19 +1812,19 @@ Vous pouvez utiliser cette fonctionnalité deux fois. Vous récupérez une utili
 
 Lorsque vous atteignez certains niveaux de Guerrier, vous gagnez des utilisations supplémentaires de cette fonctionnalité.</content>
   <content contentuid="h8bf4bd01g12ddg80fag3922gb5bd2d3c378f" version="1">Champ protecteur</content>
-  <content contentuid="h11246ce1g1053g5998g5c40ga6494d732ee0" version="1">Lorsque vous ou une autre créature que vous pouvez voir à 30 pieds ou moins de vous subissez des dégâts, vous pouvez utiliser votre Réaction pour dépenser un Dé d'énergie psionique, le lancer et réduire les dégâts reçus du résultat plus votre modificateur d'Intelligence (réduction minimum de 1), en créant un bouclier momentané de force télékinésique.</content>
+  <content contentuid="h11246ce1g1053g5998g5c40ga6494d732ee0" version="1">Lorsque vous ou une autre créature que vous pouvez voir à 9 mètres ou moins de vous subissez des dégâts, vous pouvez utiliser votre Réaction pour dépenser un Dé d'énergie psionique, le lancer et réduire les dégâts reçus du résultat plus votre modificateur d'Intelligence (réduction minimum de 1), en créant un bouclier momentané de force télékinésique.</content>
   <content contentuid="h50cf5378ga381gc18fg0f16g6bba3d2edf30" version="1">Pouvoir psionique</content>
   <content contentuid="h7e07ba43g48ccgb3bag0de0g3c6c93d8eabb" version="1">Frappe psionique</content>
-  <content contentuid="h26010d04g5728g38d0g7666g1a3a63e82e9a" version="1">Vous pouvez propulser vos armes avec une force psionique. Une fois à chacun de vos tours, immédiatement après avoir touché une cible à 30 pieds ou moins de vous avec une attaque et lui avoir infligé des dégâts avec une arme, vous pouvez dépenser un Dé d'énergie psionique, le lancer et infliger des dégâts de Force à la cible égaux au résultat plus votre modificateur d'Intelligence.</content>
+  <content contentuid="h26010d04g5728g38d0g7666g1a3a63e82e9a" version="1">Vous pouvez propulser vos armes avec une force psionique. Une fois à chacun de vos tours, immédiatement après avoir touché une cible à 9 mètres ou moins de vous avec une attaque et lui avoir infligé des dégâts avec une arme, vous pouvez dépenser un Dé d'énergie psionique, le lancer et infliger des dégâts de Force à la cible égaux au résultat plus votre modificateur d'Intelligence.</content>
   <content contentuid="h87667666gffa0g8813gb1a6gcf359a467b69" version="1">Frappe psionique en Coup critique</content>
   <content contentuid="h112e5aabgae68g5b63g8e95g3c2e5fd8ebb8" version="1">Mouvement télékinésique</content>
-  <content contentuid="h789e4f7cgbbfdgd136g7526g0cb392afcf9d" version="1">Vous pouvez déplacer un objet ou une créature avec votre esprit. En tant qu'action de Magie, choisissez une cible que vous pouvez voir à 30 pieds ou moins de vous ; la cible doit être un objet libre de taille Grande ou plus petite ou une créature consentante autre que vous. Vous transportez la cible jusqu'à 30 pieds vers un espace inoccupé que vous pouvez voir. Alternativement, si la cible est un objet de taille Minuscule, vous pouvez la transporter vers ou depuis votre main.</content>
+  <content contentuid="h789e4f7cgbbfdgd136g7526g0cb392afcf9d" version="1">Vous pouvez déplacer un objet ou une créature avec votre esprit. En tant qu'action de Magie, choisissez une cible que vous pouvez voir à 9 mètres ou moins de vous ; la cible doit être un objet libre de taille Grande ou plus petite ou une créature consentante autre que vous. Vous transportez la cible jusqu'à 9 mètres vers un espace inoccupé que vous pouvez voir. Alternativement, si la cible est un objet de taille Minuscule, vous pouvez la transporter vers ou depuis votre main.</content>
   <content contentuid="hb9f6e95bg1ecbg4d70g2b47g004a19f989d8" version="1">Niveau 7 : Bond psionique</content>
-  <content contentuid="h53a46d69g6181g8c48g7c48g569803d1df00" version="2">En tant qu'Action bonus, vous pouvez vous envoler vers une position en n'utilisant que 10 pieds de mouvement. Une fois que vous avez utilisé cette Action bonus, vous ne pouvez plus le faire jusqu'à ce que vous terminiez un Repos court ou long, à moins que vous ne dépensiez un Dé d'énergie psionique (aucune action requise) pour récupérer son utilisation.</content>
+  <content contentuid="h53a46d69g6181g8c48g7c48g569803d1df00" version="2">En tant qu'Action bonus, vous pouvez vous envoler vers une position en n'utilisant que 3 mètres de mouvement. Une fois que vous avez utilisé cette Action bonus, vous ne pouvez plus le faire jusqu'à ce que vous terminiez un Repos court ou long, à moins que vous ne dépensiez un Dé d'énergie psionique (aucune action requise) pour récupérer son utilisation.</content>
   <content contentuid="h82e5f786g25beg91b9g6a62g3f5142f4ec41" version="1">Bond psionique</content>
-  <content contentuid="ha42816f3g2b46g7a69gebb9g476dfa5e4f31" version="2">En tant qu'Action bonus, vous pouvez vous envoler vers une position en n'utilisant que 10 pieds de mouvement. Une fois que vous avez utilisé cette Action bonus, vous ne pouvez plus le faire jusqu'à ce que vous terminiez un Repos court ou long, à moins que vous ne dépensiez un Dé d'énergie psionique (aucune action requise) pour récupérer son utilisation.</content>
+  <content contentuid="ha42816f3g2b46g7a69gebb9g476dfa5e4f31" version="2">En tant qu'Action bonus, vous pouvez vous envoler vers une position en n'utilisant que 3 mètres de mouvement. Une fois que vous avez utilisé cette Action bonus, vous ne pouvez plus le faire jusqu'à ce que vous terminiez un Repos court ou long, à moins que vous ne dépensiez un Dé d'énergie psionique (aucune action requise) pour récupérer son utilisation.</content>
   <content contentuid="h890ef36dga451ge5acgb49dg6c441e309f11" version="1">Niveau 7 : Poussée télékinésique (À terre)</content>
-  <content contentuid="h9fa30afdgf4e2g7e74ga57fgdbedd4b1e363" version="1">Lorsque vous infligez des dégâts à une cible avec votre Frappe psionique, vous pouvez forcer la cible à effectuer un jet de sauvegarde de Force (DD 8 plus votre modificateur d'Intelligence et votre bonus de maîtrise). En cas d'échec, vous pouvez donner à la cible la condition À terre ou la transporter jusqu'à 10 pieds horizontalement.</content>
+  <content contentuid="h9fa30afdgf4e2g7e74ga57fgdbedd4b1e363" version="1">Lorsque vous infligez des dégâts à une cible avec votre Frappe psionique, vous pouvez forcer la cible à effectuer un jet de sauvegarde de Force (DD 8 plus votre modificateur d'Intelligence et votre bonus de maîtrise). En cas d'échec, vous pouvez donner à la cible la condition À terre ou la transporter jusqu'à 3 mètres horizontalement.</content>
   <content contentuid="heae343e1g10f2g46fcgb78cgffc541e0c708" version="1">Niveau 7 : Poussée télékinésique (Repoussé)</content>
   <content contentuid="hd22b82f8g71dfg62f2g255eg6bc04daa6824" version="1">Niveau 10 : Esprit protégé</content>
   <content contentuid="ha5b2a394g2eb1g625dg2bdfgb9595a404a80" version="1">Vous avez la Résistance aux dégâts Psychiques. De plus, vous êtes immunisé aux conditions Charmé et Effrayé.</content>
@@ -1776,28 +1859,28 @@ Efforcez-vous d'être connu par vos actes.
 Faites face aux épreuves avec courage.
 Inspirez les autres à aspirer à la gloire.</content>
   <content contentuid="h1f4761f8g70f7ge58fg4098g3ada7c0d7a24" version="1">Niveau 3 : Gloire inspirante</content>
-  <content contentuid="h94d2b863gce81ge85ag20a9gd351c1d2fbe8" version="2">Vous pouvez dépenser une utilisation de votre Conduit du serment pour distribuer des Points de vie temporaires aux créatures de votre choix à 30 pieds ou moins de vous, ce qui peut vous inclure. Le nombre total de Points de vie temporaires est égal à 2d8 plus votre niveau de Paladin, réparti entre les créatures choisies comme vous le souhaitez.</content>
+  <content contentuid="h94d2b863gce81ge85ag20a9gd351c1d2fbe8" version="2">Vous pouvez dépenser une utilisation de votre Conduit du serment pour distribuer des Points de vie temporaires aux créatures de votre choix à 9 mètres ou moins de vous, ce qui peut vous inclure. Le nombre total de Points de vie temporaires est égal à 2d8 plus votre niveau de Paladin, réparti entre les créatures choisies comme vous le souhaitez.</content>
   <content contentuid="h03040e0bgc3c2g707bg30dcgcf793eb4b7da" version="1">Niveau 3 : Athlète hors pair</content>
-  <content contentuid="h7b9c5b5dg52ddg7d07gf72dgc579b62da603" version="1">Vous avez l'Avantage aux tests de Force (Athlétisme) et de Dextérité (Acrobaties), et la distance de vos Sauts en longueur et Sauts en hauteur augmente de 10 pieds (cette distance supplémentaire coûte du mouvement comme d'habitude).</content>
+  <content contentuid="h7b9c5b5dg52ddg7d07gf72dgc579b62da603" version="1">Vous avez l'Avantage aux tests de Force (Athlétisme) et de Dextérité (Acrobaties), et la distance de vos Sauts en longueur et Sauts en hauteur augmente de 3 mètres (cette distance supplémentaire coûte du mouvement comme d'habitude).</content>
   <content contentuid="hadc15c48g3bdeg8e40g44fagefe0290db6ee" version="1">Niveau 7 : Aura d'alacrité</content>
-  <content contentuid="h4b966c82g6ac4g74b4g1befg09e4bfb45f98" version="1">Votre Vitesse augmente de 10 pieds.
+  <content contentuid="h4b966c82g6ac4g74b4g1befg09e4bfb45f98" version="1">Votre Vitesse augmente de 3 mètres.
 
-De plus, chaque fois qu'un allié entre dans votre Aura de protection pour la première fois lors d'un tour ou commence son tour là-dedans, la Vitesse de l'allié augmente de 10 pieds jusqu'à la fin de son prochain tour.</content>
+De plus, chaque fois qu'un allié entre dans votre Aura de protection pour la première fois lors d'un tour ou commence son tour là-dedans, la Vitesse de l'allié augmente de 3 mètres jusqu'à la fin de son prochain tour.</content>
   <content contentuid="h39f392e7g879agff67g5eafg1fbe11db0e2a" version="1">Niveau 3 : Sorts du Serment de gloire</content>
   <content contentuid="hc41356d2g2208g0d0fg0023g8a9c6958aaac" version="1">La magie de votre serment vous garantit d'avoir toujours certains sorts préparés. Lorsque vous atteignez les niveaux de Paladin spécifiés dans le tableau des Sorts du Serment de gloire, vous avez toujours les sorts suivants préparés : au niveau 3, Éclair sacré et Héroïsme ; au niveau 5, Amélioration des caractéristiques et Arme magique ; et au niveau 9, Hâte et Protection contre l'énergie.</content>
   <content contentuid="he69c1c77gfc97gb4e2g7877gb843a6c497b6" version="1">Gloire inspirante</content>
-  <content contentuid="h46a88a7bg99ddgbfe4gc4aeg5843b027814d" version="2">Vous pouvez dépenser une utilisation de votre Conduit du serment pour distribuer des Points de vie temporaires aux créatures de votre choix à 30 pieds ou moins de vous, ce qui peut vous inclure. Le nombre total de Points de vie temporaires est égal à 2d8 plus votre niveau de Paladin, réparti entre les créatures choisies comme vous le souhaitez.</content>
+  <content contentuid="h46a88a7bg99ddgbfe4gc4aeg5843b027814d" version="2">Vous pouvez dépenser une utilisation de votre Conduit du serment pour distribuer des Points de vie temporaires aux créatures de votre choix à 9 mètres ou moins de vous, ce qui peut vous inclure. Le nombre total de Points de vie temporaires est égal à 2d8 plus votre niveau de Paladin, réparti entre les créatures choisies comme vous le souhaitez.</content>
   <content contentuid="hb9b1e9b0g8892g5337gacb7g38aabc6e1177" version="1">Gloire inspirante</content>
   <content contentuid="h142d77edg6f50gc87fg72f5g3158719e648d" version="1">Aura d'alacrité</content>
-  <content contentuid="h7a033e2cg8e6cgf063g4a3cgbbe483e2b4cf" version="1">Votre Vitesse augmente de 10 pieds.</content>
+  <content contentuid="h7a033e2cg8e6cgf063g4a3cgbbe483e2b4cf" version="1">Votre Vitesse augmente de 3 mètres.</content>
   <content contentuid="h28c5c053g608eg5d6cg49bdg9f3b8000ddfc" version="1">Niveau 3 : Frappes terrifiantes</content>
-  <content contentuid="h9d7e1bf3g8ce5g97cdg6455g9d50ab2376ba" version="2">Vous pouvez augmenter vos frappes d'arme avec une magie marquant l'esprit, puisée dans les profondeurs sombres de la Féerie. Lorsque vous touchez une créature avec une arme, vous pouvez infliger 1d4 dégâts Psychiques supplémentaires à la cible, qui ne peut subir ces dégâts supplémentaires qu'une fois par tour. Les dégâts supplémentaires passent à 1d6 lorsque vous atteignez le niveau 11 du Rôdeur.</content>
+  <content contentuid="h9d7e1bf3g8ce5g97cdg6455g9d50ab2376ba" version="2">Vous pouvez augmenter vos frappes d'arme avec une magie marquant l'esprit, puisée dans les profondeurs sombres de la Féérie sauvage. Lorsque vous touchez une créature avec une arme, vous pouvez infliger 1d4 dégâts Psychiques supplémentaires à la cible, qui ne peut subir ces dégâts supplémentaires qu'une fois par tour. Les dégâts supplémentaires passent à 1d6 lorsque vous atteignez le niveau 11 du Rôdeur.</content>
   <content contentuid="h4b83ca6ag67bbga7f4gb3acgd0dc994c7828" version="1">Niveau 3 : Sorts du Vagabond féerique</content>
   <content contentuid="h4ae962aag1f80gf20eg9ad2g481c0cb2a1fe" version="2">Lorsque vous atteignez un niveau de Rôdeur spécifié dans le tableau des Sorts du Vagabond féerique, vous avez toujours les sorts indiqués préparés. Au niveau 3, vous avez toujours Charme-personne préparé ; au niveau 5, Pas brumeux ; et au niveau 9, Invoquer un fée.</content>
   <content contentuid="h4d499d8ag414fg53a9g921age039dc3c0999" version="1">Niveau 3 : Glamour d'un autre monde</content>
   <content contentuid="hd06b5e66g0e5agf687ge0cegb2e88e5b715d" version="1">Chaque fois que vous effectuez un test de Charisme, vous gagnez un bonus au test égal à votre modificateur de Sagesse.</content>
   <content contentuid="h96a833b9g92f8g5154g4eefg6f117854d8dc" version="1">Niveau 7 : Rebondissement ensorceleur</content>
-  <content contentuid="h7eb96189g76dfg2301gb96dg3136060e0f85" version="2">La magie de la Féerie protège votre esprit. Vous êtes immunisé aux conditions Charmé et Effrayé.</content>
+  <content contentuid="h7eb96189g76dfg2301gb96dg3136060e0f85" version="2">La magie de la Féérie sauvage protège votre esprit. Vous êtes immunisé aux conditions Charmé et Effrayé.</content>
   <content contentuid="h9dab7504gf784g5021g0203g9af9fa141199" version="1">Niveau 11 : Vagabond brumeux</content>
   <content contentuid="hf409717bg5c28g26d8gd2b4g68055dc739d0" version="1">Vous pouvez lancer Pas brumeux sans dépenser d'emplacement de sort. Vous pouvez le faire un nombre de fois égal à votre modificateur de Sagesse (minimum une fois), et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
   <content contentuid="hca8dab54g1bbegcd4bg350agf4c1e9eb7523" version="2">Pas brumeux</content>
@@ -1812,7 +1895,7 @@ Vous récupérez un de vos Dés d'énergie psionique dépensés lorsque vous ter
   <content contentuid="hbbc444d1gb077g0152ga3a4gb6e3870b0ab6" version="2">Niveau 3 : Talent psioniquement renforcé</content>
   <content contentuid="h2c90402dgbf9bg9e7eg0564g9741710af3b2" version="1">Si vous ratez un test de caractéristique utilisant une compétence ou un outil pour lequel vous avez la maîtrise, vous pouvez lancer un Dé d'énergie psionique et ajouter le résultat au test, transformant potentiellement un échec en réussite. Le dé n'est dépensé que si le jet réussit ensuite.</content>
   <content contentuid="hd37bdacag5d81g33e4gfebeg8a73e82f76c0" version="2">Niveau 9 : Téléportation psychique</content>
-  <content contentuid="hd91b7847g79e2gdae7g83f9g933470184630" version="3">En tant qu'Action bonus, vous manifestez une Lame psychique, dépensez un Dé d'énergie psionique et le lancez, puis lancez la lame vers un espace inoccupé que vous pouvez voir à 30 pieds ou moins. Vous vous téléportez ensuite vers cet espace, et la lame disparaît.</content>
+  <content contentuid="hd91b7847g79e2gdae7g83f9g933470184630" version="3">En tant qu'Action bonus, vous manifestez une Lame psychique, dépensez un Dé d'énergie psionique et le lancez, puis lancez la lame vers un espace inoccupé que vous pouvez voir à 9 mètres ou moins. Vous vous téléportez ensuite vers cet espace, et la lame disparaît.</content>
   <content contentuid="h3580697bg942bgc735g6a43g973225efaf2b" version="1">Niveau 3 : Frappes à guidage automatique</content>
   <content contentuid="h9469e0a4gb203g618fg7964ge5af1758af45" version="2">Si vous effectuez un jet d'attaque avec votre Lame psychique et ratez la cible, vous pouvez lancer un Dé d'énergie psionique et ajouter le résultat au jet d'attaque.</content>
   <content contentuid="h688284efg92e3g531egd411g61df3c36b276" version="1">Niveau 9 : Voile psychique</content>
@@ -1820,7 +1903,7 @@ Vous récupérez un de vos Dés d'énergie psionique dépensés lorsque vous ter
   <content contentuid="h601e5866g9f98g634egeeacg4867d033d389" version="1">Si vous effectuez un jet d'attaque avec votre Lame psychique et ratez la cible, vous pouvez lancer un Dé d'énergie psionique et ajouter le résultat au jet d'attaque.</content>
   <content contentuid="h71aac9ecg0f80gd235g2f2agef4ffc97d6a4" version="1">Frappes à guidage automatique</content>
   <content contentuid="he29c5d51gec42gc381gbc4bg435221bc0568" version="1">Téléportation psychique</content>
-  <content contentuid="h6075d06fg73e3g4deag566fg55d336f1350b" version="1">En tant qu'Action bonus, vous manifestez une Lame psychique, dépensez un Dé d'énergie psionique et le lancez, puis lancez la lame vers un espace inoccupé que vous pouvez voir à 30 pieds ou moins. Vous vous téléportez ensuite vers cet espace, et la lame disparaît.</content>
+  <content contentuid="h6075d06fg73e3g4deag566fg55d336f1350b" version="1">En tant qu'Action bonus, vous manifestez une Lame psychique, dépensez un Dé d'énergie psionique et le lancez, puis lancez la lame vers un espace inoccupé que vous pouvez voir à 9 mètres ou moins. Vous vous téléportez ensuite vers cet espace, et la lame disparaît.</content>
   <content contentuid="h535f8fd1g0766g1526ge835g936f753a3b27" version="1">Lames psychiques</content>
   <content contentuid="h35a0000fg8dc5g3af7ge6b5g3ad5700dd6e6" version="2">Vous pouvez manifester des lames scintillantes d'énergie psychique.
 
@@ -1847,13 +1930,13 @@ Au niveau 3 d'Ensorceleur, vous avez préparé Bras de Hadar, Apaisement des ém
   <content contentuid="h9cc59e90gba0dg93e0gfef2g7374298fdf05" version="1">Vous avez la Résistance aux dégâts Psychiques. De plus, vous êtes immunisé aux conditions Charmé et Effrayé.</content>
   <content contentuid="h4aa07c08gb93egab88g61e1g0ced3d3207e0" version="1">Lorsque vous lancez un sort de niveau 1 ou supérieur de votre fonctionnalité Sorts psioniques, vous pouvez le lancer en dépensant un emplacement de sort comme d'habitude, ou en dépensant un nombre de Points de sorcellerie égal au niveau du sort. Si vous lancez le sort en utilisant des Points de sorcellerie, il ne nécessite aucune composante Verbale ou Somatique, et il ne nécessite aucune composante Matérielle à moins qu'elle ne soit consommée par le sort ou qu'un coût y soit spécifié.</content>
   <content contentuid="hb9ab7ccag545bgfa3age395g6151554c8b9d" version="1">Niveau 3 : Sorts de l'Engrenage</content>
-  <content contentuid="hba43aa06gc80fg3f74gdf69g57af1f3cc5c1" version="1">Lorsque vous atteignez certains niveaux d'Ensorceleur spécifiés dans le tableau des Sorts de l'Engrenage, vous avez toujours les sorts indiqués préparés. Au niveau 3 d'Ensorceleur, vous avez préparé Aide, Soins, Restauration partielle et Protection contre le Mal et le Bien. Au niveau 5, vous avez également préparé Dissipation de la magie et Protection contre l'énergie. Au niveau 7, vous obtenez Liberté de mouvement. Au niveau 9, vous obtenez Grande restauration, tous toujours préparés.</content>
+  <content contentuid="hba43aa06gc80fg3f74gdf69g57af1f3cc5c1" version="1">Lorsque vous atteignez certains niveaux d'Ensorceleur spécifiés dans le tableau des Sorts de l'Engrenage, vous avez toujours les sorts indiqués préparés. Au niveau 3 d'Ensorceleur, vous avez préparé Aide, Soins, Restauration partielle et Protection contre le mal et le bien. Au niveau 5, vous avez également préparé Dissipation de la magie et Protection contre l'énergie. Au niveau 7, vous obtenez Liberté de mouvement. Au niveau 9, vous obtenez Grande restauration, tous toujours préparés.</content>
   <content contentuid="hfd40eb1dg31b8ge687g72f6g0d0e8189a3d0" version="1">Niveau 3 : Restaurer l'équilibre</content>
-  <content contentuid="he4b6fb34g750cgd80agfb13ga652ce65321c" version="1">Votre lien avec le plan de l'ordre absolu vous permet d'égaliser les moments chaotiques. Lorsqu'une créature que vous pouvez voir à 60 pieds ou moins de vous est sur le point de lancer un d20 avec Avantage ou Désavantage, vous pouvez utiliser votre Réaction pour empêcher le jet d'être affecté par l'Avantage et le Désavantage.
+  <content contentuid="he4b6fb34g750cgd80agfb13ga652ce65321c" version="1">Votre lien avec le plan de l'ordre absolu vous permet d'égaliser les moments chaotiques. Lorsqu'une créature que vous pouvez voir à 18 mètres ou moins de vous est sur le point de lancer un d20 avec Avantage ou Désavantage, vous pouvez utiliser votre Réaction pour empêcher le jet d'être affecté par l'Avantage et le Désavantage.
 
 Vous pouvez utiliser cette fonctionnalité un nombre de fois égal à votre modificateur de Charisme (minimum une fois), et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
   <content contentuid="h0760afc2g8dcegf074g4f57g884f001c7d9e" version="1">Niveau 6 : Bastion de la loi</content>
-  <content contentuid="h9363b64fg9775gd54eg1f42g92939094253b" version="3">Vous pouvez puiser dans la grande équation de l'existence pour imprégner une créature d'un bouclier scintillant d'ordre. En tant qu'action de Magie, vous pouvez dépenser 1 à 5 Points de sorcellerie pour créer un protège-sort magique autour de vous-même ou d'une autre créature que vous pouvez voir à 30 pieds ou moins. Le protège-sort est représenté par un nombre de d8 égal au nombre de Points de sorcellerie dépensés pour le créer. Lorsque la créature protégée subit des dégâts, elle peut dépenser un certain nombre de ces dés, les lancer et réduire les dégâts subis du total obtenu.
+  <content contentuid="h9363b64fg9775gd54eg1f42g92939094253b" version="3">Vous pouvez puiser dans la grande équation de l'existence pour imprégner une créature d'un bouclier scintillant d'ordre. En tant qu'action de Magie, vous pouvez dépenser 1 à 5 Points de sorcellerie pour créer un protège-sort magique autour de vous-même ou d'une autre créature que vous pouvez voir à 9 mètres ou moins. Le protège-sort est représenté par un nombre de d8 égal au nombre de Points de sorcellerie dépensés pour le créer. Lorsque la créature protégée subit des dégâts, elle peut dépenser un certain nombre de ces dés, les lancer et réduire les dégâts subis du total obtenu.
 
 Le protège-sort dure jusqu'à ce que vous terminiez un Repos long ou jusqu'à ce que vous utilisiez à nouveau cette fonctionnalité.</content>
   <content contentuid="h129f9c6ag91ebg3ef2gb8e5g098fd3be5d35" version="1">Sorcellerie de l'Engrenage</content>
@@ -1861,9 +1944,9 @@ Le protège-sort dure jusqu'à ce que vous terminiez un Repos long ou jusqu'à c
   <content contentuid="hdcacc812gc374g969dg7744ge4d90251ef2c" version="1">Restaurer l'équilibre</content>
   <content contentuid="h0ed6c9e8gda3agd358gefd4gde8c0591a01e" version="1">Restaurer l'équilibre : Annuler l'Avantage</content>
   <content contentuid="h19f611d1g3d11g7a46g194eg9cb9032b0e08" version="1">Restaurer l'équilibre : Annuler le Désavantage</content>
-  <content contentuid="hbc25fac8gb48eg59a1gb63eg766af1e2e342" version="1">Votre lien avec le plan de l'ordre absolu vous permet d'égaliser les moments chaotiques. Lorsqu'une créature que vous pouvez voir à 60 pieds ou moins de vous est sur le point de lancer un d20 avec Avantage ou Désavantage, vous pouvez utiliser votre Réaction pour empêcher le jet d'être affecté par l'Avantage et le Désavantage.</content>
+  <content contentuid="hbc25fac8gb48eg59a1gb63eg766af1e2e342" version="1">Votre lien avec le plan de l'ordre absolu vous permet d'égaliser les moments chaotiques. Lorsqu'une créature que vous pouvez voir à 18 mètres ou moins de vous est sur le point de lancer un d20 avec Avantage ou Désavantage, vous pouvez utiliser votre Réaction pour empêcher le jet d'être affecté par l'Avantage et le Désavantage.</content>
   <content contentuid="hf99f0430gcf80g65cag1938ge75ef3c48bfe" version="1">Bastion de la loi</content>
-  <content contentuid="h5b259fc9g61a3g1b94g1d3cgb22d7ecefdc2" version="3">Vous pouvez puiser dans la grande équation de l'existence pour imprégner une créature d'un bouclier scintillant d'ordre. En tant qu'action de Magie, vous pouvez dépenser 1 à 5 Points de sorcellerie pour créer un protège-sort magique autour de vous-même ou d'une autre créature que vous pouvez voir à 30 pieds ou moins. Le protège-sort est représenté par un nombre de d8 égal au nombre de Points de sorcellerie dépensés pour le créer. Lorsque la créature protégée subit des dégâts, elle peut dépenser un certain nombre de ces dés, les lancer et réduire les dégâts subis du total obtenu.
+  <content contentuid="h5b259fc9g61a3g1b94g1d3cgb22d7ecefdc2" version="3">Vous pouvez puiser dans la grande équation de l'existence pour imprégner une créature d'un bouclier scintillant d'ordre. En tant qu'action de Magie, vous pouvez dépenser 1 à 5 Points de sorcellerie pour créer un protège-sort magique autour de vous-même ou d'une autre créature que vous pouvez voir à 9 mètres ou moins. Le protège-sort est représenté par un nombre de d8 égal au nombre de Points de sorcellerie dépensés pour le créer. Lorsque la créature protégée subit des dégâts, elle peut dépenser un certain nombre de ces dés, les lancer et réduire les dégâts subis du total obtenu.
 
 Le protège-sort dure jusqu'à ce que vous terminiez un Repos long ou jusqu'à ce que vous utilisiez à nouveau cette fonctionnalité.</content>
   <content contentuid="h6b29df7eg3f06gf064ge8b2g8615908c2d76" version="1">Bastion de la loi : 1</content>
@@ -1881,9 +1964,9 @@ Le protège-sort dure jusqu'à ce que vous terminiez un Repos long ou jusqu'à c
   <content contentuid="h7a832abfgfed6g1f5fgab2ag1ba65771f70f" version="1">Niveau 3 : Flux du chaos</content>
   <content contentuid="h5d220f70g754fg8fc3g0596ge5dd3a6a27a9" version="1">Vous pouvez manipuler le chaos lui-même pour vous donner l'Avantage à un Test de D20 avant de lancer le d20. Une fois que vous l'avez fait, vous devez lancer un sort d'Ensorceleur avec un emplacement de sort ou terminer un Repos long avant de pouvoir utiliser à nouveau cette fonctionnalité.
 
-Si vous lancez un sort d'Ensorceleur avec un emplacement de sort avant de terminer un Repos long, vous lancez automatiquement sur le tableau des Surtensions de magie sauvage.</content>
-  <content contentuid="hdc8c75ffg7a02g2926g526bgd090debe8ddf" version="1">Niveau 3 : Surtension de magie sauvage</content>
-  <content contentuid="h4f44c253geed3g7c67g3a13g4d233307de70" version="1">Votre incantation peut déclencher des surtensions de magie sauvage. Une fois par tour, vous pouvez lancer 1d20 immédiatement après avoir lancé un sort d'Ensorceleur avec un emplacement de sort. Si vous obtenez un 20, lancez sur le tableau des Surtensions de magie sauvage pour créer un effet magique.</content>
+Si vous lancez un sort d'Ensorceleur avec un emplacement de sort avant de terminer un Repos long, vous lancez automatiquement sur le tableau des Pics de magie sauvage.</content>
+  <content contentuid="hdc8c75ffg7a02g2926g526bgd090debe8ddf" version="1">Niveau 3 : Pic de magie sauvage</content>
+  <content contentuid="h4f44c253geed3g7c67g3a13g4d233307de70" version="1">Votre incantation peut déclencher des pics de magie sauvage. Une fois par tour, vous pouvez lancer 1d20 immédiatement après avoir lancé un sort d'Ensorceleur avec un emplacement de sort. Si vous obtenez un 20, lancez sur le tableau des Pics de magie sauvage pour créer un effet magique.</content>
   <content contentuid="h244e3990gdb04g5925g28c5g71c83b2f29f9" version="1">Charge du Flux du chaos</content>
   <content contentuid="h552c9325gee4bg961cg2d50g7acb0983f1ce" version="1">Indique si vous pouvez utiliser votre Flux du chaos.</content>
   <content contentuid="h3cab5040g2f51gf20bg9f65ge152e797670f" version="1">Niveau 6 : Tordre la chance</content>
@@ -1902,9 +1985,9 @@ Au niveau 3, vous obtenez Apaisement des émotions, Feu féerique, Pas brumeux, 
 
 De plus, chaque fois que vous lancez ce sort, vous pouvez choisir l'un des effets supplémentaires suivants.
 
-Pas revigorant. Immédiatement après votre téléportation, vous et une créature que vous pouvez voir à 10 pieds ou moins de vous gagnez 1d10 Points de vie temporaires.
+Pas revigorant. Immédiatement après votre téléportation, vous et une créature que vous pouvez voir à 3 mètres ou moins de vous gagnez 1d10 Points de vie temporaires.
 
-Pas nargueur. Les créatures à 10 pieds ou moins de l'espace que vous avez quitté doivent réussir un jet de sauvegarde de Sagesse contre votre DD de sorts ou avoir le Désavantage aux jets d'attaque contre des créatures autres que vous jusqu'au début de votre prochain tour.</content>
+Pas nargueur. Les créatures à 3 mètres ou moins de l'espace que vous avez quitté doivent réussir un jet de sauvegarde de Sagesse contre votre DD de sorts ou avoir le Désavantage aux jets d'attaque contre des créatures autres que vous jusqu'au début de votre prochain tour.</content>
   <content contentuid="h6115b3f2g010ag8559g7318gc2394c1971ed" version="1">Niveau 6 : Évasion brumeuse</content>
   <content contentuid="h6dbe3baeg32b7g2be3gc059gc25854510170" version="3">Vous pouvez lancer Pas brumeux en tant que Réaction en réponse à des dégâts reçus.
 
@@ -1912,21 +1995,21 @@ De plus, les effets suivants font maintenant partie de vos options de Pas des f�
 
 Pas disparaissant. Vous avez la condition Invisible jusqu'au début de votre prochain tour ou jusqu'immédiatement après avoir effectué un jet d'attaque, infligé des dégâts ou lancé un sort.
 
-Pas redoutable. Les créatures à 10 pieds ou moins de l'espace que vous avez quitté ou de l'espace où vous apparaissez (votre choix) doivent réussir un jet de sauvegarde de Sagesse contre votre DD de sorts ou subir 2d10 dégâts Psychiques.</content>
+Pas redoutable. Les créatures à 3 mètres ou moins de l'espace que vous avez quitté ou de l'espace où vous apparaissez (votre choix) doivent réussir un jet de sauvegarde de Sagesse contre votre DD de sorts ou subir 2d10 dégâts Psychiques.</content>
   <content contentuid="h308c54bfg7af4ga905g67ffg8c054f26beab" version="1">Niveau 10 : Défenses ensorcelantes</content>
   <content contentuid="h9ff8c44bg3303gce13g6778gf58e24c5dda9" version="2">Votre patron vous apprend à protéger votre esprit et votre corps. Vous êtes immunisé à la condition Charmé.
 
 De plus, immédiatement après qu'une créature que vous pouvez voir vous touche avec un jet d'attaque, vous pouvez utiliser votre Réaction pour réduire de moitié les dégâts que vous subissez (arrondi à l'inférieur), et vous pouvez forcer l'attaquant à subir des dégâts Psychiques égaux aux dégâts que vous subissez.</content>
   <content contentuid="h832c95cdged4dg5872g8888g502dc91b83e0" version="1">Pas revigorant</content>
-  <content contentuid="h34d645ffgccd0g672cg5920g5e1aa15ee5a7" version="4">Immédiatement après votre téléportation, vous et une créature que vous pouvez voir à 10 pieds ou moins de vous gagnez 1d10 Points de vie temporaires.</content>
+  <content contentuid="h34d645ffgccd0g672cg5920g5e1aa15ee5a7" version="4">Immédiatement après votre téléportation, vous et une créature que vous pouvez voir à 3 mètres ou moins de vous gagnez 1d10 Points de vie temporaires.</content>
   <content contentuid="h7abb1184g0680g881dg18abgfc004e48f6e5" version="1">Pas revigorant</content>
   <content contentuid="h9b9091cdg68c3ga5edgce70g3588f2071f07" version="1">Gagnez 1d10 Points de vie temporaires.</content>
   <content contentuid="h756fd0efg7178gaf40g2209ge695b89e27d9" version="1">Pas nargueur</content>
-  <content contentuid="h444275c2g565cg45a9gdfbdg183d47facddb" version="1">Les créatures à 10 pieds ou moins de l'espace que vous avez quitté doivent réussir un jet de sauvegarde de Sagesse contre votre DD de sorts ou avoir le Désavantage aux jets d'attaque contre des créatures autres que vous jusqu'au début de votre prochain tour.</content>
+  <content contentuid="h444275c2g565cg45a9gdfbdg183d47facddb" version="1">Les créatures à 3 mètres ou moins de l'espace que vous avez quitté doivent réussir un jet de sauvegarde de Sagesse contre votre DD de sorts ou avoir le Désavantage aux jets d'attaque contre des créatures autres que vous jusqu'au début de votre prochain tour.</content>
   <content contentuid="ha4fa9aabgb628g9f25g60a6g8ef2736d6490" version="1">Pas nargueur</content>
   <content contentuid="h81e4c4fcge764ge0d3g745cgea094c73c3cc" version="1">Pas disparaissant</content>
   <content contentuid="h7bd1bb01g45ccge8e6g5722g3072b6b0bf23" version="1">Vous avez la condition Invisible jusqu'au début de votre prochain tour ou jusqu'immédiatement après avoir effectué un jet d'attaque, infligé des dégâts ou lancé un sort.</content>
-  <content contentuid="h6153da66gbfbeg1d0dgec8agfbc6490c04f5" version="1">Les créatures à 10 pieds ou moins de l'espace que vous avez quitté ou de l'espace où vous apparaissez (votre choix) doivent réussir un jet de sauvegarde de Sagesse contre votre DD de sorts ou subir 2d10 dégâts Psychiques.</content>
+  <content contentuid="h6153da66gbfbeg1d0dgec8agfbc6490c04f5" version="1">Les créatures à 3 mètres ou moins de l'espace que vous avez quitté ou de l'espace où vous apparaissez (votre choix) doivent réussir un jet de sauvegarde de Sagesse contre votre DD de sorts ou subir 2d10 dégâts Psychiques.</content>
   <content contentuid="h417a65f0geb7ag67d8g7e8eg6c0ea35a7357" version="1">Pas redoutable</content>
   <content contentuid="h30f638b6g1b28g3f1fgb8cbge2ee1097d9ae" version="1">Pas redoutable</content>
   <content contentuid="hf54c9af9g03dcg0142g4026g6139efcbb06e" version="1">Défenses ensorcelantes</content>
@@ -1941,20 +2024,20 @@ Au niveau 3 d'Occultiste, vous avez toujours préparé Aide, Soins, Éclair sacr
   <content contentuid="hf6fabff6g83a2gbd76gb861g272a6aa3b80c" version="1">Niveau 3 : Lumière de guérison</content>
   <content contentuid="hdaeea362gfb80g3de3gfc7bgaaff6ca3e93f" version="1">Vous acquérez la capacité de canaliser de l'énergie céleste pour guérir les blessures. Vous disposez d'une réserve de d6 pour alimenter cette guérison. Le nombre de dés dans la réserve est égal à 1 plus votre niveau d'Occultiste.
 
-En tant qu'Action bonus, vous pouvez vous soigner ou soigner une créature que vous pouvez voir à 60 pieds ou moins de vous, en dépensant des dés de la réserve. Le nombre maximum de dés que vous pouvez dépenser à la fois est égal à votre modificateur de Charisme (minimum d'un dé). Lancez les dés que vous dépensez et restaurez un nombre de Points de vie égal au total obtenu. Votre réserve récupère tous les dés dépensés lorsque vous terminez un Repos long.</content>
+En tant qu'Action bonus, vous pouvez vous soigner ou soigner une créature que vous pouvez voir à 18 mètres ou moins de vous, en dépensant des dés de la réserve. Le nombre maximum de dés que vous pouvez dépenser à la fois est égal à votre modificateur de Charisme (minimum d'un dé). Lancez les dés que vous dépensez et restaurez un nombre de Points de vie égal au total obtenu. Votre réserve récupère tous les dés dépensés lorsque vous terminez un Repos long.</content>
   <content contentuid="h0c3b5562gfcc3gad99gd963g1df27e943cd2" version="1">Niveau 6 : Âme rayonnante</content>
   <content contentuid="h870b18d3g13d8ge83dg1253gf5261403acb2" version="1">Votre lien avec votre patron vous permet de servir de conduit pour l'énergie rayonnante. Vous avez la Résistance aux dégâts Rayonnants. Une fois par tour, lorsqu'un sort que vous lancez inflige des dégâts Rayonnants ou de Feu, vous pouvez ajouter votre modificateur de Charisme aux dégâts de ce sort contre l'une des cibles du sort.</content>
   <content contentuid="heab6ca12g945dg3d00g4c47g4b04d1d8218e" version="1">Niveau 10 : Résilience céleste</content>
-  <content contentuid="hcdda7ab4ge734g2112g0666gf41d8d14e579" version="2">Vous et chaque allié à 30 pieds ou moins de vous gagnez des Points de vie temporaires égaux à votre niveau d'Occultiste plus votre modificateur de Charisme. Une fois que vous avez utilisé cette fonctionnalité, vous ne pouvez plus l'utiliser jusqu'à ce que vous terminiez un Repos court.</content>
+  <content contentuid="hcdda7ab4ge734g2112g0666gf41d8d14e579" version="2">Vous et chaque allié à 9 mètres ou moins de vous gagnez des Points de vie temporaires égaux à votre niveau d'Occultiste plus votre modificateur de Charisme. Une fois que vous avez utilisé cette fonctionnalité, vous ne pouvez plus l'utiliser jusqu'à ce que vous terminiez un Repos court.</content>
   <content contentuid="h57173a7egcdf0g4150gbb9eg91bada654a99" version="1">Lumière de guérison</content>
   <content contentuid="h13ee529eg2e3ag6b49ge487g5564265ef86c" version="1">Vous acquérez la capacité de canaliser de l'énergie céleste pour guérir les blessures. Vous disposez d'une réserve de d6 pour alimenter cette guérison. Le nombre de dés dans la réserve est égal à 1 plus votre niveau d'Occultiste.
 
-En tant qu'Action bonus, vous pouvez vous soigner ou soigner une créature que vous pouvez voir à 60 pieds ou moins de vous, en dépensant des dés de la réserve. Le nombre maximum de dés que vous pouvez dépenser à la fois est égal à votre modificateur de Charisme (minimum d'un dé). Lancez les dés que vous dépensez et restaurez un nombre de Points de vie égal au total obtenu. Votre réserve récupère tous les dés dépensés lorsque vous terminez un Repos long.</content>
+En tant qu'Action bonus, vous pouvez vous soigner ou soigner une créature que vous pouvez voir à 18 mètres ou moins de vous, en dépensant des dés de la réserve. Le nombre maximum de dés que vous pouvez dépenser à la fois est égal à votre modificateur de Charisme (minimum d'un dé). Lancez les dés que vous dépensez et restaurez un nombre de Points de vie égal au total obtenu. Votre réserve récupère tous les dés dépensés lorsque vous terminez un Repos long.</content>
   <content contentuid="h58ef9ee0gc980ga2beg9382g25dbf67b4b32" version="1">Lumière de guérison</content>
   <content contentuid="h482a7463gb3a7g35cfgba9fg3f522b1db925" version="1">Résilience céleste</content>
-  <content contentuid="h1b6e4734gfe4cg6127g1562gd33af4d185ba" version="1">Vous et chaque allié à 30 pieds ou moins de vous gagnez des Points de vie temporaires égaux à votre niveau d'Occultiste plus votre modificateur de Charisme. Une fois que vous avez utilisé cette fonctionnalité, vous ne pouvez plus l'utiliser jusqu'à ce que vous terminiez un Repos court.</content>
+  <content contentuid="h1b6e4734gfe4cg6127g1562gd33af4d185ba" version="1">Vous et chaque allié à 9 mètres ou moins de vous gagnez des Points de vie temporaires égaux à votre niveau d'Occultiste plus votre modificateur de Charisme. Une fois que vous avez utilisé cette fonctionnalité, vous ne pouvez plus l'utiliser jusqu'à ce que vous terminiez un Repos court.</content>
   <content contentuid="h9a77bd65gc6e8gc16bgece1g0bad2814b83d" version="1">Résilience céleste</content>
-  <content contentuid="h1a05b56aga724gdcdbge2deg4a389d5eeb0b" version="1">Vous et chaque allié à 30 pieds ou moins de vous gagnez des Points de vie temporaires égaux à votre niveau d'Occultiste plus votre modificateur de Charisme. Une fois que vous avez utilisé cette fonctionnalité, vous ne pouvez plus l'utiliser jusqu'à ce que vous terminiez un Repos court.</content>
+  <content contentuid="h1a05b56aga724gdcdbge2deg4a389d5eeb0b" version="1">Vous et chaque allié à 9 mètres ou moins de vous gagnez des Points de vie temporaires égaux à votre niveau d'Occultiste plus votre modificateur de Charisme. Une fois que vous avez utilisé cette fonctionnalité, vous ne pouvez plus l'utiliser jusqu'à ce que vous terminiez un Repos court.</content>
   <content contentuid="h2959b164gbec0g86fag029fgac4b296abbc5" version="1">Arme de souffle</content>
   <content contentuid="hbf57bf77g6e32gc55agf5aeg088b18b87af5" version="1">Vol draconique</content>
   <content contentuid="h1ad7e3a3g7b2fg4393g4b53g5a1bc9137cbd" version="1">Lorsque vous atteignez le niveau 5 du personnage, vous pouvez canaliser la magie draconique pour vous donner un vol temporaire. En tant qu'Action bonus, vous faites surgir des ailes spectrales dans votre dos qui durent 10 minutes ou jusqu'à ce que vous les rétractiez (aucune action requise) ou que vous ayez la condition Neutralisé. Pendant ce temps, vous avez une Vitesse de vol égale à votre Vitesse. Vos ailes semblent être faites de la même énergie que votre Arme de souffle. Une fois que vous avez utilisé ce trait, vous ne pouvez plus le faire jusqu'à ce que vous terminiez un Repos long.</content>
@@ -1977,14 +2060,14 @@ Vous pouvez utiliser ce trait un nombre de fois égal à votre bonus de maîtris
   <content contentuid="ha554c47egeb81g75ccgd39cg1311b5e29042" version="1">Vous gagnez un nombre de Points de vie temporaires égal à votre bonus de maîtrise.</content>
   <content contentuid="hf861876fg4ca8gf9c0g6492g1bb8a0a92ebb" version="1">Montée d'adrénaline</content>
   <content contentuid="he98b170fg0b2bg4502g8a0fg3f8f765d62aa" version="1">Vous pouvez prendre l'action Foncer en tant qu'Action bonus. Ce faisant, vous gagnez un nombre de Points de vie temporaires égal à votre bonus de maîtrise.</content>
-  <content contentuid="hebe3b6e0g1e21g24c8g8ce2gd9aaa9e5dde4" version="1">Tour de magie des hauts elfes</content>
-  <content contentuid="h9adf7805gb424g309ag6e71g53eca41cd8d5" version="1">Vous pouvez changer votre tour de magie en en sélectionnant un autre dans la liste de sorts du Magicien ci-dessous. Ce tour de magie n'utilise pas d'&lt;LSTag Tooltip="SpellSlot"&gt;emplacement de sort&lt;/LSTag&gt; et peut être lancé à volonté.</content>
+  <content contentuid="hebe3b6e0g1e21g24c8g8ce2gd9aaa9e5dde4" version="1">Sort mineur des hauts elfes</content>
+  <content contentuid="h9adf7805gb424g309ag6e71g53eca41cd8d5" version="1">Vous pouvez changer votre sort mineur en en sélectionnant un autre dans la liste de sorts du Magicien ci-dessous. Ce sort mineur n'utilise pas d'&lt;LSTag Tooltip="SpellSlot"&gt;emplacement de sort&lt;/LSTag&gt; et peut être lancé à volonté.</content>
   <content contentuid="h9b697d45g3dd3gf371g2860g7b65899c8fc7" version="1">Résistance</content>
-  <content contentuid="h10997edbg285bg8db6g0718gb2e6c09ff676" version="1">Niveau 3 : Bénédiction de l'Être sombre</content>
-  <content contentuid="h03df3855gb482gdaf5g11f0gbf6d6d9fbb62" version="1">Lorsque vous réduisez un ennemi à 0 Points de vie, vous gagnez des Points de vie temporaires égaux à votre modificateur de Charisme plus votre niveau d'Occultiste (minimum de 1 Point de vie temporaire). Vous bénéficiez également de cet avantage si quelqu'un d'autre réduit un ennemi à 10 pieds ou moins de vous à 0 Points de vie.</content>
-  <content contentuid="hde74c01eg8bb3gbf23g8416g7da16527c0d5" version="1">Bénédiction de l'Être sombre</content>
-  <content contentuid="he0b3dcccga1b5gd89bgf47ag768a98964bc3" version="1">Si une créature à 10 pieds ou moins de vous est réduite à 0 Points de vie par quelqu'un d'autre que vous, vous gagnez des Points de vie temporaires égaux à votre modificateur de Charisme plus votre niveau d'Occultiste (minimum de 1 Point de vie temporaire).</content>
-  <content contentuid="hbbedb4f1g60d4g6ed0gb97bg90c73d16c026" version="1">Niveau 6 : Chance de l'Être sombre</content>
+  <content contentuid="h10997edbg285bg8db6g0718gb2e6c09ff676" version="1">Niveau 3 : Bénédiction des ténèbres</content>
+  <content contentuid="h03df3855gb482gdaf5g11f0gbf6d6d9fbb62" version="1">Lorsque vous réduisez un ennemi à 0 Points de vie, vous gagnez des Points de vie temporaires égaux à votre modificateur de Charisme plus votre niveau d'Occultiste (minimum de 1 Point de vie temporaire). Vous bénéficiez également de cet avantage si quelqu'un d'autre réduit un ennemi à 3 mètres ou moins de vous à 0 Points de vie.</content>
+  <content contentuid="hde74c01eg8bb3gbf23g8416g7da16527c0d5" version="1">Bénédiction des ténèbres</content>
+  <content contentuid="he0b3dcccga1b5gd89bgf47ag768a98964bc3" version="1">Si une créature à 3 mètres ou moins de vous est réduite à 0 Points de vie par quelqu'un d'autre que vous, vous gagnez des Points de vie temporaires égaux à votre modificateur de Charisme plus votre niveau d'Occultiste (minimum de 1 Point de vie temporaire).</content>
+  <content contentuid="hbbedb4f1g60d4g6ed0gb97bg90c73d16c026" version="1">Niveau 6 : Chance du ténébreux</content>
   <content contentuid="h975e39acg9a17g2ad0g477cgf30fdb0bf07d" version="1">Niveau 10 : Résilience infernale</content>
   <content contentuid="hbfafa7a4g3ea7g96f1gcfebg2da208843ab2" version="1">Niveau 3 : Rappel mortel</content>
   <content contentuid="h2af9e353ga54bg35f7gcc87g05adfcd9b61a" version="1">Niveau 6 : Protection entropique</content>
@@ -2031,7 +2114,7 @@ Une fois que vous avez utilisé cette fonctionnalité, vous ne pouvez plus l'uti
   <content contentuid="hc1919180g48a0ga814g77dega72819b9d91a" version="1">Inspiration héroïque : Relancer avec Avantage (Jet de sauvegarde)</content>
   <content contentuid="h665b0831g0a27gcf47g1dafg16ce9df4ed5c" version="1">Gagnez l'&lt;LSTag Tooltip="Advantage"&gt;Avantage&lt;/LSTag&gt; à votre &lt;LSTag Tooltip="SavingThrow"&gt;Jet de sauvegarde&lt;/LSTag&gt;.</content>
   <content contentuid="h3f7b8985g6d22gafeag4f95gff41b038514a" version="1">Interception</content>
-  <content contentuid="h2f17ec6fgaccfg9489ga33dg5178d82df62d" version="1">Lorsqu'une créature que vous pouvez voir touche une autre créature à 5 pieds ou moins de vous avec un jet d'attaque, vous pouvez utiliser votre Réaction pour réduire les dégâts infligés à la cible de 1d10 plus votre bonus de maîtrise. Vous devez tenir un Bouclier ou une arme courante ou de guerre pour utiliser cette Réaction.</content>
+  <content contentuid="h2f17ec6fgaccfg9489ga33dg5178d82df62d" version="1">Lorsqu'une créature que vous pouvez voir touche une autre créature à 1,50 mètre ou moins de vous avec un jet d'attaque, vous pouvez utiliser votre Réaction pour réduire les dégâts infligés à la cible de 1d10 plus votre bonus de maîtrise. Vous devez tenir un Bouclier ou une arme courante ou de guerre pour utiliser cette Réaction.</content>
   <content contentuid="haa6b6306gc9beg2335g7d38gc8a89fd7d942" version="1">Lorsque vous soignez une autre créature, elle bénéficie de l'effet suivant : chaque fois qu'une créature effectue un jet d'attaque contre elle avant la fin du sort, l'attaquant soustrait 1d4 du jet.</content>
   <content contentuid="h07ec80cfg5173g412ag13f9g0b0939797d6c" version="1">Résilience draconique : Points de vie</content>
   <content contentuid="hd645cdfeg2751g6421g0bb5gbb5188468ed1" version="1">Votre maximum de &lt;LSTag Tooltip="HitPoints"&gt;points de vie&lt;/LSTag&gt; augmente de 1 pour chaque niveau d'Ensorceleur.</content>
@@ -2040,14 +2123,14 @@ Une fois que vous avez utilisé cette fonctionnalité, vous ne pouvez plus l'uti
   <content contentuid="h425e3ae9ge949g55bbg3aecg26401432f816" version="1">Lorsque vous inspirez un allié en utilisant l'&lt;LSTag Type="Spell" Tooltip="Target_BardicInspiration"&gt;Inspiration bardique&lt;/LSTag&gt;, vous gagnez [1], égal à votre niveau de Barde.</content>
   <content contentuid="h4b3bbd82gcfdegf0b2g8843g1b27f8c2a5b8" version="1">Lorsque vous inspirez un allié en utilisant l'&lt;LSTag Type="Spell" Tooltip="Target_BardicInspiration"&gt;Inspiration bardique&lt;/LSTag&gt;, il récupère également [1], égal au résultat de votre dé d'Inspiration bardique.</content>
   <content contentuid="h67022386g828fg30bag1c0cg215dae9c4f39" version="3">Les créatures mortes-vivantes qui touchent le porteur subissent [1]. Les Bêtes qui touchent le porteur deviennent &lt;LSTag Type="Status" Tooltip="CHARMED"&gt;Charmées&lt;/LSTag&gt;.</content>
-  <content contentuid="hca956f6fg7446gdf7fg60bag36e7853ca0c9" version="1">Le sort se termine si vous tombez à 0 Points de vie. Il se termine également si le sort est relancé sur l'une ou l'autre des créatures connectées. Le sort reste en vigueur uniquement si vous et la cible êtes à 60 pieds ou moins l'un de l'autre.</content>
-  <content contentuid="hd0f268c5ga792g388ag89beg27993a801b4e" version="1">Le sort se termine si vous tombez à 0 Points de vie. Il se termine également si le sort est relancé sur l'une ou l'autre des créatures connectées. Le sort reste en vigueur uniquement si vous et la cible êtes à 60 pieds ou moins l'un de l'autre.</content>
-  <content contentuid="hddf1d80agc605gd10ageadfg364f889fcd0e" version="1">Le sort se termine si vous tombez à 0 Points de vie. Il se termine également si le sort est relancé sur l'une ou l'autre des créatures connectées. Le sort reste en vigueur uniquement si vous et la cible êtes à 60 pieds ou moins l'un de l'autre.</content>
-  <content contentuid="hfb95ce72g8252ge83fg5316gf6e8f6c45584" version="1">Le sort se termine si vous tombez à 0 Points de vie. Il se termine également si le sort est relancé sur l'une ou l'autre des créatures connectées. Le sort reste en vigueur uniquement si vous et la cible êtes à 60 pieds ou moins l'un de l'autre.</content>
-  <content contentuid="hacd0f311gff68ge0cegd678g80ea9a8ee794" version="1">Le sort se termine si vous tombez à 0 Points de vie. Il se termine également si le sort est relancé sur l'une ou l'autre des créatures connectées. Le sort reste en vigueur uniquement si vous et la cible êtes à 60 pieds ou moins l'un de l'autre.</content>
-  <content contentuid="h1cf67618gcdc1g9bf0g352egd9e5052a34ad" version="1">Le sort se termine si vous tombez à 0 Points de vie. Il se termine également si le sort est relancé sur l'une ou l'autre des créatures connectées. Le sort reste en vigueur uniquement si vous et la cible êtes à 60 pieds ou moins l'un de l'autre.</content>
-  <content contentuid="hd3e9c567g2905g672bg0224gf1c8ec229255" version="1">Le sort se termine si vous tombez à 0 Points de vie. Il se termine également si le sort est relancé sur l'une ou l'autre des créatures connectées. Le sort reste en vigueur uniquement si vous et la cible êtes à 60 pieds ou moins l'un de l'autre.</content>
-  <content contentuid="h917f9908g4fcbge66dgb997gdac87ffc4aff" version="1">Le sort se termine si vous tombez à 0 Points de vie. Il se termine également si le sort est relancé sur l'une ou l'autre des créatures connectées. Le sort reste en vigueur uniquement si vous et la cible êtes à 60 pieds ou moins l'un de l'autre.</content>
+  <content contentuid="hca956f6fg7446gdf7fg60bag36e7853ca0c9" version="1">Le sort se termine si vous tombez à 0 Points de vie. Il se termine également si le sort est relancé sur l'une ou l'autre des créatures connectées. Le sort reste en vigueur uniquement si vous et la cible êtes à 18 mètres ou moins l'un de l'autre.</content>
+  <content contentuid="hd0f268c5ga792g388ag89beg27993a801b4e" version="1">Le sort se termine si vous tombez à 0 Points de vie. Il se termine également si le sort est relancé sur l'une ou l'autre des créatures connectées. Le sort reste en vigueur uniquement si vous et la cible êtes à 18 mètres ou moins l'un de l'autre.</content>
+  <content contentuid="hddf1d80agc605gd10ageadfg364f889fcd0e" version="1">Le sort se termine si vous tombez à 0 Points de vie. Il se termine également si le sort est relancé sur l'une ou l'autre des créatures connectées. Le sort reste en vigueur uniquement si vous et la cible êtes à 18 mètres ou moins l'un de l'autre.</content>
+  <content contentuid="hfb95ce72g8252ge83fg5316gf6e8f6c45584" version="1">Le sort se termine si vous tombez à 0 Points de vie. Il se termine également si le sort est relancé sur l'une ou l'autre des créatures connectées. Le sort reste en vigueur uniquement si vous et la cible êtes à 18 mètres ou moins l'un de l'autre.</content>
+  <content contentuid="hacd0f311gff68ge0cegd678g80ea9a8ee794" version="1">Le sort se termine si vous tombez à 0 Points de vie. Il se termine également si le sort est relancé sur l'une ou l'autre des créatures connectées. Le sort reste en vigueur uniquement si vous et la cible êtes à 18 mètres ou moins l'un de l'autre.</content>
+  <content contentuid="h1cf67618gcdc1g9bf0g352egd9e5052a34ad" version="1">Le sort se termine si vous tombez à 0 Points de vie. Il se termine également si le sort est relancé sur l'une ou l'autre des créatures connectées. Le sort reste en vigueur uniquement si vous et la cible êtes à 18 mètres ou moins l'un de l'autre.</content>
+  <content contentuid="hd3e9c567g2905g672bg0224gf1c8ec229255" version="1">Le sort se termine si vous tombez à 0 Points de vie. Il se termine également si le sort est relancé sur l'une ou l'autre des créatures connectées. Le sort reste en vigueur uniquement si vous et la cible êtes à 18 mètres ou moins l'un de l'autre.</content>
+  <content contentuid="h917f9908g4fcbge66dgb997gdac87ffc4aff" version="1">Le sort se termine si vous tombez à 0 Points de vie. Il se termine également si le sort est relancé sur l'une ou l'autre des créatures connectées. Le sort reste en vigueur uniquement si vous et la cible êtes à 18 mètres ou moins l'un de l'autre.</content>
   <content contentuid="h90381d36g6a66g678dgc622g940db553e2a2" version="1">Don : Touché par les fées</content>
   <content contentuid="hfaef3824g8845gb735gf4dfgd86da7822941" version="1">Choisissez un sort de niveau 1 de l'école de Divination ou d'Enchantement. Vous avez toujours ce sort et Pas brumeux préparés. Vous gagnez également un emplacement de sort de niveau 1 et un emplacement de sort de niveau 2.</content>
   <content contentuid="h373ea885g4542g96b0g1626g9afe46582637" version="1">Don : Touché par les ombres</content>
@@ -2057,13 +2140,13 @@ Une fois que vous avez utilisé cette fonctionnalité, vous ne pouvez plus l'uti
   <content contentuid="h45c39024gdfe0g1fbeg74d2g67115110174b" version="1">Touché par les ombres</content>
   <content contentuid="hbd7f0193ge427g3d75gc0adgfdba8212fb8b" version="1">Choisissez un sort de niveau 1 de l'école d'Illusion ou de Nécromancie. Vous avez toujours ce sort et Invisibilité préparés. Vous gagnez également un emplacement de sort de niveau 1 et un emplacement de sort de niveau 2.</content>
   <content contentuid="h217127dag7542g9cacg618cg5aa51ecced4b" version="1">Don : Meneur inspirant</content>
-  <content contentuid="h008b1355g9855gf610g8c06gec5ceab5ab6f" version="1">Lorsque vous terminez un Repos court ou long, vous pouvez donner une performance inspirante : un discours, une chanson ou une danse. Vous pouvez utiliser cette fonctionnalité une fois par Repos court. Ce faisant, chaque allié à 30 pieds ou moins de vous gagne des Points de vie temporaires égaux à votre niveau de personnage plus votre bonus de maîtrise.</content>
+  <content contentuid="h008b1355g9855gf610g8c06gec5ceab5ab6f" version="1">Lorsque vous terminez un Repos court ou long, vous pouvez donner une performance inspirante : un discours, une chanson ou une danse. Vous pouvez utiliser cette fonctionnalité une fois par Repos court. Ce faisant, chaque allié à 9 mètres ou moins de vous gagne des Points de vie temporaires égaux à votre niveau de personnage plus votre bonus de maîtrise.</content>
   <content contentuid="h38de6e70g3483gb2a8gf232gce6933397614" version="1">Meneur inspirant</content>
-  <content contentuid="ha3aeca2ag84a7g9aa2gc23cg0d41a7036cc2" version="1">Lorsque vous terminez un Repos court ou long, vous pouvez donner une performance inspirante : un discours, une chanson ou une danse. Vous pouvez utiliser cette fonctionnalité une fois par Repos court. Ce faisant, chaque allié à 30 pieds ou moins de vous gagne des Points de vie temporaires égaux à votre niveau de personnage plus votre bonus de maîtrise.</content>
+  <content contentuid="ha3aeca2ag84a7g9aa2gc23cg0d41a7036cc2" version="1">Lorsque vous terminez un Repos court ou long, vous pouvez donner une performance inspirante : un discours, une chanson ou une danse. Vous pouvez utiliser cette fonctionnalité une fois par Repos court. Ce faisant, chaque allié à 9 mètres ou moins de vous gagne des Points de vie temporaires égaux à votre niveau de personnage plus votre bonus de maîtrise.</content>
   <content contentuid="h67402ac7g0551gf435g6451g8cdb39545b19" version="1">Meneur inspirant</content>
   <content contentuid="hd28c4d74gd3aag5aa9g12b2g628e33edb9c9" version="1">Gagnez des Points de vie temporaires égaux au niveau du lanceur de sorts plus son bonus de maîtrise.</content>
   <content contentuid="hea65502fg6391g1f02gf466g3d9d8f544c0b" version="1">Meneur inspirant</content>
-  <content contentuid="hfe85ad95g8cb3g8eecg7ca9g7f8ee3255f42" version="1">Lorsque vous terminez un Repos court ou long, vous pouvez donner une performance inspirante : un discours, une chanson ou une danse. Vous pouvez utiliser cette fonctionnalité une fois par Repos court. Ce faisant, chaque allié à 30 pieds ou moins de vous gagne des Points de vie temporaires égaux à votre niveau de personnage plus votre bonus de maîtrise.</content>
+  <content contentuid="hfe85ad95g8cb3g8eecg7ca9g7f8ee3255f42" version="1">Lorsque vous terminez un Repos court ou long, vous pouvez donner une performance inspirante : un discours, une chanson ou une danse. Vous pouvez utiliser cette fonctionnalité une fois par Repos court. Ce faisant, chaque allié à 9 mètres ou moins de vous gagne des Points de vie temporaires égaux à votre niveau de personnage plus votre bonus de maîtrise.</content>
   <content contentuid="h722f5cc4g1b03ga262gffdfg044c2f2f2f85" version="1">Don : Expert en compétences</content>
   <content contentuid="h07dde1d7g4173g2970g8a5fgd318f17b9b5f" version="1">Maîtrise de compétence. Vous obtenez la maîtrise d'une compétence de votre choix.
 
@@ -2073,11 +2156,11 @@ Expertise. Choisissez une compétence pour laquelle vous avez la maîtrise mais 
 
 Expertise. Choisissez une compétence pour laquelle vous avez la maîtrise mais pas l'Expertise. Vous obtenez l'Expertise dans cette compétence.</content>
   <content contentuid="h0c144373g63c1g842bg99b7g472028280932" version="1">Don : Discret</content>
-  <content contentuid="h355c781dg7ea0g31c3g7904g5e09dcd7d24d" version="1">Vision aveugle. Vous avez une Vision aveugle à une portée de 10 pieds.
+  <content contentuid="h355c781dg7ea0g31c3g7904g5e09dcd7d24d" version="1">Vision aveugle. Vous avez une Vision aveugle à une portée de 3 mètres.
 
 Brouillard de guerre. Le DD pour devenir Invisible lorsque vous prenez l'action Se cacher est 15 au lieu de 20.</content>
   <content contentuid="h3590e174g151cg1c92gb9f4gb875191a6261" version="3">Discret</content>
-  <content contentuid="h0df1df8cg4144g5ee4g0641gab98d991d8dc" version="1">Vision aveugle. Vous avez une Vision aveugle à une portée de 10 pieds.
+  <content contentuid="h0df1df8cg4144g5ee4g0641gab98d991d8dc" version="1">Vision aveugle. Vous avez une Vision aveugle à une portée de 3 mètres.
 
 Brouillard de guerre. Le DD pour devenir Invisible lorsque vous prenez l'action Se cacher est 15 au lieu de 20.</content>
   <content contentuid="h7c85fa7fgebf4g2fbcg397bg07dedebf1d32" version="2">Lame de feu</content>
@@ -2091,21 +2174,21 @@ Brouillard de guerre. Le DD pour devenir Invisible lorsque vous prenez l'action 
   <content contentuid="h49c4cec7gb617g6a1eg491fgb75829e376fa" version="1">Don : Crainte draconique</content>
   <content contentuid="h1e4b1002g6774g3698g6495gb47ef39af956" version="2">Vous gagnez une utilisation de votre Arme de souffle.
 
-Vous pouvez dépenser une utilisation de votre Arme de souffle pour rugir, forçant chaque créature de votre choix à 30 pieds ou moins de vous à effectuer un jet de sauvegarde de Sagesse. En cas d'échec, une cible devient Effrayée par vous pendant 1 minute.</content>
+Vous pouvez dépenser une utilisation de votre Arme de souffle pour rugir, forçant chaque créature de votre choix à 9 mètres ou moins de vous à effectuer un jet de sauvegarde de Sagesse. En cas d'échec, une cible devient Effrayée par vous pendant 1 minute.</content>
   <content contentuid="h430183d9g2467g740eg12f4g394e373bda31" version="1">Crainte draconique</content>
-  <content contentuid="h1296e788gbe31g8450g4a0cg6c2851fe0b5f" version="1">Vous pouvez dépenser une utilisation de votre Arme de souffle pour rugir, forçant chaque créature de votre choix à 30 pieds ou moins de vous à effectuer un jet de sauvegarde de Sagesse. En cas d'échec, une cible devient Effrayée par vous pendant 1 minute.</content>
+  <content contentuid="h1296e788gbe31g8450g4a0cg6c2851fe0b5f" version="1">Vous pouvez dépenser une utilisation de votre Arme de souffle pour rugir, forçant chaque créature de votre choix à 9 mètres ou moins de vous à effectuer un jet de sauvegarde de Sagesse. En cas d'échec, une cible devient Effrayée par vous pendant 1 minute.</content>
   <content contentuid="hf77239c8gc341gd005gafa4g973247f6b867" version="1">Crainte draconique</content>
-  <content contentuid="h1db10ba1g91aagc5a2g2acbg5853ba104450" version="5">Prérequis : Né-du-dragon
+  <content contentuid="h1db10ba1g91aagc5a2g2acbg5853ba104450" version="5">Prérequis : Drakéide
 
 Lorsque vous êtes en colère, vous pouvez irradier une menace.
 
 Vous gagnez une utilisation de votre Arme de souffle.
 
-Vous pouvez dépenser une utilisation de votre Arme de souffle pour rugir, forçant chaque créature de votre choix à 30 pieds ou moins de vous à effectuer un jet de sauvegarde de Sagesse. En cas d'échec, une cible devient Effrayée par vous pendant 1 minute.</content>
+Vous pouvez dépenser une utilisation de votre Arme de souffle pour rugir, forçant chaque créature de votre choix à 9 mètres ou moins de vous à effectuer un jet de sauvegarde de Sagesse. En cas d'échec, une cible devient Effrayée par vous pendant 1 minute.</content>
   <content contentuid="h5029006cg1d84g898agfbf2g6cbc772fdf9b" version="1">Guide de Xanathar pour tout</content>
   <content contentuid="ha022bdf2g8459g8f09g9f3eg1fb7dd37302a" version="1">Guide de Xanathar pour tout</content>
   <content contentuid="h8f0ab00ag0746gf074g340age19b8809a448" version="1">Écailles de dragon</content>
-  <content contentuid="h9034c86agb8d7g13ffge863g1561ec6ea096" version="3">Prérequis : Né-du-dragon
+  <content contentuid="h9034c86agb8d7g13ffge863g1561ec6ea096" version="3">Prérequis : Drakéide
 
 Vous manifestez des écailles et des griffes rappelant vos ancêtres draconiques.
 
@@ -2142,7 +2225,7 @@ Chaque fois que vous avez l'Avantage à un jet d'attaque utilisant la Dextérit�
   <content contentuid="hb58ca71cg198agc573gb1c7g7c178be23f23" version="1">Disparaître</content>
   <content contentuid="h05d7703fg52a0gdeefgd5b6g6d58a2ca1db4" version="3">Prérequis : Gnome
 
-Votre peuple est intelligent, avec un talent pour la magie des illusions. Vous avez appris un tour de magie pour disparaître lorsque vous subissez des dommages.
+Votre peuple est intelligent, avec un talent pour la magie des illusions. Vous avez appris un sort mineur pour disparaître lorsque vous subissez des dommages.
 
 Immédiatement après avoir subi des dégâts, vous pouvez utiliser une Réaction pour devenir magiquement Invisible jusqu'à la fin de votre prochain tour ou jusqu'à ce que vous attaquiez, infligiez des dégâts ou forciez quelqu'un à effectuer un jet de sauvegarde. Une fois que vous avez utilisé cette capacité, vous ne pouvez plus le faire jusqu'à ce que vous terminiez un Repos court ou long.</content>
   <content contentuid="h9f87a9d2g9d12g4c2cg64e6g15737cbc6441" version="1">Don : Flammes de Phlégéthos</content>
@@ -2153,7 +2236,7 @@ Chaque fois que vous lancez un sort qui inflige des dégâts de feu, vous pouvez
   <content contentuid="hb537b09ag83a8g4f18gf705gc5ec2b658965" version="1">Flammes de Phlégéthos</content>
   <content contentuid="h5421b0a0g7e88g3249g1c1fg0bb7fa658d3a" version="1">Chaque fois que vous lancez un sort qui inflige des dégâts de feu, vous pouvez faire en sorte que des flammes vous enveloppent jusqu'à la fin de votre prochain tour. Pendant que ces flammes sont présentes, toute créature qui vous frappe avec une attaque de mêlée subit 1d4 dégâts de feu.</content>
   <content contentuid="h3502d470g3a45gf7d7g2d8dgb6979a6b5440" version="1">Flammes de Phlégéthos</content>
-  <content contentuid="hc93c8d09ge62bg58d1g07dcgb03858e06604" version="2">Prérequis : Tiefelin
+  <content contentuid="hc93c8d09ge62bg58d1g07dcgb03858e06604" version="2">Prérequis : Tieffelin
 
 Vous apprenez à invoquer le feu des enfers pour servir vos commandements.
 
@@ -2164,7 +2247,7 @@ Chaque fois que vous lancez un sort qui inflige des dégâts de feu, vous pouvez
   <content contentuid="h8a863439g286bg8971g8df1g7a3cb3edc5c6" version="1">Vous avez la Résistance aux dégâts de froid et aux dégâts de poison.
 Vous avez l'Avantage aux jets de sauvegarde contre le Poison.</content>
   <content contentuid="h9870add4g87a1g306fg4d11g7626059e8997" version="1">Constitution infernale</content>
-  <content contentuid="h303c0002gfd86g7697g4741ge4ae9b93c916" version="2">Prérequis : Tiefelin
+  <content contentuid="h303c0002gfd86g7697g4741ge4ae9b93c916" version="2">Prérequis : Tieffelin
 
 Le sang infernal coule fortement en vous, libérant une résilience semblable à celle possédée par certains démons.
 
@@ -2181,11 +2264,11 @@ Lorsque vous réussissez un &lt;LSTag Tooltip="CriticalHit"&gt;Coup critique&lt;
 
 Vous êtes inhabituellement agile pour votre race.
 
-Augmentez votre vitesse de marche de 5 pieds.
+Augmentez votre vitesse de marche de 1,50 mètre.
 Vous obtenez la maîtrise de la compétence Acrobaties ou Athlétisme (au choix).
 Vous avez l'Avantage à tout test de Force (Athlétisme) ou de Dextérité (Acrobaties) que vous effectuez pour vous échapper d'une entrave.</content>
   <content contentuid="h1dbe3f90g3d47gc1cagd861g317e83891368" version="1">Don : Agilité trapue</content>
-  <content contentuid="h40770da0g7507g2a0eg4c0dgbab4e296bc1d" version="1">Augmentez votre vitesse de marche de 5 pieds.
+  <content contentuid="h40770da0g7507g2a0eg4c0dgbab4e296bc1d" version="1">Augmentez votre vitesse de marche de 1,50 mètre.
 Vous obtenez la maîtrise de la compétence Acrobaties ou Athlétisme (au choix).
 Vous avez l'Avantage à tout test de Force (Athlétisme) ou de Dextérité (Acrobaties) que vous effectuez pour vous échapper d'une entrave.</content>
   <content contentuid="h35050c0eg78deg45e0g4f6fg8c9ef353a3a9" version="1">Apprenti occulte</content>
@@ -2198,34 +2281,34 @@ Vous gagnez 2 points de sorcellerie à dépenser en Métamagie (ces points s'ajo
   <content contentuid="hc21b0d36g2755g50e6ge494g02f450138ec2" version="1">Chaudron de Tasha</content>
   <content contentuid="hce732cf1g4e06ge110g8d34g08c428a3b974" version="1">Chaudron de Tasha</content>
   <content contentuid="h0cb1e09cg436bgc901g0c7cg06f2eb6a1066" version="1">Terreur du dragon</content>
-  <content contentuid="h7859cbddgc1d2g2fb6g37e8ge9fff27abfce" version="1">Vous pouvez effectuer une action Magique pour instiller la terreur dans une créature que vous pouvez voir à 30 pieds ou moins de vous. La cible doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Effrayé jusqu'à la fin de votre prochain tour.</content>
+  <content contentuid="h7859cbddgc1d2g2fb6g37e8ge9fff27abfce" version="1">Vous pouvez effectuer une action Magique pour instiller la terreur dans une créature que vous pouvez voir à 9 mètres ou moins de vous. La cible doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Effrayé jusqu'à la fin de votre prochain tour.</content>
   <content contentuid="h0d2663e7ga6eag1b82g8e4bg4351babc6226" version="2">Don d'origine : Initié au Culte du Dragon</content>
-  <content contentuid="h5648b3eag0325g46d8g5cd1g0463117aab6a" version="4">Terreur du dragon. Vous pouvez effectuer une action Magique pour instiller la terreur dans une créature que vous pouvez voir à 30 pieds ou moins de vous. La cible doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Effrayé jusqu'à la fin de votre prochain tour.
+  <content contentuid="h5648b3eag0325g46d8g5cd1g0463117aab6a" version="4">Terreur du dragon. Vous pouvez effectuer une action Magique pour instiller la terreur dans une créature que vous pouvez voir à 9 mètres ou moins de vous. La cible doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Effrayé jusqu'à la fin de votre prochain tour.
 
 Inspiré par la peur. Lorsque vous amenez une créature à avoir la condition Effrayé et que vous êtes la source de sa peur, vous gagnez une Inspiration héroïque. Une fois que vous avez utilisé cet avantage, vous ne pouvez plus le faire jusqu'à ce que vous terminiez un Repos court ou long.</content>
   <content contentuid="hee930e39g569egbf9bgf8d4gce1dcff3b5cd" version="1">Inspiration héroïque</content>
   <content contentuid="hd9193a10g8e78g28bagc22eg90d1be20c4d7" version="1">Vous gagnez une Inspiration héroïque chaque fois que vous terminez un Repos long. Si vous avez une Inspiration héroïque, vous pouvez la dépenser pour relancer n'importe quel dé immédiatement après l'avoir lancé.</content>
   <content contentuid="h07d286f6gc9ceg419dgb13dg7480d479c810" version="3">Royaumes Oubliés : Héros de Féérune : Dons d'origine</content>
   <content contentuid="hab576294g3e47gcbbeg44c0g9dc38a2a3ab6" version="2">Royaumes Oubliés : Héros de Féérune</content>
-  <content contentuid="hc477acf9gaec4g36b5g7d0bg06d04d9b41f4" version="2">Terreur du dragon. Vous pouvez effectuer une action Magique pour instiller la terreur dans une créature que vous pouvez voir à 30 pieds ou moins de vous. La cible doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Effrayé jusqu'à la fin de votre prochain tour.
+  <content contentuid="hc477acf9gaec4g36b5g7d0bg06d04d9b41f4" version="2">Terreur du dragon. Vous pouvez effectuer une action Magique pour instiller la terreur dans une créature que vous pouvez voir à 9 mètres ou moins de vous. La cible doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Effrayé jusqu'à la fin de votre prochain tour.
 
 Inspiré par la peur. Lorsque vous amenez une créature à avoir la condition Effrayé et que vous êtes la source de sa peur, vous gagnez une Inspiration héroïque. Une fois que vous avez utilisé cet avantage, vous ne pouvez plus le faire jusqu'à ce que vous terminiez un Repos court ou long.</content>
   <content contentuid="h131adc06g9cd1g7b27g9571g87157dc4b980" version="2">Initié au Culte du Dragon</content>
   <content contentuid="h9882b9efg772bg815eg465bg5671d559ae9f" version="2">Don d'origine : Novice de l'Enclave d'Émeraude</content>
   <content contentuid="ha908486dgac97g5080g2fcdg248197559140" version="1">Communication avec les animaux. Vous avez toujours le sort Communication avec les animaux préparé et pouvez le lancer avec n'importe quel emplacement de sort que vous possédez.
 
-Équipe en tandem. Lorsque vous prenez l'action Aider, vous pouvez échanger votre place avec un allié consentant à 5 pieds ou moins de vous dans le cadre de cette même action. Ce déplacement ne provoque pas d'Attaques d'opportunité.</content>
+Équipe en tandem. Lorsque vous prenez l'action Aider, vous pouvez échanger votre place avec un allié consentant à 1,50 mètre ou moins de vous dans le cadre de cette même action. Ce déplacement ne provoque pas d'Attaques d'opportunité.</content>
   <content contentuid="hff02d5beg6459g3c3ag3b99gadddccb29990" version="1">Novice de l'Enclave d'Émeraude</content>
   <content contentuid="h9dd6f816g7d8eg2378g9af9g3b609e271919" version="1">Communication avec les animaux. Vous avez toujours le sort Communication avec les animaux préparé et pouvez le lancer avec n'importe quel emplacement de sort que vous possédez.
 
-Équipe en tandem. Lorsque vous prenez l'action Aider, vous pouvez échanger votre place avec un allié consentant à 5 pieds ou moins de vous dans le cadre de cette même action. Ce déplacement ne provoque pas d'Attaques d'opportunité.</content>
+Équipe en tandem. Lorsque vous prenez l'action Aider, vous pouvez échanger votre place avec un allié consentant à 1,50 mètre ou moins de vous dans le cadre de cette même action. Ce déplacement ne provoque pas d'Attaques d'opportunité.</content>
   <content contentuid="h0c7893begd4c4gb155gaa06gc35e907bc369" version="1">Agent des Harfeurs</content>
   <content contentuid="h9a020e0cgf5c4g50b0g2c1eg4923fce674b6" version="3">Formation aux instruments. Vous obtenez la maîtrise des Instruments de musique.
 
-Mélodie distrayante. Lorsque vous prenez l'action Distraire pour aider au jet d'attaque d'un allié, l'ennemi que vous distrayez peut se trouver à 30 pieds ou moins de vous, plutôt qu'à 5 pieds ou moins, à condition que l'ennemi puisse vous voir ou vous entendre.</content>
+Mélodie distrayante. Lorsque vous prenez l'action Distraire pour aider au jet d'attaque d'un allié, l'ennemi que vous distrayez peut se trouver à 9 mètres ou moins de vous, plutôt qu'à 1,50 mètre ou moins, à condition que l'ennemi puisse vous voir ou vous entendre.</content>
   <content contentuid="h96873617g1939g4ab3g3ea5g0e3840510734" version="1">Formation aux instruments. Vous obtenez la maîtrise des Instruments de musique.
 
-Mélodie distrayante. Lorsque vous prenez l'action Distraire pour aider au jet d'attaque d'un allié, l'ennemi que vous distrayez peut se trouver à 30 pieds ou moins de vous, plutôt qu'à 5 pieds ou moins, à condition que l'ennemi puisse vous voir ou vous entendre.</content>
+Mélodie distrayante. Lorsque vous prenez l'action Distraire pour aider au jet d'attaque d'un allié, l'ennemi que vous distrayez peut se trouver à 9 mètres ou moins de vous, plutôt qu'à 1,50 mètre ou moins, à condition que l'ennemi puisse vous voir ou vous entendre.</content>
   <content contentuid="ha3dd6113g523fga059ga221g580b213b88b8" version="2">Agent de l'Alliance des Seigneurs</content>
   <content contentuid="h4ee892fdg07d1g3e46ga80bg74e493bcf181" version="1">Frappe inspirante. Une fois par tour lorsque vous réussissez un Coup critique contre une créature, vous gagnez une Inspiration héroïque.
 
@@ -2239,22 +2322,22 @@ Réaffirmer l'honneur. Lorsqu'un ennemi que vous pouvez voir vous inflige des d�
   <content contentuid="h9fa0d3deg53aag92d4g5ba5g0185574f2cd7" version="1">Agent de l'Alliance des Seigneurs</content>
   <content contentuid="hf2f81938g5ca0gb0eega680g3ec73dd11dd8" version="1">Supplique. Vous obtenez la maîtrise de Persuasion.
 
-Cri de ralliement. Vous pouvez choisir un nombre de créatures égal à votre bonus de maîtrise que vous pouvez voir à 30 pieds ou moins de vous. Ces créatures gagnent une Inspiration héroïque. Une fois que vous avez utilisé cet avantage, vous ne pouvez plus le faire jusqu'à ce que vous terminiez un Repos long.</content>
+Cri de ralliement. Vous pouvez choisir un nombre de créatures égal à votre bonus de maîtrise que vous pouvez voir à 9 mètres ou moins de vous. Ces créatures gagnent une Inspiration héroïque. Une fois que vous avez utilisé cet avantage, vous ne pouvez plus le faire jusqu'à ce que vous terminiez un Repos long.</content>
   <content contentuid="ha118d2a1gbbb4gcfd3g1676g37accfee78d4" version="1">Tour du Dragon Pourpre</content>
   <content contentuid="h460435aaga1b3g7abbg15e5g3ca6334b18ec" version="2">Don d'origine : Tour du Dragon Pourpre</content>
   <content contentuid="h76a090b6gcb17g375dg822fgdf79bae4b00a" version="1">Supplique. Vous obtenez la maîtrise de Persuasion.
 
-Cri de ralliement. Vous pouvez choisir un nombre de créatures égal à votre bonus de maîtrise que vous pouvez voir à 30 pieds ou moins de vous. Ces créatures gagnent une Inspiration héroïque. Une fois que vous avez utilisé cet avantage, vous ne pouvez plus le faire jusqu'à ce que vous terminiez un Repos long.</content>
+Cri de ralliement. Vous pouvez choisir un nombre de créatures égal à votre bonus de maîtrise que vous pouvez voir à 9 mètres ou moins de vous. Ces créatures gagnent une Inspiration héroïque. Une fois que vous avez utilisé cet avantage, vous ne pouvez plus le faire jusqu'à ce que vous terminiez un Repos long.</content>
   <content contentuid="hbd9d344cgf966g1f1ag6c2ag2c71696c22ea" version="1">Cri de ralliement</content>
-  <content contentuid="h5084d2fcg51fdgc84dg02cfg9b81d8b498cd" version="1">Vous pouvez choisir un nombre de créatures égal à votre bonus de maîtrise que vous pouvez voir à 30 pieds ou moins de vous. Ces créatures gagnent une Inspiration héroïque.</content>
+  <content contentuid="h5084d2fcg51fdgc84dg02cfg9b81d8b498cd" version="1">Vous pouvez choisir un nombre de créatures égal à votre bonus de maîtrise que vous pouvez voir à 9 mètres ou moins de vous. Ces créatures gagnent une Inspiration héroïque.</content>
   <content contentuid="h37427b79gd475g84c7g03e9g66f300db641b" version="1">Étincelle du Feu des sorts</content>
   <content contentuid="hdefd07e9gac32g3227g03d6g27116876f808" version="1">Absorption magique. Une fois par tour, lorsque vous subissez des dégâts d'un sort ou d'un effet magique, vous réduisez les dégâts totaux subis de 1d4.
 
-Flamme du Feu des sorts. Vous apprenez le tour de magie Flamme sacrée. Vous pouvez également lancer ce tour de magie en tant qu'Action bonus un nombre de fois égal à votre bonus de maîtrise, et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
+Flamme du Feu des sorts. Vous apprenez le sort mineur Flamme sacrée. Vous pouvez également lancer ce sort mineur en tant qu'Action bonus un nombre de fois égal à votre bonus de maîtrise, et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
   <content contentuid="hd178e099gb659g6341ga121g62c3fe95197b" version="2">Don d'origine : Étincelle du Feu des sorts</content>
   <content contentuid="h5b07f997g2114g17b3gd384gcaa505b50750" version="1">Absorption magique. Une fois par tour, lorsque vous subissez des dégâts d'un sort ou d'un effet magique, vous réduisez les dégâts totaux subis de 1d4.
 
-Flamme du Feu des sorts. Vous apprenez le tour de magie Flamme sacrée. Vous pouvez également lancer ce tour de magie en tant qu'Action bonus un nombre de fois égal à votre bonus de maîtrise, et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
+Flamme du Feu des sorts. Vous apprenez le sort mineur Flamme sacrée. Vous pouvez également lancer ce sort mineur en tant qu'Action bonus un nombre de fois égal à votre bonus de maîtrise, et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
   <content contentuid="h8b6799cbg2042gdd00gaddeg24b4180f6ca3" version="1">Absorption magique</content>
   <content contentuid="h7a0876d7g8491g0bbeg8ee3g09ef60d525a6" version="1">Flamme du Feu des sorts</content>
   <content contentuid="h6fcd846dgd479g5f4dgffd4g14a8140f6ba1" version="2">Vous pouvez lancer Flamme sacrée en tant qu'Action bonus un nombre de fois égal à votre bonus de maîtrise.</content>
@@ -2262,25 +2345,25 @@ Flamme du Feu des sorts. Vous apprenez le tour de magie Flamme sacrée. Vous pou
   <content contentuid="h7b8e3a06gdde1gc2ecgce15ga5797c09467a" version="2">Une fois par tour, lorsque vous subissez des dégâts d'un sort ou d'un effet magique, vous réduisez les dégâts totaux subis de 1d4.</content>
   <content contentuid="h11f2c0a6g0e9cg591agcdd9g71cba221f057" version="1">Une fois par tour, lorsque vous subissez des dégâts d'un sort ou d'un effet magique, vous réduisez les dégâts totaux subis de 1d4.</content>
   <content contentuid="h1683d699gbd26g0b5fg3b54g431044aa2005" version="1">Apprenti du Gantelet</content>
-  <content contentuid="hfde09985geec3g307ag4015ga087801eec7f" version="1">Tenir ensemble. Lorsqu'un allié à 5 pieds ou moins de vous est soumis à un effet qui le repousserait ou l'attirerait, vous pouvez utiliser votre Réaction pour empêcher cet allié d'être repoussé ou attiré. Pour bénéficier de cet avantage, l'allié ne peut pas avoir la condition Neutralisé.</content>
+  <content contentuid="hfde09985geec3g307ag4015ga087801eec7f" version="1">Tenir ensemble. Lorsqu'un allié à 1,50 mètre ou moins de vous est soumis à un effet qui le repousserait ou l'attirerait, vous pouvez utiliser votre Réaction pour empêcher cet allié d'être repoussé ou attiré. Pour bénéficier de cet avantage, l'allié ne peut pas avoir la condition Neutralisé.</content>
   <content contentuid="h892adbd2g77e7g3445g2923gacaeb87d4b31" version="1">Voyou des Zhentarim</content>
   <content contentuid="h35e74b0fg788bg373bg7feag7976ce468738" version="2">Exploiter l'ouverture. Lorsque vous lancez des dégâts pour une Attaque d'opportunité, vous pouvez lancer les dés de dégâts deux fois et utiliser l'un ou l'autre résultat contre la cible.
 
-La famille avant tout. Une fois par Repos long, vous accordez à vous-même et aux alliés à 30 pieds ou moins de vous l'Avantage aux jets d'Initiative.</content>
+La famille avant tout. Une fois par Repos long, vous accordez à vous-même et aux alliés à 9 mètres ou moins de vous l'Avantage aux jets d'Initiative.</content>
   <content contentuid="hcdc555cfg9d57g4360g3b62gca191ef8dbeb" version="2">Don d'origine : Apprenti du Gantelet</content>
-  <content contentuid="hae5d214ag6792g7325g5146gf48dfd5f7239" version="1">Tenir ensemble. Lorsqu'un allié à 5 pieds ou moins de vous est soumis à un effet qui le repousserait ou l'attirerait, vous pouvez utiliser votre Réaction pour empêcher cet allié d'être repoussé ou attiré. Pour bénéficier de cet avantage, l'allié ne peut pas avoir la condition Neutralisé.</content>
+  <content contentuid="hae5d214ag6792g7325g5146gf48dfd5f7239" version="1">Tenir ensemble. Lorsqu'un allié à 1,50 mètre ou moins de vous est soumis à un effet qui le repousserait ou l'attirerait, vous pouvez utiliser votre Réaction pour empêcher cet allié d'être repoussé ou attiré. Pour bénéficier de cet avantage, l'allié ne peut pas avoir la condition Neutralisé.</content>
   <content contentuid="hc035112fg126ag11d6gfb7dg336a2c68d5d8" version="2">Don d'origine : Voyou des Zhentarim</content>
   <content contentuid="hb6c99f09gddf8gda0ag3134gfda7f384b17d" version="2">Exploiter l'ouverture. Lorsque vous lancez des dégâts pour une Attaque d'opportunité, vous pouvez lancer les dés de dégâts deux fois et utiliser l'un ou l'autre résultat contre la cible.
 
-La famille avant tout. Une fois par Repos long, vous accordez à vous-même et aux alliés à 30 pieds ou moins de vous l'Avantage aux jets d'Initiative.</content>
+La famille avant tout. Une fois par Repos long, vous accordez à vous-même et aux alliés à 9 mètres ou moins de vous l'Avantage aux jets d'Initiative.</content>
   <content contentuid="h2be276d9g9017gecc8g9365g09bb5b15e42e" version="1">Tenir ensemble</content>
-  <content contentuid="h4bf93b9cg7a63g5e2bgf86ag8868c3da02b1" version="1">Lorsque cette fonctionnalité est activée, vous ne pouvez pas effectuer de Réactions. En échange, les alliés à 5 pieds ou moins de vous ne peuvent pas être repoussés ou attirés par des effets à moins qu'ils n'aient la condition Neutralisé.</content>
+  <content contentuid="h4bf93b9cg7a63g5e2bgf86ag8868c3da02b1" version="1">Lorsque cette fonctionnalité est activée, vous ne pouvez pas effectuer de Réactions. En échange, les alliés à 1,50 mètre ou moins de vous ne peuvent pas être repoussés ou attirés par des effets à moins qu'ils n'aient la condition Neutralisé.</content>
   <content contentuid="h8a6c93d3gcdf4g613agfc21g4b2eb3d82a7e" version="1">Vous ne pouvez pas être repoussé ou attiré par des effets à moins que vous n'ayez la condition Neutralisé.</content>
   <content contentuid="h45c64306g0c10g4b75g2a61ga03cdc9f028f" version="1">La famille avant tout</content>
   <content contentuid="h0d3b5485g5c57gea41ga802gd8b3685f8840" version="1">La famille avant tout</content>
-  <content contentuid="h376cf1deg3cbcgd0e3gd8b3g7017359c484e" version="1">Une fois par Repos long, vous accordez à vous-même et aux alliés à 30 pieds ou moins de vous l'Avantage aux jets d'Initiative.</content>
+  <content contentuid="h376cf1deg3cbcgd0e3gd8b3g7017359c484e" version="1">Une fois par Repos long, vous accordez à vous-même et aux alliés à 9 mètres ou moins de vous l'Avantage aux jets d'Initiative.</content>
   <content contentuid="hdc0c151fgfe8egbcabge68cg685831c227f1" version="1">Infligez [1] dégâts supplémentaires avec les armes de mêlée et les armes improvisées, et lors des lancers.</content>
-  <content contentuid="hbba7650bg2c8bga26fga741g9eb4b22d5870" version="1">Vos tours de magie causant des dégâts affectent même les créatures qui évitent le gros de l'effet. Lorsque vous lancez un tour de magie sur une créature et que vous ratez le jet d'attaque ou que la cible réussit un jet de sauvegarde contre le tour de magie, la cible subit la moitié des dégâts du tour de magie (le cas échéant) mais ne subit aucun effet supplémentaire du tour de magie.</content>
+  <content contentuid="hbba7650bg2c8bga26fga741g9eb4b22d5870" version="1">Vos sorts mineurs causant des dégâts affectent même les créatures qui évitent le gros de l'effet. Lorsque vous lancez un sort mineur sur une créature et que vous ratez le jet d'attaque ou que la cible réussit un jet de sauvegarde contre le sort mineur, la cible subit la moitié des dégâts du sort mineur (le cas échéant) mais ne subit aucun effet supplémentaire du sort mineur.</content>
   <content contentuid="h97952f3cg6278g1f14ge37fg872fa1c84f63" version="1">Fermier</content>
   <content contentuid="h15dc29ceg8c9cg6290g5aa9gcfb5242e5617" version="2">Don : Robuste
 
@@ -2326,7 +2409,7 @@ Les zones de magie morte du désert d'Anauroch sont une abomination pour les lan
 
 Vous êtes un initié du Culte du Dragon. Vous avez découvert ou été amené dans une cellule du culte, où vous avez incarné les valeurs honorées par les cultistes du dragon : la duplicité, le secret et la détermination. En échange de votre serment de servir le culte, le culte vous a offert la compagnie d'autres adorateurs de dragons, ainsi que l'accès à des ressources susceptibles d'aider vos études dans les domaines de l'arcane et de l'occultisme.
 
-Terreur du dragon. Vous pouvez effectuer une action Magique pour instiller la terreur dans une créature que vous pouvez voir à 30 pieds ou moins de vous. La cible doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Effrayé jusqu'à la fin de votre prochain tour.
+Terreur du dragon. Vous pouvez effectuer une action Magique pour instiller la terreur dans une créature que vous pouvez voir à 9 mètres ou moins de vous. La cible doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Effrayé jusqu'à la fin de votre prochain tour.
 
 Inspiré par la peur. Lorsque vous amenez une créature à avoir la condition Effrayé et que vous êtes la source de sa peur, vous gagnez une Inspiration héroïque. Une fois que vous avez utilisé cet avantage, vous ne pouvez plus le faire jusqu'à ce que vous terminiez un Repos court ou long.</content>
   <content contentuid="h90ac0b94ga91cg1944g4476gd94460ac409f" version="1">Gardien de l'Enclave d'Émeraude</content>
@@ -2336,7 +2419,7 @@ En tant que Gardien de l'Enclave d'Émeraude, vous prenez soin de ceux qui prenn
 
 Communication avec les animaux. Vous avez toujours le sort Communication avec les animaux préparé et pouvez le lancer avec n'importe quel emplacement de sort que vous possédez.
 
-Équipe en tandem. Lorsque vous prenez l'action Aider, vous pouvez échanger votre place avec un allié consentant à 5 pieds ou moins de vous dans le cadre de cette même action. Ce déplacement ne provoque pas d'Attaques d'opportunité.</content>
+Équipe en tandem. Lorsque vous prenez l'action Aider, vous pouvez échanger votre place avec un allié consentant à 1,50 mètre ou moins de vous dans le cadre de cette même action. Ce déplacement ne provoque pas d'Attaques d'opportunité.</content>
   <content contentuid="hdca03596gcde4g4b29g8a36g81f8496c69a4" version="1">Mercenaire du Poing de Feu</content>
   <content contentuid="he09a0c77g31aeg7362g892bg7bdd827aa73e" version="2">Don : Robuste
 
@@ -2352,13 +2435,13 @@ Vous avez accepté une invitation à rejoindre les Harfeurs, en prêtant serment
 
 Formation aux instruments. Vous obtenez la maîtrise des Instruments de musique.
 
-Mélodie distrayante. Lorsque vous prenez l'action Distraire pour aider au jet d'attaque d'un allié, l'ennemi que vous distrayez peut se trouver à 30 pieds ou moins de vous, plutôt qu'à 5 pieds ou moins, à condition que l'ennemi puisse vous voir ou vous entendre.</content>
+Mélodie distrayante. Lorsque vous prenez l'action Distraire pour aider au jet d'attaque d'un allié, l'ennemi que vous distrayez peut se trouver à 9 mètres ou moins de vous, plutôt qu'à 1,50 mètre ou moins, à condition que l'ennemi puisse vous voir ou vous entendre.</content>
   <content contentuid="h3da2c0c2ge282gffe0g4fc2gbb39fdf2759a" version="1">Pêcheur sur glace</content>
   <content contentuid="h0326e7b1g8c73g586agce87gedf968fe63ea" version="2">Don : Vigilance
 
 Vous êtes issu d'une fière lignée de pêcheurs sur glace des Dix-Bourgs de la Vallée des Vents Glacés. Attraper la truite à tête obtuse n'est pas le métier le plus glorieux du Nord, mais c'est un gagne-pain honnête. Vous avez entraîné vos sens au moindre mouvement du fil, arraché de grosses truites des lacs couverts de glace et vidé assez de truites à tête obtuse pour nourrir votre village à maintes reprises. Ces expériences ont endurci votre corps et votre esprit pour une vie d'aventurier.
 
-Tenir ensemble. Lorsqu'un allié à 5 pieds ou moins de vous est soumis à un effet qui le repousserait ou l'attirerait, vous pouvez utiliser votre Réaction pour empêcher cet allié d'être repoussé ou attiré. Pour bénéficier de cet avantage, l'allié ne peut pas avoir la condition Neutralisé.</content>
+Tenir ensemble. Lorsqu'un allié à 1,50 mètre ou moins de vous est soumis à un effet qui le repousserait ou l'attirerait, vous pouvez utiliser votre Réaction pour empêcher cet allié d'être repoussé ou attiré. Pour bénéficier de cet avantage, l'allié ne peut pas avoir la condition Neutralisé.</content>
   <content contentuid="hc067f1degeab6gcb46ge111g828cec427e50" version="1">Chevalier du Gantelet</content>
   <content contentuid="hc3c055e8g4d69gee62gad8cg75de8ea0fec1" version="1">Don : Apprenti du Gantelet
 
@@ -2390,7 +2473,7 @@ Vous avez pledgé votre vie à la sécurité du Cormyr et avez cherché à inté
 
 Supplique. Vous obtenez la maîtrise de Persuasion.
 
-Cri de ralliement. Vous pouvez choisir un nombre de créatures égal à votre bonus de maîtrise que vous pouvez voir à 30 pieds ou moins de vous. Ces créatures gagnent une Inspiration héroïque. Une fois que vous avez utilisé cet avantage, vous ne pouvez plus le faire jusqu'à ce que vous terminiez un Repos long.</content>
+Cri de ralliement. Vous pouvez choisir un nombre de créatures égal à votre bonus de maîtrise que vous pouvez voir à 9 mètres ou moins de vous. Ces créatures gagnent une Inspiration héroïque. Une fois que vous avez utilisé cet avantage, vous ne pouvez plus le faire jusqu'à ce que vous terminiez un Repos long.</content>
   <content contentuid="h625450b8g42bdgc0cag5d94g932492b64ed0" version="1">Vagabond rashémi</content>
   <content contentuid="h75277cafgfc31g7483g2ad8gfd91011a85cc" version="1">Don : Robuste
 
@@ -2406,7 +2489,7 @@ Vous portez le don du feu des sorts : une forme rare de magie qui canalise la pu
 
 Absorption magique. Une fois par tour, lorsque vous subissez des dégâts d'un sort ou d'un effet magique, vous réduisez les dégâts totaux subis de 1d4.
 
-Flamme du Feu des sorts. Vous apprenez le tour de magie Flamme sacrée. Vous pouvez également lancer ce tour de magie en tant qu'Action bonus un nombre de fois égal à votre bonus de maîtrise, et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
+Flamme du Feu des sorts. Vous apprenez le sort mineur Flamme sacrée. Vous pouvez également lancer ce sort mineur en tant qu'Action bonus un nombre de fois égal à votre bonus de maîtrise, et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
   <content contentuid="h502820d0g8b37g078bg65f7g4a80446379d8" version="1">Mercenaire des Zhentarim</content>
   <content contentuid="hdeab958dge913gf95bg123dg27338a365d6d" version="2">Don : Voyou des Zhentarim
 
@@ -2414,15 +2497,15 @@ Peut-être aviez-vous besoin d'argent. Peut-être aspiriez-vous à une famille, 
 
 Exploiter l'ouverture. Lorsque vous lancez des dégâts pour une Attaque d'opportunité, vous pouvez lancer les dés de dégâts deux fois et utiliser l'un ou l'autre résultat contre la cible.
 
-La famille avant tout. Une fois par Repos long, vous accordez à vous-même et aux alliés à 30 pieds ou moins de vous l'Avantage aux jets d'Initiative.</content>
+La famille avant tout. Une fois par Repos long, vous accordez à vous-même et aux alliés à 9 mètres ou moins de vous l'Avantage aux jets d'Initiative.</content>
   <content contentuid="h6c0d30c6gd6bagd6f9g6ed0g7d30fcd174dd" version="1">Don : Lanceur du Froid</content>
-  <content contentuid="he5401f43ga2cfgcd9dgcb25g6ce8548e686a" version="1">Tour de magie. Vous apprenez le tour de magie Rayon de givre.
+  <content contentuid="he5401f43ga2cfgcd9dgcb25g6ce8548e686a" version="1">Sort mineur. Vous apprenez le sort mineur Rayon de givre.
 
 Gelure. Une fois par tour lorsque vous touchez une créature avec un jet d'attaque et infligez des dégâts de Froid, vous pouvez temporairement annuler les défenses de la créature. La créature soustrait 1d4 du prochain jet de sauvegarde qu'elle effectue avant la fin de votre prochain tour.</content>
   <content contentuid="h046e98e9gd6d2gf0ecga207gad73de421d8c" version="1">Don : Cicatrices du Dragon</content>
   <content contentuid="h1b40d160ge647gb336gde38g35a23097c13b" version="1">Résistance aux dégâts. Lorsque vous obtenez ce don, choisissez Acide, Froid, Feu, Foudre ou Poison. Vous avez la Résistance au type de dégâts choisi.
 
-Pouvoir impressionnant. Lorsque vous infligez des dégâts à une créature dans le cadre de l'action Attaque ou Magique à votre tour, vous pouvez utiliser l'avantage Terreur du dragon du don Initié au Culte du Dragon en tant qu'Action bonus ce tour.</content>
+Pouvoir impressionnant. Lorsque vous infligez des dégâts à une créature dans le cadre de l'action Attaquer ou Magique à votre tour, vous pouvez utiliser l'avantage Terreur du dragon du don Initié au Culte du Dragon en tant qu'Action bonus ce tour.</content>
   <content contentuid="h956022bdge5c5g1d50gfb23ga2e9b937150f" version="1">Don : Magie de l'Enclave</content>
   <content contentuid="h99dd2a82gb360g8747g2eafg30d4b056f72d" version="1">Vous avez toujours le sort Pousse épineuse préparé. Vous pouvez le lancer une fois sans dépenser d'emplacement de sort, et vous récupérez la capacité de le faire lorsque vous terminez un Repos court. Lorsque vous lancez le sort de cette façon, il ne nécessite pas de Concentration.</content>
   <content contentuid="h7330e7c6gc771g8abbg45f0g15512946f998" version="1">Don : Fripon féerique</content>
@@ -2440,17 +2523,17 @@ Volonté inspirante. Vous avez l'Avantage aux jets de sauvegarde contre les cond
   <content contentuid="h4aee3eacgaf72gc757g8d80g048d0a64e805" version="1">Don : Résolution seigneuriale</content>
   <content contentuid="h86fbc975g75b4gcf4cg3416geb64d948c1e4" version="1">Porte-étendard. Vous êtes immunisé contre les conditions À terre, Charmé et Effrayé.</content>
   <content contentuid="h75370f04gff6egfa29g73e5g4e8d6739e8fa" version="1">Don : Touché par le Mythal</content>
-  <content contentuid="h81877b18gdacfg553cge0c9g65813ccf4557" version="1">Votre incantation peut déclencher des surtensions de magie sauvage. Une fois par tour, vous pouvez lancer 1d20 immédiatement après avoir lancé un sort avec un emplacement de sort. Si vous obtenez un 20, lancez sur la table de Surtension de magie sauvage pour créer un effet magique.</content>
+  <content contentuid="h81877b18gdacfg553cge0c9g65813ccf4557" version="1">Votre incantation peut déclencher des pics de magie sauvage. Une fois par tour, vous pouvez lancer 1d20 immédiatement après avoir lancé un sort avec un emplacement de sort. Si vous obtenez un 20, lancez sur la table de Pic de magie sauvage pour créer un effet magique.</content>
   <content contentuid="h3860f913g1f6fg4b18g9ecfgabcab0169949" version="1">Don : Résilience de l'Ordre</content>
-  <content contentuid="hddb981a7g0a29gd059gf634g1b2d20e1a8fd" version="1">Pendant que vous utilisez Tenir ensemble (Apprenti du Gantelet), les alliés à 5 pieds ou moins de vous sont immunisés contre la condition À terre et ont l'Avantage aux jets de sauvegarde de Force.</content>
+  <content contentuid="hddb981a7g0a29gd059gf634g1b2d20e1a8fd" version="1">Pendant que vous utilisez Tenir ensemble (Apprenti du Gantelet), les alliés à 1,50 mètre ou moins de vous sont immunisés contre la condition À terre et ont l'Avantage aux jets de sauvegarde de Force.</content>
   <content contentuid="h9c38c422gaf7bg5622gf3baga2123af217ab" version="1">Don : Commandant du Dragon Pourpre</content>
-  <content contentuid="hf790b35fg5b7ege376ge7e5gfdcf78fcbf35" version="2">Encourager l'allié. En tant qu'Action bonus, vous soutenez un allié que vous pouvez voir à 30 pieds ou moins. Cet allié gagne des Points de vie temporaires égaux à 2d6 plus votre bonus de maîtrise. Vous pouvez utiliser cette Action bonus un nombre de fois égal à votre bonus de maîtrise, et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.
+  <content contentuid="hf790b35fg5b7ege376ge7e5gfdcf78fcbf35" version="2">Encourager l'allié. En tant qu'Action bonus, vous soutenez un allié que vous pouvez voir à 9 mètres ou moins. Cet allié gagne des Points de vie temporaires égaux à 2d6 plus votre bonus de maîtrise. Vous pouvez utiliser cette Action bonus un nombre de fois égal à votre bonus de maîtrise, et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.
 
 Dernier bastion. Vous avez l'Avantage aux jets d'attaque lorsque vous êtes À moitié mort.</content>
   <content contentuid="h9de5f3bdgd036g8fc7gc000g9f162c3acfc6" version="1">Don : Adepte du Feu des sorts</content>
   <content contentuid="h94e22d9cg05ceg0802gc712g372cd3b8f030" version="1">Les sorts que vous lancez et les attaques que vous effectuez ignorent la &lt;LSTag Tooltip="Resistant"&gt;Résistance&lt;/LSTag&gt; aux dégâts Rayonnants. De plus, lorsque vous infligez des dégâts Rayonnants avec un sort, vous ne pouvez pas obtenir un 1.</content>
   <content contentuid="h2d5b87b6g1172g67b5gcfefg0bf170e5aaef" version="1">Don : Tactiques des Zhentarim</content>
-  <content contentuid="h06b8380ag7f73g106agdf63g8dabbadb964c" version="1">Représailles. Immédiatement après qu'une créature à 5 pieds ou moins de vous vous frappe avec une attaque de mêlée, vous pouvez effectuer une Attaque d'opportunité contre cette créature.
+  <content contentuid="h06b8380ag7f73g106agdf63g8dabbadb964c" version="1">Représailles. Immédiatement après qu'une créature à 1,50 mètre ou moins de vous vous frappe avec une attaque de mêlée, vous pouvez effectuer une Attaque d'opportunité contre cette créature.
 
 Mercenaire polyvalent. Choisissez une compétence dans laquelle vous avez la maîtrise. Vous avez l'Expertise dans cette compétence.</content>
   <content contentuid="h32fd92c5gd42cg926fgb1adg572674b52c38" version="1">Don : Cicatrices du Dragon (Résistance à l'Acide)</content>
@@ -2466,21 +2549,21 @@ Mercenaire polyvalent. Choisissez une compétence dans laquelle vous avez la ma�
   <content contentuid="h5d1b146eg0fd5g7577gcd29g2497b1c1beae" version="1">Porte-étendard</content>
   <content contentuid="h7f09b2d2g5ce4g617bgbbb7gae4f47ac82af" version="1">Vous êtes immunisé contre la condition À terre et avez l'Avantage aux jets de sauvegarde de Force.</content>
   <content contentuid="h11b2630egba57g41bfg86afga1a03173230e" version="1">Encourager l'allié</content>
-  <content contentuid="h74764f94g16bbg3291g6bf1g64f2467c1d2d" version="1">En tant qu'Action bonus, vous soutenez un allié que vous pouvez voir à 30 pieds ou moins. Cet allié gagne des Points de vie temporaires égaux à 2d6 plus votre bonus de maîtrise. Vous pouvez utiliser cette Action bonus un nombre de fois égal à votre bonus de maîtrise, et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
+  <content contentuid="h74764f94g16bbg3291g6bf1g64f2467c1d2d" version="1">En tant qu'Action bonus, vous soutenez un allié que vous pouvez voir à 9 mètres ou moins. Cet allié gagne des Points de vie temporaires égaux à 2d6 plus votre bonus de maîtrise. Vous pouvez utiliser cette Action bonus un nombre de fois égal à votre bonus de maîtrise, et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
   <content contentuid="h84f4adf1gf6eag1710g1245gca69206d05fe" version="1">Encourager l'allié</content>
   <content contentuid="h2287dbd5gd1ffga56ag677eg771e23ed7f4c" version="1">Gagnez des Points de vie temporaires égaux à 2d6 plus le bonus de maîtrise du lanceur de sorts.</content>
   <content contentuid="h1bca3b80g61b0g1241gad6dg59a5b944962e" version="1">Représailles</content>
-  <content contentuid="h3b19c28cg80dcg38e9gc853g0c674ef3b5e5" version="1">Immédiatement après qu'une créature à 5 pieds ou moins de vous vous frappe avec une attaque de mêlée, vous pouvez effectuer une Attaque d'opportunité contre cette créature.</content>
+  <content contentuid="h3b19c28cg80dcg38e9gc853g0c674ef3b5e5" version="1">Immédiatement après qu'une créature à 1,50 mètre ou moins de vous vous frappe avec une attaque de mêlée, vous pouvez effectuer une Attaque d'opportunité contre cette créature.</content>
   <content contentuid="h7266774agddd3g954ag8493g86532999d2ae" version="1">Royaumes Oubliés : Héros de Féérune : Dons généraux</content>
   <content contentuid="hb3bd7f59g0610g8deag20d1ga4bb317c1e9b" version="1">Royaumes Oubliés : Héros de Féérune : Dons généraux</content>
   <content contentuid="h29ab3531g02fbgac9egf6b3g45f445778cb6" version="1">Lanceur du Froid</content>
-  <content contentuid="hc43fd16fgcee0g3229g6eaeg057f44917b4e" version="1">Tour de magie. Vous apprenez le tour de magie Rayon de givre.
+  <content contentuid="hc43fd16fgcee0g3229g6eaeg057f44917b4e" version="1">Sort mineur. Vous apprenez le sort mineur Rayon de givre.
 
 Gelure. Une fois par tour lorsque vous touchez une créature avec un jet d'attaque et infligez des dégâts de Froid, vous pouvez temporairement annuler les défenses de la créature. La créature soustrait 1d4 du prochain jet de sauvegarde qu'elle effectue avant la fin de votre prochain tour.</content>
   <content contentuid="h1c19b94dg0f16g1ad9ge5e7g35a02c85c163" version="1">Cicatrices du Dragon</content>
   <content contentuid="hb1847b98g2cc5gbe94g49f1gc11efdbfb5a5" version="1">Résistance aux dégâts. Lorsque vous obtenez ce don, choisissez Acide, Froid, Feu, Foudre ou Poison. Vous avez la Résistance au type de dégâts choisi.
 
-Pouvoir impressionnant. Lorsque vous infligez des dégâts à une créature dans le cadre de l'action Attaque ou Magique à votre tour, vous pouvez utiliser l'avantage Terreur du dragon du don Initié au Culte du Dragon en tant qu'Action bonus ce tour.</content>
+Pouvoir impressionnant. Lorsque vous infligez des dégâts à une créature dans le cadre de l'action Attaquer ou Magique à votre tour, vous pouvez utiliser l'avantage Terreur du dragon du don Initié au Culte du Dragon en tant qu'Action bonus ce tour.</content>
   <content contentuid="h2fc939d2gdb2egc680g11d6gd7ecee244590" version="1">Magie de l'Enclave</content>
   <content contentuid="hd23656cfg57f8g9378gb515g69eaf09ae893" version="1">Vous avez toujours le sort Pousse épineuse préparé. Vous pouvez le lancer une fois sans dépenser d'emplacement de sort, et vous récupérez la capacité de le faire lorsque vous terminez un Repos court. Lorsque vous lancez le sort de cette façon, il ne nécessite pas de Concentration.</content>
   <content contentuid="hb79bd3d9g613dg22a6gdf89ged7bb1cc5f1d" version="1">Fripon féerique</content>
@@ -2498,17 +2581,17 @@ Volonté inspirante. Vous avez l'Avantage aux jets de sauvegarde contre les cond
   <content contentuid="h073d0597g8104g5749g9c62g13790ccd3f2b" version="1">Résolution seigneuriale</content>
   <content contentuid="hca4c73c6g5ff9g1e2dg6288g9bd5466da9c1" version="1">Porte-étendard. Vous êtes immunisé contre les conditions À terre, Charmé et Effrayé.</content>
   <content contentuid="h4da279bag6b5fg0d46gfa98g0b2a70b0ce8e" version="1">Touché par le Mythal</content>
-  <content contentuid="hb1afe5dagdd44g9fb0ga44bgfc95f9dd8e59" version="1">Votre incantation peut déclencher des surtensions de magie sauvage. Une fois par tour, vous pouvez lancer 1d20 immédiatement après avoir lancé un sort avec un emplacement de sort. Si vous obtenez un 20, lancez sur la table de Surtension de magie sauvage pour créer un effet magique.</content>
+  <content contentuid="hb1afe5dagdd44g9fb0ga44bgfc95f9dd8e59" version="1">Votre incantation peut déclencher des pics de magie sauvage. Une fois par tour, vous pouvez lancer 1d20 immédiatement après avoir lancé un sort avec un emplacement de sort. Si vous obtenez un 20, lancez sur la table de Pic de magie sauvage pour créer un effet magique.</content>
   <content contentuid="h9cc613dfgb0bcgce96gb19bg02330e4dff7a" version="1">Résilience de l'Ordre</content>
-  <content contentuid="h4d3fa3f2g1f1aga0c3gb83bg94d626b6b33f" version="1">Pendant que vous utilisez Tenir ensemble (Apprenti du Gantelet), les alliés à 5 pieds ou moins de vous sont immunisés contre la condition À terre et ont l'Avantage aux jets de sauvegarde de Force.</content>
+  <content contentuid="h4d3fa3f2g1f1aga0c3gb83bg94d626b6b33f" version="1">Pendant que vous utilisez Tenir ensemble (Apprenti du Gantelet), les alliés à 1,50 mètre ou moins de vous sont immunisés contre la condition À terre et ont l'Avantage aux jets de sauvegarde de Force.</content>
   <content contentuid="h322b2b28g4f47gfef1g0501g09a299ea04dd" version="1">Commandant du Dragon Pourpre</content>
-  <content contentuid="h4f5ef875gef6dg93aag6e38g370f1fde0a68" version="2">Encourager l'allié. En tant qu'Action bonus, vous soutenez un allié que vous pouvez voir à 30 pieds ou moins. Cet allié gagne des Points de vie temporaires égaux à 2d6 plus votre bonus de maîtrise. Vous pouvez utiliser cette Action bonus un nombre de fois égal à votre bonus de maîtrise, et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.
+  <content contentuid="h4f5ef875gef6dg93aag6e38g370f1fde0a68" version="2">Encourager l'allié. En tant qu'Action bonus, vous soutenez un allié que vous pouvez voir à 9 mètres ou moins. Cet allié gagne des Points de vie temporaires égaux à 2d6 plus votre bonus de maîtrise. Vous pouvez utiliser cette Action bonus un nombre de fois égal à votre bonus de maîtrise, et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.
 
 Dernier bastion. Vous avez l'Avantage aux jets d'attaque lorsque vous êtes À moitié mort.</content>
   <content contentuid="he27e1f66g8aceg44b2gecc9g07a86e98de57" version="1">Adepte du Feu des sorts</content>
   <content contentuid="hf7ce49baga00eg630eg2b32g38d71accc648" version="1">Les sorts que vous lancez et les attaques que vous effectuez ignorent la &lt;LSTag Tooltip="Resistant"&gt;Résistance&lt;/LSTag&gt; aux dégâts Rayonnants. De plus, lorsque vous infligez des dégâts Rayonnants avec un sort, vous ne pouvez pas obtenir un 1.</content>
   <content contentuid="h868d132cgda3cg9662gc17ega94ac1ad380e" version="1">Tactiques des Zhentarim</content>
-  <content contentuid="he09232a3g8429ge28bga994gd171ef3f3292" version="1">Représailles. Immédiatement après qu'une créature à 5 pieds ou moins de vous vous frappe avec une attaque de mêlée, vous pouvez effectuer une Attaque d'opportunité contre cette créature.
+  <content contentuid="he09232a3g8429ge28bga994gd171ef3f3292" version="1">Représailles. Immédiatement après qu'une créature à 1,50 mètre ou moins de vous vous frappe avec une attaque de mêlée, vous pouvez effectuer une Attaque d'opportunité contre cette créature.
 
 Mercenaire polyvalent. Choisissez une compétence dans laquelle vous avez la maîtrise. Vous avez l'Expertise dans cette compétence.</content>
   <content contentuid="h3566bf7ege17bg0f56g4fbdgfac65706f1a2" version="1">Lors de la création de votre personnage ou de la redistribution, choisissez un seul Don d'origine Initié à la magie. En sélectionner plusieurs peut causer des problèmes inattendus.</content>
@@ -2517,7 +2600,7 @@ Mercenaire polyvalent. Choisissez une compétence dans laquelle vous avez la ma�
   <content contentuid="h1f3d47b6gbc1fgf224g07d7g6347072349e6" version="2">Don : Tueur de dragons</content>
   <content contentuid="h2407b839gbdcdg7a29gb1ceg77ebf305424f" version="2">Vous avez l'Avantage aux jets d'Attaque contre les créatures de taille Grande ou plus grande. De plus, vous infligez des dégâts supplémentaires égaux à votre modificateur de Force lorsque vous touchez de telles créatures.</content>
   <content contentuid="hedc33adbg89b5ge699g0a6bgf060748fb8bb" version="2">Don : Éclat de courroux</content>
-  <content contentuid="h1fa402eeg7070g07b2gbfbaga67c4ad37e78" version="3">En tant qu'Action bonus, vous pouvez faire en sorte qu'une arme de mêlée que vous maniez émette une lumière faible dans un rayon de 10 pieds pendant 10 tours. La lumière est de la lumière solaire. Pendant que l'arme brille, elle inflige des dégâts Rayonnants au lieu de son type de dégâts normal.
+  <content contentuid="h1fa402eeg7070g07b2gbfbaga67c4ad37e78" version="3">En tant qu'Action bonus, vous pouvez faire en sorte qu'une arme de mêlée que vous maniez émette une lumière faible dans un rayon de 3 mètres pendant 10 tours. La lumière est de la lumière solaire. Pendant que l'arme brille, elle inflige des dégâts Rayonnants au lieu de son type de dégâts normal.
 
 Lorsque vous réussissez un coup critique avec une attaque d'arme de mêlée, vous pouvez lancer l'un des dés de dégâts de l'arme une fois de plus et l'ajouter.</content>
   <content contentuid="h12c8377bg73a7g1523gd2f7gce9b3dfd5731" version="2">Don : Agilité</content>
@@ -2529,9 +2612,9 @@ Lorsque vous réussissez un coup critique avec une attaque d'arme de mêlée, vo
   <content contentuid="h8bfddb10g014ag1ffagebccgfc7f04dceadc" version="1">Tir mortel</content>
   <content contentuid="h76568432gfb37gc67cgcb8egf3cebfdfa094" version="1">En tant qu'Action bonus, vous vous donnez l'Avantage à votre jet d'attaque d'arme à distance au tour actuel. Vous ne pouvez utiliser cette Action bonus que si vous ne vous êtes pas déplacé pendant ce tour, et après l'avoir utilisée, votre Vitesse est 0 jusqu'à la fin du tour actuel.</content>
   <content contentuid="h93af975eg1568g7912g8166g2000a25d6098" version="1">Éclat de courroux</content>
-  <content contentuid="h89b6e006g139bgf893g9a7dg642ea772fd27" version="2">En tant qu'Action bonus, vous pouvez faire en sorte qu'une arme de mêlée que vous maniez émette une lumière faible dans un rayon de 10 pieds pendant 10 tours. La lumière est de la lumière solaire. Pendant que l'arme brille, elle inflige des dégâts Rayonnants au lieu de son type de dégâts normal.</content>
+  <content contentuid="h89b6e006g139bgf893g9a7dg642ea772fd27" version="2">En tant qu'Action bonus, vous pouvez faire en sorte qu'une arme de mêlée que vous maniez émette une lumière faible dans un rayon de 3 mètres pendant 10 tours. La lumière est de la lumière solaire. Pendant que l'arme brille, elle inflige des dégâts Rayonnants au lieu de son type de dégâts normal.</content>
   <content contentuid="hcd7ebaacgd104g7c94g39abga1726e706521" version="1">Éclat de courroux</content>
-  <content contentuid="h44cd6db6gdaa7gaac2g514cg11ae3a98f828" version="1">En tant qu'Action bonus, vous pouvez faire en sorte qu'une arme de mêlée que vous maniez émette une lumière faible dans un rayon de 10 pieds pendant 10 tours. La lumière est de la lumière solaire. Pendant que l'arme brille, elle inflige des dégâts Rayonnants au lieu de son type de dégâts normal.</content>
+  <content contentuid="h44cd6db6gdaa7gaac2g514cg11ae3a98f828" version="1">En tant qu'Action bonus, vous pouvez faire en sorte qu'une arme de mêlée que vous maniez émette une lumière faible dans un rayon de 3 mètres pendant 10 tours. La lumière est de la lumière solaire. Pendant que l'arme brille, elle inflige des dégâts Rayonnants au lieu de son type de dégâts normal.</content>
   <content contentuid="hec257629g3869gaf27g7d40g1a0a389564d4" version="1">Le Jeu de rôle du Seigneur des Anneaux</content>
   <content contentuid="h5660c039gdc35g3a65gfe67gdd812981ab72" version="1">Le Jeu de rôle du Seigneur des Anneaux</content>
   <content contentuid="h8e50ea07g829fg41c1gfdaeg0618e6beca34" version="1">Tir mortel</content>
@@ -2549,7 +2632,7 @@ Lorsque vous effectuez une attaque avec une arme à distance, vous utilisez votr
   <content contentuid="h2ffcb591g0cc8ga4f6g50f8g0b3e5ae7dcf0" version="1">Éclat de courroux</content>
   <content contentuid="h63f9716cgc2d1g6fcbg46fcg4c5e77c4be1d" version="2">Votre peuple a connu de nombreuses défaites, et de nombreuses victoires stériles dans ses guerres contre l'Ombre. La rage mortelle que vos proches éprouvent pour l'Ennemi infuse vos armes d'un éclat de flamme glacée.
 
-En tant qu'Action bonus, vous pouvez faire en sorte qu'une arme de mêlée que vous maniez émette une lumière faible dans un rayon de 10 pieds pendant 10 tours. La lumière est de la lumière solaire. Pendant que l'arme brille, elle inflige des dégâts Rayonnants au lieu de son type de dégâts normal.
+En tant qu'Action bonus, vous pouvez faire en sorte qu'une arme de mêlée que vous maniez émette une lumière faible dans un rayon de 3 mètres pendant 10 tours. La lumière est de la lumière solaire. Pendant que l'arme brille, elle inflige des dégâts Rayonnants au lieu de son type de dégâts normal.
 
 Lorsque vous réussissez un coup critique avec une attaque d'arme de mêlée, vous pouvez lancer l'un des dés de dégâts de l'arme une fois de plus et l'ajouter.</content>
   <content contentuid="hbae36f77gae16gae82g11feg104123766490" version="1">Agilité</content>
@@ -2567,49 +2650,49 @@ Une fois à chacun de vos tours avant la fin de la transformation, vous pouvez i
 
 Vous pouvez infliger des dégâts supplémentaires à une cible lorsque vous lui infligez des dégâts avec une attaque ou un sort. Les dégâts supplémentaires sont égaux à votre bonus de maîtrise. Le type de dégâts est Nécrotique pour Linceul nécrotique, ou Rayonnant pour Ailes célestes et Radiance intérieure.</content>
   <content contentuid="h3f49f80egbab5g00d8gc75fg71bb7b054fc6" version="1">Radiance intérieure</content>
-  <content contentuid="h947e63dfge856g93fdge133g7915f597706a" version="1">Une lumière ardente rayonne temporairement de vos yeux et de votre bouche. Pendant la durée, vous émettez une Lumière vive dans un rayon de 10 pieds et une Lumière faible sur 10 pieds supplémentaires, et à la fin de chacun de vos tours, chaque créature à 10 pieds ou moins de vous subit des dégâts Rayonnants égaux à votre bonus de maîtrise.</content>
+  <content contentuid="h947e63dfge856g93fdge133g7915f597706a" version="1">Une lumière ardente rayonne temporairement de vos yeux et de votre bouche. Pendant la durée, vous émettez une Lumière vive dans un rayon de 3 mètres et une Lumière faible sur 3 mètres supplémentaires, et à la fin de chacun de vos tours, chaque créature à 3 mètres ou moins de vous subit des dégâts Rayonnants égaux à votre bonus de maîtrise.</content>
   <content contentuid="hfae2afebg7426gcf8cg5c76g65cdce3c393d" version="1">Ailes célestes</content>
   <content contentuid="h80c3bb0dgd84cg63b6g9b47g339cb3415da6" version="1">Deux ailes spectrales poussent temporairement dans votre dos. Jusqu'à la fin de la transformation, vous avez une Vitesse de vol égale à votre Vitesse.</content>
   <content contentuid="h618cb471geddfg2d11g70feg9e12919e4a68" version="1">Linceul nécrotique</content>
-  <content contentuid="h6a146679g10b4gcab6g7371g8809ef5326f6" version="2">Vos yeux deviennent des puits de ténèbres, et des ailes sans vol poussent brièvement dans votre dos. Les créatures de votre choix à 10 pieds ou moins de vous doivent réussir un jet de sauvegarde de Charisme ou avoir la condition Effrayé pendant 1 minute.</content>
+  <content contentuid="h6a146679g10b4gcab6g7371g8809ef5326f6" version="2">Vos yeux deviennent des puits de ténèbres, et des ailes sans vol poussent brièvement dans votre dos. Les créatures de votre choix à 3 mètres ou moins de vous doivent réussir un jet de sauvegarde de Charisme ou avoir la condition Effrayé pendant 1 minute.</content>
   <content contentuid="h34ab3782g568fg1b60g9a2eg148d28686613" version="1">Ailes célestes</content>
   <content contentuid="hbcd3d36fgdc84gb744gaaf6ge51968dbc88e" version="1">Deux ailes spectrales poussent temporairement dans votre dos. Jusqu'à la fin de la transformation, vous avez une Vitesse de vol égale à votre Vitesse.</content>
   <content contentuid="hb450a1d2g4f77g57dbg4c25gd3acee588f18" version="1">Radiance intérieure</content>
-  <content contentuid="h4049a129gb079gf0dagb270g0aa72eb1171d" version="1">Une lumière ardente rayonne temporairement de vos yeux et de votre bouche. Pendant la durée, vous émettez une Lumière vive dans un rayon de 10 pieds et une Lumière faible sur 10 pieds supplémentaires, et à la fin de chacun de vos tours, chaque créature à 10 pieds ou moins de vous subit des dégâts Rayonnants égaux à votre bonus de maîtrise.</content>
+  <content contentuid="h4049a129gb079gf0dagb270g0aa72eb1171d" version="1">Une lumière ardente rayonne temporairement de vos yeux et de votre bouche. Pendant la durée, vous émettez une Lumière vive dans un rayon de 3 mètres et une Lumière faible sur 3 mètres supplémentaires, et à la fin de chacun de vos tours, chaque créature à 3 mètres ou moins de vous subit des dégâts Rayonnants égaux à votre bonus de maîtrise.</content>
   <content contentuid="h5455adb5gc4c2g9159g585eg6c24762cbd53" version="1">Linceul nécrotique</content>
-  <content contentuid="h3a16b87eg8dd3g9578gd609gbf2f106aa676" version="1">Vos yeux deviennent brièvement des puits de ténèbres, et des ailes sans vol poussent temporairement dans votre dos. Les créatures autres que vos alliés à 10 pieds ou moins de vous doivent réussir un jet de sauvegarde de Charisme ou avoir la condition Effrayé jusqu'à la fin de votre prochain tour.</content>
+  <content contentuid="h3a16b87eg8dd3g9578gd609gbf2f106aa676" version="1">Vos yeux deviennent brièvement des puits de ténèbres, et des ailes sans vol poussent temporairement dans votre dos. Les créatures autres que vos alliés à 3 mètres ou moins de vous doivent réussir un jet de sauvegarde de Charisme ou avoir la condition Effrayé jusqu'à la fin de votre prochain tour.</content>
   <content contentuid="h14b0a7adg6f8dg3aefgbc10ge9f1398e2825" version="1">Radiance intérieure</content>
   <content contentuid="h868292b4g07bag5039g7a39g8b646671c67e" version="2">A une pénalité de 1d4 aux &lt;LSTag Tooltip="SavingThrow"&gt;Jets de sauvegarde&lt;/LSTag&gt;.</content>
-  <content contentuid="h6ef5198eg577fg6ca6gc4d9gb725efc2c584" version="1">Éclat mental</content>
+  <content contentuid="h6ef5198eg577fg6ca6gc4d9gb725efc2c584" version="1">Piqûre mentale</content>
   <content contentuid="h8c610e61ga284gbdd9gf4c4gc19e363942ea" version="1">Collège de la Lune</content>
   <content contentuid="h759d592bgce3eg0689gb28cgb0e2182d4aba" version="1">Le Collège de la Lune tire ses origines des anciens cercles druidiques des Îles Lune, qui confièrent aux premiers Bardes de cette tradition la mission de chronicler les histoires des îles et de leurs peuples. Les Bardes de ce collège puisent dans la magie féerique des îles et le pouvoir primordial des lunefontaines pour soutenir leurs alliés, protéger le monde naturel et inspirer leurs œuvres bardiques.</content>
   <content contentuid="h9223661bgace2gba01g10dcgfc1ea09add5a" version="1">Niveau 3 : Inspiration de la Lune</content>
   <content contentuid="he8fec49dgf4c3g6a97g790bg3a7f505054bf" version="1">Le pouvoir primal et changeant de la lune coule en vous, vous accordant les avantages suivants.
 
-Éclipse inspirée. Lorsque vous prenez une Action bonus pour donner un dé d'Inspiration bardique à une créature, vous pouvez avoir la condition Invisible et vous téléporter jusqu'à 30 pieds vers un espace inoccupé que vous pouvez voir dans le cadre de cette Action bonus. Cette invisibilité dure jusqu'au début de votre prochain tour et se termine tôt immédiatement après avoir effectué un jet d'attaque, infligé des dégâts ou lancé un sort.
+Éclipse inspirée. Lorsque vous prenez une Action bonus pour donner un dé d'Inspiration bardique à une créature, vous pouvez avoir la condition Invisible et vous téléporter jusqu'à 9 mètres vers un espace inoccupé que vous pouvez voir dans le cadre de cette Action bonus. Cette invisibilité dure jusqu'au début de votre prochain tour et se termine tôt immédiatement après avoir effectué un jet d'attaque, infligé des dégâts ou lancé un sort.
 
-Vitalité lunaire. Une fois par tour lorsque vous restaurez des Points de vie à une créature avec un sort, vous pouvez dépenser un dé d'Inspiration bardique et augmenter le nombre de Points de vie restaurés d'un montant égal à un jet du dé d'Inspiration bardique. La Vitesse de la créature augmente également de 10 pieds jusqu'à la fin de son prochain tour.</content>
+Vitalité lunaire. Une fois par tour lorsque vous restaurez des Points de vie à une créature avec un sort, vous pouvez dépenser un dé d'Inspiration bardique et augmenter le nombre de Points de vie restaurés d'un montant égal à un jet du dé d'Inspiration bardique. La Vitesse de la créature augmente également de 3 mètres jusqu'à la fin de son prochain tour.</content>
   <content contentuid="haca3aef8ga626gc323g22acg746bfa4a9426" version="1">Niveau 3 : Savoir primordial</content>
-  <content contentuid="h16bfd443g2ac4gcdcegaa91gcadfccb20761" version="1">Vous apprenez le Druidique et un tour de magie de la liste de sorts du Druide. Il compte comme un sort de Barde pour vous mais ne compte pas dans le nombre de tours de magie que vous connaissez.
+  <content contentuid="h16bfd443g2ac4gcdcegaa91gcadfccb20761" version="1">Vous apprenez le Druidique et un sort mineur de la liste de sorts du Druide. Il compte comme un sort de Barde pour vous mais ne compte pas dans le nombre de sorts mineurs que vous connaissez.
 
 De plus, choisissez l'une des compétences suivantes : Dressage, Perspicacité, Médecine, Nature, Perception ou Survie. Vous avez la maîtrise de cette compétence.</content>
   <content contentuid="h3911c437g16cagdddcgede4gaa0c643aec8c" version="1">Niveau 6 : Bénédictions du clair de lune</content>
   <content contentuid="haa5e73d8ga7e5ge281g8b67gae695bb23d75" version="1">Vous avez toujours le sort Rayon de lune préparé.
 
-Pendant que vous lancez Rayon de lune, une créature de votre choix que vous pouvez voir à 60 pieds ou moins de vous récupère 2d4 Points de vie.
+Pendant que vous lancez Rayon de lune, une créature de votre choix que vous pouvez voir à 18 mètres ou moins de vous récupère 2d4 Points de vie.
 
 Une fois que vous avez utilisé cette fonctionnalité pour modifier un lancer de Rayon de lune, vous ne pouvez plus l'utiliser jusqu'à ce que vous terminiez un Repos long.</content>
   <content contentuid="h4b8c5fb1g0cb0gdf42g5d1bgd60b7110c837" version="1">Éclipse inspirée</content>
-  <content contentuid="h354b3d9ag3986g5438g5c7fg5f7f7196c4c4" version="1">Lorsque vous prenez une Action bonus pour donner un dé d'Inspiration bardique à une créature, vous pouvez avoir la condition Invisible et vous téléporter jusqu'à 30 pieds vers un espace inoccupé que vous pouvez voir dans le cadre de cette Action bonus. Cette invisibilité dure jusqu'au début de votre prochain tour et se termine tôt immédiatement après avoir effectué un jet d'attaque, infligé des dégâts ou lancé un sort.</content>
+  <content contentuid="h354b3d9ag3986g5438g5c7fg5f7f7196c4c4" version="1">Lorsque vous prenez une Action bonus pour donner un dé d'Inspiration bardique à une créature, vous pouvez avoir la condition Invisible et vous téléporter jusqu'à 9 mètres vers un espace inoccupé que vous pouvez voir dans le cadre de cette Action bonus. Cette invisibilité dure jusqu'au début de votre prochain tour et se termine tôt immédiatement après avoir effectué un jet d'attaque, infligé des dégâts ou lancé un sort.</content>
   <content contentuid="ha0ddac76g013eg8574g0831g4fde2e2fef92" version="1">Éclipse inspirée</content>
-  <content contentuid="h976048b3gf9c6gba32g7185g9373737f96b8" version="1">Lorsque vous prenez une Action bonus pour donner un dé d'Inspiration bardique à une créature, vous pouvez avoir la condition Invisible et vous téléporter jusqu'à 30 pieds vers un espace inoccupé que vous pouvez voir dans le cadre de cette Action bonus. Cette invisibilité dure jusqu'au début de votre prochain tour et se termine tôt immédiatement après avoir effectué un jet d'attaque, infligé des dégâts ou lancé un sort.</content>
+  <content contentuid="h976048b3gf9c6gba32g7185g9373737f96b8" version="1">Lorsque vous prenez une Action bonus pour donner un dé d'Inspiration bardique à une créature, vous pouvez avoir la condition Invisible et vous téléporter jusqu'à 9 mètres vers un espace inoccupé que vous pouvez voir dans le cadre de cette Action bonus. Cette invisibilité dure jusqu'au début de votre prochain tour et se termine tôt immédiatement après avoir effectué un jet d'attaque, infligé des dégâts ou lancé un sort.</content>
   <content contentuid="h9f1b45feg3a13g4bccg4842g98f511ae2e02" version="1">Vitalité lunaire</content>
-  <content contentuid="h88fd7cb1g4a94g8ad2g4bf8ga268d1168276" version="1">La Vitesse de la créature augmente également de 10 pieds.</content>
+  <content contentuid="h88fd7cb1g4a94g8ad2g4bf8ga268d1168276" version="1">La Vitesse de la créature augmente également de 3 mètres.</content>
   <content contentuid="h6088fb76ga8b7g5ae5gfb3eg1af90e35d769" version="1">Vitalité lunaire</content>
-  <content contentuid="h81c2cbd1ge2a2g4781g89a2gf1b79723f601" version="1">Une fois par tour lorsque vous restaurez des Points de vie à une créature avec un sort, vous pouvez dépenser un dé d'Inspiration bardique et augmenter le nombre de Points de vie restaurés d'un montant égal à un jet du dé d'Inspiration bardique. La Vitesse de la créature augmente également de 10 pieds jusqu'à la fin de son prochain tour.</content>
+  <content contentuid="h81c2cbd1ge2a2g4781g89a2gf1b79723f601" version="1">Une fois par tour lorsque vous restaurez des Points de vie à une créature avec un sort, vous pouvez dépenser un dé d'Inspiration bardique et augmenter le nombre de Points de vie restaurés d'un montant égal à un jet du dé d'Inspiration bardique. La Vitesse de la créature augmente également de 3 mètres jusqu'à la fin de son prochain tour.</content>
   <content contentuid="hc939b12eg2ee5g197bgc522ga5abc592a4b0" version="1">Vitalité lunaire</content>
   <content contentuid="h97618a1dg57f7g2acfg001dg5ba785249fde" version="1">Bénédictions du clair de lune</content>
-  <content contentuid="h13f755b1gb20cg69d9g98a6g40d319bcab11" version="1">Pendant que vous lancez Rayon de lune, une créature de votre choix que vous pouvez voir à 60 pieds ou moins de vous récupère 2d4 Points de vie.</content>
+  <content contentuid="h13f755b1gb20cg69d9g98a6g40d319bcab11" version="1">Pendant que vous lancez Rayon de lune, une créature de votre choix que vous pouvez voir à 18 mètres ou moins de vous récupère 2d4 Points de vie.</content>
   <content contentuid="h010a539fg50d1ga5d6g15a9g504704ac4e2c" version="1">Porte-bannière</content>
   <content contentuid="h6ea1c6eag9b3dg7479ge12cgb52dd829b0da" version="1">Les Porte-bannières sont des exemples de valeur et de leadership qui protègent les innocents et rallient les aventuriers aux causes de la justice et de la liberté. Beaucoup sont des chevaliers servant en Cormyr, dans les Marches d'Argent, à Damara, à Chessenta ou dans d'autres terres à travers Féérune. Ils errent dans les royaumes en tant que chevaliers errants, portant le combat contre le mal au-delà des frontières de leurs royaumes.
 
@@ -2617,15 +2700,15 @@ Un Porte-bannière s'appuie sur le jugement, la bravoure et la fidélité au cod
   <content contentuid="h40c5a6a5g42eagbba6g5c64g5ece9eb7fe14" version="1">Niveau 3 : Émissaire chevaleresque</content>
   <content contentuid="ha6aeb659gba2ag0648g1d28g8d765621e3a9" version="1">Vous obtenez l'Expertise dans toutes les compétences suivantes : Perspicacité, Intimidation, Persuasion et Représentation.</content>
   <content contentuid="h3f223b42g605egefc2g504ag6ef36cc460ed" version="1">Niveau 3 : Récupération de groupe</content>
-  <content contentuid="ha8111f35ge4bag28bcg4d99g339262b0a595" version="2">Lorsque vous utilisez votre Second souffle pour récupérer des Points de vie, vous pouvez choisir un nombre d'alliés dans une émanation de 30 pieds depuis vous, jusqu'à un nombre d'alliés égal à votre modificateur de Charisme. Chacun de ces alliés récupère des Points de vie égaux à 1d10 + votre niveau de Guerrier.</content>
+  <content contentuid="ha8111f35ge4bag28bcg4d99g339262b0a595" version="2">Lorsque vous utilisez votre Second souffle pour récupérer des Points de vie, vous pouvez choisir un nombre d'alliés dans une émanation de 9 mètres depuis vous, jusqu'à un nombre d'alliés égal à votre modificateur de Charisme. Chacun de ces alliés récupère des Points de vie égaux à 1d10 + votre niveau de Guerrier.</content>
   <content contentuid="hc240e7f1g2979geff6gfcc4g1d63a78b39bd" version="1">Niveau 7 : Tactiques d'équipe</content>
   <content contentuid="h3cc7fa69g03fdgb1f5g1a26g3dbd2b575ce8" version="1">Lorsque vous utilisez la Récupération de groupe, chaque allié choisi a l'Avantage aux Tests d20 jusqu'au début de votre prochain tour.</content>
   <content contentuid="h4def2360g5a4cgbe2fge70fgbe9d99d7fa1f" version="1">Niveau 10 : Sursaut de ralliement</content>
-  <content contentuid="h9e1cff8dg946cga7ccgaeddg5ee4b899b6c6" version="1">Lorsque vous utilisez votre Sursaut d'action, vous pouvez choisir un nombre d'alliés dans une émanation de 30 pieds depuis vous, jusqu'à un nombre d'alliés égal à votre modificateur de Charisme. Chacun de ces alliés bénéficie du Sursaut d'action.</content>
+  <content contentuid="h9e1cff8dg946cga7ccgaeddg5ee4b899b6c6" version="1">Lorsque vous utilisez votre Sursaut d'action, vous pouvez choisir un nombre d'alliés dans une émanation de 9 mètres depuis vous, jusqu'à un nombre d'alliés égal à votre modificateur de Charisme. Chacun de ces alliés bénéficie du Sursaut d'action.</content>
   <content contentuid="h20c820b5g9ed5g6cf5gf004ge0cc7d3c1bb8" version="1">Récupération de groupe</content>
-  <content contentuid="h6bfa7986g7edeg322fgd99egace84461fcf5" version="1">Vous choisissez un nombre d'alliés dans une émanation de 30 pieds depuis vous, jusqu'à un nombre d'alliés égal à votre modificateur de Charisme. Chacun de ces alliés récupère des Points de vie égaux à 1d10 + votre niveau de Guerrier.</content>
+  <content contentuid="h6bfa7986g7edeg322fgd99egace84461fcf5" version="1">Vous choisissez un nombre d'alliés dans une émanation de 9 mètres depuis vous, jusqu'à un nombre d'alliés égal à votre modificateur de Charisme. Chacun de ces alliés récupère des Points de vie égaux à 1d10 + votre niveau de Guerrier.</content>
   <content contentuid="hed379247g311dgc5a8g87cag1e9a14eb6346" version="1">Sursaut de ralliement</content>
-  <content contentuid="h02149e62gbafbgc9c5g274fg20af94229331" version="1">Vous choisissez un nombre d'alliés dans une émanation de 30 pieds depuis vous, jusqu'à un nombre d'alliés égal à votre modificateur de Charisme. Chacun de ces alliés bénéficie de votre Sursaut d'action.</content>
+  <content contentuid="h02149e62gbafbgc9c5g274fg20af94229331" version="1">Vous choisissez un nombre d'alliés dans une émanation de 9 mètres depuis vous, jusqu'à un nombre d'alliés égal à votre modificateur de Charisme. Chacun de ces alliés bénéficie de votre Sursaut d'action.</content>
   <content contentuid="hcc7a8ccdg1f74g8794gabebg481d991a2048" version="1">Tactiques d'équipe</content>
   <content contentuid="hfb637e3bg85b6g0960g0cb5g7005f951cbcd" version="1">A l'Avantage aux Tests d20 jusqu'au début de votre prochain tour.</content>
   <content contentuid="ha112c9d1gc29dg2a81g78e9g5ee83dc15b44" version="1">Niveau 3 : Explorateur du froid</content>
@@ -2676,11 +2759,11 @@ Respectez les éléments, et craignez leur courroux.</content>
 
 Écrasement du dao. La terre se soulève autour de la cible. La cible a la condition Entravé.
 
-Fuite du djinn. Vous vous téléportez vers un espace inoccupé que vous pouvez voir à 30 pieds ou moins de vous et prenez une forme semi-incorporelle, qui dure jusqu'à la fin de votre prochain tour. Pendant cette forme, vous avez la Résistance aux dégâts Contondants, Perforants et Tranchants, et vous avez l'Immunité aux conditions À terre et Entravé.
+Fuite du djinn. Vous vous téléportez vers un espace inoccupé que vous pouvez voir à 9 mètres ou moins de vous et prenez une forme semi-incorporelle, qui dure jusqu'à la fin de votre prochain tour. Pendant cette forme, vous avez la Résistance aux dégâts Contondants, Perforants et Tranchants, et vous avez l'Immunité aux conditions À terre et Entravé.
 
-Fureur de l'éfrit. La cible subit 2d4 dégâts de Feu supplémentaires, et des flammes jaillissent de la cible vers tous les ennemis que vous pouvez voir à 30 pieds ou moins de vous. Chacune de ces créatures subit également 2d4 dégâts de Feu.
+Fureur de l'éfrit. La cible subit 2d4 dégâts de Feu supplémentaires, et des flammes jaillissent de la cible vers tous les ennemis que vous pouvez voir à 9 mètres ou moins de vous. Chacune de ces créatures subit également 2d4 dégâts de Feu.
 
-Déferlement du marid. La cible et chaque créature de votre choix dans une Émanation de 10 pieds depuis vous effectuent un jet de sauvegarde de Force contre votre DD de sauvegarde des sorts. En cas d'échec, une créature est repoussée de 15 pieds directement loin de vous et a la condition À terre.</content>
+Déferlement du marid. La cible et chaque créature de votre choix dans une Émanation de 3 mètres depuis vous effectuent un jet de sauvegarde de Force contre votre DD de sauvegarde des sorts. En cas d'échec, une créature est repoussée de 4,50 mètres directement loin de vous et a la condition À terre.</content>
   <content contentuid="hf359a230g9c7ag4b00g9797g85e2e40e5b9f" version="1">Niveau 3 : Sorts du Génie</content>
   <content contentuid="he0865db7gfb16g94fegbb02gd941d6db835a" version="1">Lorsque vous atteignez certains niveaux de Paladin, la magie du génie garantit que vous avez toujours des sorts spécifiques préparés. Au niveau 3, vous avez toujours Orbe chromatique et Châtiment tonnant préparés. Au niveau 5, vous avez également Image miroir et Force fantomatique préparés. Au niveau 9, vous avez également Vol et Forme gazeuse préparés.</content>
   <content contentuid="h9ef367bcg743fg6596ga14cgdc4842c967b1" version="1">Niveau 3 : Splendeur du Génie</content>
@@ -2692,15 +2775,15 @@ Vous obtenez également la maîtrise d'une des compétences suivantes de votre c
   <content contentuid="h7ce47465gdfeag71dcgb0bdgeadc0c987cab" version="1">Écrasement du dao</content>
   <content contentuid="hb3aa275bga6abgc81agd39bg3d1c211dcc20" version="1">La terre se soulève autour de la cible. La cible a la condition Entravé.</content>
   <content contentuid="hd20d93a6g9ec6gc3cdg1890g0e70817191af" version="2">Fuite du djinn</content>
-  <content contentuid="hc2eacb6dgfdd7gb76ag186cgecc6d2ed93b5" version="1">Vous vous téléportez vers un espace inoccupé que vous pouvez voir à 30 pieds ou moins de vous et prenez une forme semi-incorporelle, qui dure jusqu'à la fin de votre prochain tour. Pendant cette forme, vous avez la Résistance aux dégâts Contondants, Perforants et Tranchants, et vous avez l'Immunité aux conditions À terre et Entravé.</content>
+  <content contentuid="hc2eacb6dgfdd7gb76ag186cgecc6d2ed93b5" version="1">Vous vous téléportez vers un espace inoccupé que vous pouvez voir à 9 mètres ou moins de vous et prenez une forme semi-incorporelle, qui dure jusqu'à la fin de votre prochain tour. Pendant cette forme, vous avez la Résistance aux dégâts Contondants, Perforants et Tranchants, et vous avez l'Immunité aux conditions À terre et Entravé.</content>
   <content contentuid="h41d151e2g9ff2g7903gdcffg74d3df5ec77f" version="2">Fureur de l'éfrit</content>
-  <content contentuid="hbf690b7ag3334g153agbf4dgf3261e437b08" version="2">La cible subit 2d4 dégâts de Feu supplémentaires, et des flammes jaillissent de la cible vers tous les ennemis que vous pouvez voir à 30 pieds ou moins de vous. Chacune de ces créatures subit également 2d4 dégâts de Feu.</content>
+  <content contentuid="hbf690b7ag3334g153agbf4dgf3261e437b08" version="2">La cible subit 2d4 dégâts de Feu supplémentaires, et des flammes jaillissent de la cible vers tous les ennemis que vous pouvez voir à 9 mètres ou moins de vous. Chacune de ces créatures subit également 2d4 dégâts de Feu.</content>
   <content contentuid="h48d5140cg0c24ga6cfg77d7g5b5aac3590e3" version="2">Déferlement du marid</content>
-  <content contentuid="h79a50a5ag645fgfec1g1742g3190589c1ba0" version="1">La cible et chaque créature de votre choix dans une Émanation de 10 pieds depuis vous effectuent un jet de sauvegarde de Force contre votre DD de sauvegarde des sorts. En cas d'échec, une créature est repoussée de 15 pieds directement loin de vous et a la condition À terre.</content>
+  <content contentuid="h79a50a5ag645fgfec1g1742g3190589c1ba0" version="1">La cible et chaque créature de votre choix dans une Émanation de 3 mètres depuis vous effectuent un jet de sauvegarde de Force contre votre DD de sauvegarde des sorts. En cas d'échec, une créature est repoussée de 4,50 mètres directement loin de vous et a la condition À terre.</content>
   <content contentuid="h19a32ab1gef64g369egfeb4ge2bbdbae8999" version="1">Fuite du djinn</content>
-  <content contentuid="h08615922g6a70gfeabg9ddeg3e421bcce131" version="1">Vous vous téléportez vers un espace inoccupé que vous pouvez voir à 30 pieds ou moins de vous et prenez une forme semi-incorporelle, qui dure jusqu'à la fin de votre prochain tour. Pendant cette forme, vous avez la Résistance aux dégâts Contondants, Perforants et Tranchants, et vous avez l'Immunité aux conditions À terre et Entravé.</content>
+  <content contentuid="h08615922g6a70gfeabg9ddeg3e421bcce131" version="1">Vous vous téléportez vers un espace inoccupé que vous pouvez voir à 9 mètres ou moins de vous et prenez une forme semi-incorporelle, qui dure jusqu'à la fin de votre prochain tour. Pendant cette forme, vous avez la Résistance aux dégâts Contondants, Perforants et Tranchants, et vous avez l'Immunité aux conditions À terre et Entravé.</content>
   <content contentuid="h2f104997g62ecgd0e7g3258g0be25d035207" version="1">Fuite du djinn</content>
-  <content contentuid="h2882b8f2g2c4dg9432gc6b0gd97aa3d6ec17" version="1">Vous vous téléportez vers un espace inoccupé que vous pouvez voir à 30 pieds ou moins de vous et prenez une forme semi-incorporelle, qui dure jusqu'à la fin de votre prochain tour. Pendant cette forme, vous avez la Résistance aux dégâts Contondants, Perforants et Tranchants, et vous avez l'Immunité aux conditions À terre et Entravé.</content>
+  <content contentuid="h2882b8f2g2c4dg9432gc6b0gd97aa3d6ec17" version="1">Vous vous téléportez vers un espace inoccupé que vous pouvez voir à 9 mètres ou moins de vous et prenez une forme semi-incorporelle, qui dure jusqu'à la fin de votre prochain tour. Pendant cette forme, vous avez la Résistance aux dégâts Contondants, Perforants et Tranchants, et vous avez l'Immunité aux conditions À terre et Entravé.</content>
   <content contentuid="hab8ce398geb65gdcbbgc14ega6cd5dd5da1c" version="1">Aura de protection élémentaire</content>
   <content contentuid="h9b2090d2g2df9ga6b6g06e6g8c2dc62f5763" version="1">A la Résistance aux dégâts d'Acide, de Froid, de Feu, de Foudre et de Tonnerre.</content>
   <content contentuid="hd699c237g9c18g83b1g6f1dg6cc399770254" version="1">Niveau 3 : Chant de la lame</content>
@@ -2711,14 +2794,14 @@ Le Chant de la lame dure 1 minute et se termine tôt si vous avez la condition N
 Vous pouvez invoquer le Chant de la lame un nombre de fois égal à votre modificateur d'Intelligence (minimum d'une fois), et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long. Vous récupérez une utilisation dépensée lorsque vous utilisez la Récupération arcanique.</content>
   <content contentuid="hcf424f73gfc0dg7cc2gd583ga378200e953d" version="1">Pendant que le Chant de la lame est actif, vous bénéficiez des avantages suivants.
 
-Agilité. Vous gagnez un bonus à votre CA égal à votre modificateur d'Intelligence (minimum de +1), et votre Vitesse augmente de 10 pieds. De plus, vous avez l'Avantage aux tests de Dextérité (Acrobaties).
+Agilité. Vous gagnez un bonus à votre CA égal à votre modificateur d'Intelligence (minimum de +1), et votre Vitesse augmente de 3 mètres. De plus, vous avez l'Avantage aux tests de Dextérité (Acrobaties).
 
 Travail à la lame. Chaque fois que vous attaquez avec une arme pour laquelle vous avez la maîtrise, vous pouvez utiliser votre modificateur d'Intelligence pour les jets d'attaque et de dégâts au lieu d'utiliser la Force ou la Dextérité.
 
 Concentration. Lorsque vous effectuez un jet de sauvegarde de Constitution pour maintenir la Concentration, vous pouvez ajouter votre modificateur d'Intelligence au total.</content>
   <content contentuid="he1fbff1eg96ceg2664g8478gd2144519fd4d" version="1">&lt;LSTag Type="Image" Info="SoftWarning"/&gt; Vous ne pouvez pas porter d'armure ni de bouclier pendant le Chant de la lame.</content>
   <content contentuid="he1710159g6478g8470g4eecg831913a667d2" version="1">&lt;LSTag Type="Image" Info="SoftWarning"/&gt; Vous devez manier une arme dans une main.</content>
-  <content contentuid="h1669b47agf0fagd245g92f2g0e39a2c90370" version="1">Agilité. Vous gagnez un bonus à votre CA égal à votre modificateur d'Intelligence (minimum de +1), et votre Vitesse augmente de 10 pieds. De plus, vous avez l'Avantage aux tests de Dextérité (Acrobaties).
+  <content contentuid="h1669b47agf0fagd245g92f2g0e39a2c90370" version="1">Agilité. Vous gagnez un bonus à votre CA égal à votre modificateur d'Intelligence (minimum de +1), et votre Vitesse augmente de 3 mètres. De plus, vous avez l'Avantage aux tests de Dextérité (Acrobaties).
 
 Travail à la lame. Chaque fois que vous attaquez avec une arme pour laquelle vous avez la maîtrise, vous pouvez utiliser votre modificateur d'Intelligence pour les jets d'attaque et de dégâts au lieu d'utiliser la Force ou la Dextérité.
 
@@ -2738,9 +2821,9 @@ Le Chant de la lame est associé aux anciennes sociétés elfiques qui ont maît
 
 Les Héritiers des Trois sont les plus répandus à Portesombre, où les Trois Morts ont vécu en tant que mortels avant d'accéder à la divinité. Les cultes clandestins de Baine, Bhaal et Myrkul comptent souvent les Héritiers des Trois parmi leurs agents les plus utiles. En dehors de Portesombre, des guildes de voleurs laïques comme les Voleurs de l'Ombre d'Amn ou la Guilde de Xanathar à Eauprofonde pourraient faire appel à un Héritier des Trois pour entreprendre un contrat particulièrement violent.</content>
   <content contentuid="hfffd3126gea34g1eb6g8f8dge04162d1ab9b" version="1">Niveau 3 : Soif de sang</content>
-  <content contentuid="hc8d05a2bgbefbg9d12gb34fg7f2025113439" version="1">Lorsqu'un ennemi que vous pouvez voir à 30 pieds ou moins de vous subit des dégâts et est Entamé après avoir subi ces dégâts sans être tué immédiatement, vous pouvez utiliser votre Réaction et vous téléporter vers un espace inoccupé que vous pouvez voir à 5 pieds ou moins de cet ennemi. Vous pouvez ensuite effectuer une attaque de mêlée. Vous pouvez utiliser cette fonctionnalité un nombre de fois égal à votre modificateur d'Intelligence (minimum d'une fois), et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
+  <content contentuid="hc8d05a2bgbefbg9d12gb34fg7f2025113439" version="1">Lorsqu'un ennemi que vous pouvez voir à 9 mètres ou moins de vous subit des dégâts et est Entamé après avoir subi ces dégâts sans être tué immédiatement, vous pouvez utiliser votre Réaction et vous téléporter vers un espace inoccupé que vous pouvez voir à 1,50 mètre ou moins de cet ennemi. Vous pouvez ensuite effectuer une attaque de mêlée. Vous pouvez utiliser cette fonctionnalité un nombre de fois égal à votre modificateur d'Intelligence (minimum d'une fois), et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
   <content contentuid="h7fa7c6fagab40g7237g2bd1g55927793880a" version="1">Niveau 3 : Allégeance funeste</content>
-  <content contentuid="h717c2effgcfefg6531g04eeg3d6a10c88329" version="2">Vous formez une Allégeance funeste en choisissant l'un des Trois Morts : Baine, Bhaal ou Myrkul. Votre choix vous accorde la Résistance à un type de dégâts spécifique et la capacité de lancer un tour de magie associé, en utilisant l'Intelligence comme capacité d'incantation.
+  <content contentuid="h717c2effgcfefg6531g04eeg3d6a10c88329" version="2">Vous formez une Allégeance funeste en choisissant l'un des Trois Morts : Baine, Bhaal ou Myrkul. Votre choix vous accorde la Résistance à un type de dégâts spécifique et la capacité de lancer un sort mineur associé, en utilisant l'Intelligence comme capacité d'incantation.
 
 Si vous choisissez Baine, vous obtenez la Résistance aux dégâts Psychiques et pouvez lancer Illusion mineure.
 
@@ -2757,14 +2840,14 @@ Vous pouvez changer de déité choisie chaque fois que vous terminez un Repos lo
 La cible Effrayée répète le jet de sauvegarde à la fin de chacun de ses tours, mettant fin à l'effet sur elle-même en cas de succès.</content>
   <content contentuid="ha452dc39g9152gfd66g823bg912ea1d1d763" version="1">Soif de sang</content>
   <content contentuid="h055feb92gbffeg6927gaafbg9aa2a91bc4cb" version="1">Soif de sang (1/2)</content>
-  <content contentuid="hf46c88e2g570bgc9f5g75e9g56ae359baec0" version="1">Lorsqu'une créature que vous pouvez voir à 30 pieds ou moins de vous subit des dégâts et devient Entamée (en dessous de [1]% de ses Points de vie) sans être réduite à 0 Point de vie, vous pouvez utiliser votre Réaction pour vous téléporter vers un espace inoccupé que vous pouvez voir à 5 pieds ou moins de cette créature. Vous pouvez ensuite effectuer une attaque de mêlée contre elle.</content>
+  <content contentuid="hf46c88e2g570bgc9f5g75e9g56ae359baec0" version="1">Lorsqu'une créature que vous pouvez voir à 9 mètres ou moins de vous subit des dégâts et devient Entamée (en dessous de [1]% de ses Points de vie) sans être réduite à 0 Point de vie, vous pouvez utiliser votre Réaction pour vous téléporter vers un espace inoccupé que vous pouvez voir à 1,50 mètre ou moins de cette créature. Vous pouvez ensuite effectuer une attaque de mêlée contre elle.</content>
   <content contentuid="h0f8f6fcfga64egf53bg718egd42ff95fd724" version="1">Soif de sang (1/4)</content>
   <content contentuid="h3afdceeegb918g70fcg89fagf3a2ca1e6ad3" version="1">Soif de sang (1/10)</content>
   <content contentuid="h25f424bdge5bbge3afg2726g10a7f60a2e85" version="1">Attaque sournoise - Soif de sang (1/2)</content>
   <content contentuid="ha3a302a9gfc50gf0b4gf483gbefeaaefaf57" version="1">Attaque sournoise - Soif de sang (1/4)</content>
   <content contentuid="h4b0fe9b5gc4bagd6ecg1fa4g6c637b6c2348" version="1">Attaque sournoise - Soif de sang (1/10)</content>
   <content contentuid="hd359e4cbgb627ga19fg33d9g819888bf29c9" version="1">Allégeance funeste</content>
-  <content contentuid="hed1840dbga25bga18bg158cg2e3656728e43" version="1">Vous formez une Allégeance funeste en choisissant l'un des Trois Morts : Baine, Bhaal ou Myrkul. Votre choix vous accorde la Résistance à un type de dégâts spécifique et la capacité de lancer un tour de magie associé, en utilisant l'Intelligence comme capacité d'incantation.</content>
+  <content contentuid="hed1840dbga25bga18bg158cg2e3656728e43" version="1">Vous formez une Allégeance funeste en choisissant l'un des Trois Morts : Baine, Bhaal ou Myrkul. Votre choix vous accorde la Résistance à un type de dégâts spécifique et la capacité de lancer un sort mineur associé, en utilisant l'Intelligence comme capacité d'incantation.</content>
   <content contentuid="h6d6ec091g6782g7736g3633g063bf2cee187" version="1">Allégeance funeste : Baine</content>
   <content contentuid="h7601f4ccg5ecfg89a8gf4d4gc425820bf2a2" version="1">Si vous choisissez Baine, vous obtenez la Résistance aux dégâts Psychiques et pouvez lancer Illusion mineure.</content>
   <content contentuid="h51a11419g7905g3848gd5bfgf6d72fd1a609" version="1">Allégeance funeste : Bhaal</content>
@@ -2781,9 +2864,9 @@ La cible Effrayée répète le jet de sauvegarde à la fin de chacun de ses tour
   <content contentuid="h5d10607dg8858g0d58gde8bgfe26a1630521" version="1">Niveau 3 : Eruption de flamme-sort</content>
   <content contentuid="h8c1cf02dg530eg20c8ge29dgf4ccedf5993c" version="1">Lorsque vous dépensez au moins 1 Point de sorcellerie dans le cadre d'une action Magique ou d'une Action bonus lors de votre tour, vous pouvez déclencher l'un des effets magiques suivants de votre choix. Vous ne pouvez le faire qu'une seule fois par tour.
 
-Flammes vivifiantes. Vous ou une créature que vous pouvez voir à 30 pieds ou moins de vous gagnez des Points de vie temporaires égaux à 1d4 plus votre modificateur de Charisme.
+Flammes vivifiantes. Vous ou une créature que vous pouvez voir à 9 mètres ou moins de vous gagnez des Points de vie temporaires égaux à 1d4 plus votre modificateur de Charisme.
 
-Feu rayonnant. Une créature que vous pouvez voir à 30 pieds ou moins de vous subit 1d4 dégâts de Feu ou Rayonnants (à votre choix).</content>
+Feu rayonnant. Une créature que vous pouvez voir à 9 mètres ou moins de vous subit 1d4 dégâts de Feu ou Rayonnants (à votre choix).</content>
   <content contentuid="h792eabcbgff7bgb40dg8713g68bba5de6f04" version="1">Niveau 3 : Sorts de flamme-sort</content>
   <content contentuid="h848282acg476egf71fgd7feg17ed2acf814f" version="1">Lorsque vous atteignez certains niveaux d'Ensorceleur, vous avez désormais toujours certains sorts spécifiques préparés. Au niveau 3, vous avez toujours Soin des blessures, Rayon ardent, Restauration inférieure et Projectile enflammé préparés. Au niveau 5, vous avez également Aura de vitalité et Contresort préparés. Au niveau 7, vous avez également Bouclier de feu et Mur de feu préparés. Au niveau 9, vous avez également Grande restauration et Châtiment de flamme préparés.</content>
   <content contentuid="h1381ca97g4947g98bdg940ag252c0d161fbf" version="1">Niveau 6 : Absorption des sorts</content>
@@ -2791,17 +2874,17 @@ Feu rayonnant. Une créature que vous pouvez voir à 30 pieds ou moins de vous s
   <content contentuid="h602c4560gbaadg43f4gca20g38ba13dd40b6" version="1">Eruption de flamme-sort</content>
   <content contentuid="h34d5fc08g03dage117ge30cge3bac9365062" version="1">Lorsque vous dépensez au moins 1 Point de sorcellerie dans le cadre d'une action Magique ou d'une Action bonus lors de votre tour, vous pouvez déclencher l'un des effets magiques suivants de votre choix. Vous ne pouvez le faire qu'une seule fois par tour.
 
-Flammes vivifiantes. Vous ou une créature que vous pouvez voir à 30 pieds ou moins de vous gagnez des Points de vie temporaires égaux à 1d4 plus votre modificateur de Charisme.
+Flammes vivifiantes. Vous ou une créature que vous pouvez voir à 9 mètres ou moins de vous gagnez des Points de vie temporaires égaux à 1d4 plus votre modificateur de Charisme.
 
-Feu rayonnant. Une créature que vous pouvez voir à 30 pieds ou moins de vous subit 1d4 dégâts de Feu ou Rayonnants (à votre choix).</content>
+Feu rayonnant. Une créature que vous pouvez voir à 9 mètres ou moins de vous subit 1d4 dégâts de Feu ou Rayonnants (à votre choix).</content>
   <content contentuid="ha9f42619g46e1gf33agd7f6gca23d5d634b0" version="1">Eruption de flamme-sort</content>
   <content contentuid="h8a4d1ebag9e23g557bg322agfe82662adcaa" version="1">Lorsque vous dépensez au moins 1 Point de sorcellerie dans le cadre d'une action Magique ou d'une Action bonus lors de votre tour, vous pouvez déclencher l'un des effets magiques suivants de votre choix. Vous ne pouvez le faire qu'une seule fois par tour.</content>
   <content contentuid="h33522f06g6cadgaee9g398eg0bd52adb964b" version="1">Flammes vivifiantes</content>
-  <content contentuid="h0ffef888g07e1g2e7dgf090g1e02c22995ae" version="1">Vous ou une créature que vous pouvez voir à 30 pieds ou moins de vous gagnez des Points de vie temporaires égaux à 1d4 plus votre modificateur de Charisme.</content>
+  <content contentuid="h0ffef888g07e1g2e7dgf090g1e02c22995ae" version="1">Vous ou une créature que vous pouvez voir à 9 mètres ou moins de vous gagnez des Points de vie temporaires égaux à 1d4 plus votre modificateur de Charisme.</content>
   <content contentuid="hcbc34c94g87dagca44ge6bcg1c07a081e603" version="1">Feu rayonnant : Feu</content>
-  <content contentuid="h37be3b80g09fbg170eg2b7cg065997dc9bf9" version="1">Une créature que vous pouvez voir à 30 pieds ou moins de vous subit 1d4 dégâts de Feu.</content>
+  <content contentuid="h37be3b80g09fbg170eg2b7cg065997dc9bf9" version="1">Une créature que vous pouvez voir à 9 mètres ou moins de vous subit 1d4 dégâts de Feu.</content>
   <content contentuid="h14663f97g9c94ge2fegb1d6g11e9d19efb32" version="1">Feu rayonnant : Rayonnant</content>
-  <content contentuid="hf4271cc8ge175g82fcg26deg011060d3570a" version="1">Une créature que vous pouvez voir à 30 pieds ou moins de vous subit 1d4 dégâts Rayonnants.</content>
+  <content contentuid="hf4271cc8ge175g82fcg26deg011060d3570a" version="1">Une créature que vous pouvez voir à 9 mètres ou moins de vous subit 1d4 dégâts Rayonnants.</content>
   <content contentuid="h9de61a36g2e2dgb757g472cge372a5d76c6d" version="1">Flammes vivifiantes</content>
   <content contentuid="h5a2f62c0g20c4g7473ge5fagb7ae81549ea5" version="1">Gagne des Points de vie temporaires égaux à 1d4 plus le modificateur de Charisme du lanceur de sorts.</content>
   <content contentuid="hebae72e1ga142gbc3dg8f84ge0a92b2e9d8e" version="1">Sorcellerie de flamme-sort</content>
@@ -2842,33 +2925,33 @@ Au niveau 9 du Tireur d'élite, vos jets d'attaque avec des armes à distance r�
   <content contentuid="hc7fb5801ga410g0b94g4884g81b249ee370c" version="1">Ascendance géante</content>
   <content contentuid="h3f95591ag3b57ge6b7g67dag6b78011d07e5" version="1">Vous descendez des Géants. Choisissez l'un des avantages suivants — un don surnaturel de votre ascendance ; vous pouvez utiliser le bénéfice choisi un nombre de fois égal à votre bonus de maîtrise, et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long :</content>
   <content contentuid="heaf54f1fg5a38gb0bcgce29ga8bbc11c1a24" version="2">Grande forme</content>
-  <content contentuid="h35af86fcg2186gfbc2g672fgcbee62e25113" version="4">Vous pouvez modifier votre taille pour devenir Grande en tant qu'Action bonus si vous vous trouvez dans un espace suffisamment grand. Cette transformation dure 10 minutes ou jusqu'à ce que vous y mettiez fin (aucune action requise). Pendant cette durée, vous avez l'Avantage aux tests de Force, et votre Vitesse augmente de 10 pieds. Une fois que vous avez utilisé ce trait, vous ne pouvez pas l'utiliser à nouveau jusqu'à ce que vous terminiez un Repos long.</content>
+  <content contentuid="h35af86fcg2186gfbc2g672fgcbee62e25113" version="4">Vous pouvez modifier votre taille pour devenir Grande en tant qu'Action bonus si vous vous trouvez dans un espace suffisamment grand. Cette transformation dure 10 minutes ou jusqu'à ce que vous y mettiez fin (aucune action requise). Pendant cette durée, vous avez l'Avantage aux tests de Force, et votre Vitesse augmente de 3 mètres. Une fois que vous avez utilisé ce trait, vous ne pouvez pas l'utiliser à nouveau jusqu'à ce que vous terminiez un Repos long.</content>
   <content contentuid="h423aa2bdgc981gde37g9921g76d99865cb47" version="1">Incursion des nuages</content>
-  <content contentuid="hc2d61264g8816g804bg2a62g2c5d7e343f46" version="1">En tant qu'Action bonus, vous vous téléportez magiquement jusqu'à 30 pieds vers un espace inoccupé que vous pouvez voir.</content>
+  <content contentuid="hc2d61264g8816g804bg2a62g2c5d7e343f46" version="1">En tant qu'Action bonus, vous vous téléportez magiquement jusqu'à 9 mètres vers un espace inoccupé que vous pouvez voir.</content>
   <content contentuid="he859361dg2b9agac3fg2bdcg3f27f7143f6a" version="1">Tonnerre de la tempête</content>
-  <content contentuid="h352899a3g7e44g14c0g1466gcef7fe4c478f" version="1">Lorsque vous subissez des dégâts d'une créature à 60 pieds ou moins de vous, vous pouvez utiliser votre Réaction pour infliger 1d8 dégâts de Tonnerre à cette créature.</content>
+  <content contentuid="h352899a3g7e44g14c0g1466gcef7fe4c478f" version="1">Lorsque vous subissez des dégâts d'une créature à 18 mètres ou moins de vous, vous pouvez utiliser votre Réaction pour infliger 1d8 dégâts de Tonnerre à cette créature.</content>
   <content contentuid="h72da1e02g769fgc8d7g7225g3cd201f1dbdb" version="1">Brûlure du feu</content>
   <content contentuid="hdf8e40d0g3c82gf0f5gdd0aga190d5e39a3e" version="1">Lorsque vous touchez une cible avec un jet d'attaque et lui infligez des dégâts, vous pouvez également lui infliger 1d10 dégâts de Feu.</content>
   <content contentuid="h1d1c4cffgbb73g4ef9g71d5gd8a78baa4388" version="1">Engelure du givre</content>
-  <content contentuid="h49c049d7g63a5ga36cgc3a4g77287ea4217d" version="1">Lorsque vous touchez une cible avec un jet d'attaque et lui infligez des dégâts, vous pouvez également lui infliger 1d6 dégâts de Froid et réduire sa Vitesse de 10 pieds jusqu'au début de votre prochain tour.</content>
+  <content contentuid="h49c049d7g63a5ga36cgc3a4g77287ea4217d" version="1">Lorsque vous touchez une cible avec un jet d'attaque et lui infligez des dégâts, vous pouvez également lui infliger 1d6 dégâts de Froid et réduire sa Vitesse de 3 mètres jusqu'au début de votre prochain tour.</content>
   <content contentuid="hfe86680bged34g3e7ag4b91g82b68408be4c" version="1">Culbute de la colline</content>
   <content contentuid="h7e92df67g8bccg75dcgb550ga5e15856d9d9" version="1">Lorsque vous touchez une créature de taille Grande ou plus petite avec un jet d'attaque et lui infligez des dégâts, vous pouvez lui infliger la condition À terre.</content>
   <content contentuid="h5739f3d4gb5c6g5f9agc4b7g7c8095805ed8" version="1">Endurance de la pierre</content>
   <content contentuid="h62045b01g1a09g4697g2c04gdffed6c1900a" version="1">Lorsque vous subissez des dégâts, vous pouvez utiliser votre Réaction pour lancer 1d12. Ajoutez votre modificateur de Constitution au résultat et réduisez les dégâts de ce total.</content>
   <content contentuid="h0bd2a433g5363g8187gc1ffg0d26612f57e4" version="1">Tonnerre de la tempête</content>
-  <content contentuid="h29815b88g3422g56c3g5aa5gb7806dbe47bc" version="1">Lorsque vous subissez des dégâts d'une créature à 60 pieds ou moins de vous, vous pouvez utiliser votre Réaction pour infliger 1d8 dégâts de Tonnerre à cette créature.</content>
+  <content contentuid="h29815b88g3422g56c3g5aa5gb7806dbe47bc" version="1">Lorsque vous subissez des dégâts d'une créature à 18 mètres ou moins de vous, vous pouvez utiliser votre Réaction pour infliger 1d8 dégâts de Tonnerre à cette créature.</content>
   <content contentuid="h955ac611g781fg6ebfge3d7gd118e6f415a5" version="1">Grande forme</content>
   <content contentuid="hb1577082gdd8ag5ff6g60bcgd99dc936bbc9" version="1">À partir du niveau 5 du personnage, vous pouvez modifier votre taille pour devenir Grande en tant qu'Action bonus si vous vous trouvez dans un espace suffisamment grand. Cette transformation dure 10 minutes.</content>
   <content contentuid="hb1ace68ega6a4gd1e5g3bb4g470b754bbd3b" version="1">Mordre la balle</content>
   <content contentuid="h5c32e99cgde90g115cgb925g8d1863515d98" version="2">Vous pouvez dépenser un Dé de risque pour gagner des Points de vie temporaires égaux au résultat du dé plus votre niveau de Tireur d'élite.</content>
   <content contentuid="h954e64afgfcbegba5ag9418g03aeba64afba" version="1">Tir à l'aveugle</content>
-  <content contentuid="h133443e3g83d1g23b9gaa79g6afa4fd2cc92" version="2">Vous pouvez dépenser un Dé de risque pour obtenir la Vision aveugle d'une portée de 30 pieds jusqu'à la fin du tour actuel.</content>
+  <content contentuid="h133443e3g83d1g23b9gaa79g6afa4fd2cc92" version="2">Vous pouvez dépenser un Dé de risque pour obtenir la Vision aveugle d'une portée de 9 mètres jusqu'à la fin du tour actuel.</content>
   <content contentuid="h6aee83f0gafd8gb807g3a1bg78fbd25f3f9b" version="1">Roulade d'esquive</content>
-  <content contentuid="h811be34fge8e2ga406g6b57gb6eda91fa978" version="2">Vous pouvez dépenser un Dé de risque pour vous déplacer jusqu'à 30 pieds. Ce déplacement ne provoque pas d'Attaques d'opportunité et n'est pas affecté par le Terrain difficile.</content>
+  <content contentuid="h811be34fge8e2ga406g6b57gb6eda91fa978" version="2">Vous pouvez dépenser un Dé de risque pour vous déplacer jusqu'à 9 mètres. Ce déplacement ne provoque pas d'Attaques d'opportunité et n'est pas affecté par le Terrain difficile.</content>
   <content contentuid="h251764bbg0827g7973g1fa1g06a686073a3e" version="1">Mordre la balle</content>
   <content contentuid="h1e6725ecg25f9g4965g6e7dg3fb50e04d1db" version="2">Gain de Points de vie temporaires égaux au résultat du dé de risque plus votre niveau de Tireur d'élite.</content>
   <content contentuid="h86d52560g0e7fga4d6g37b2gbf26b4ebf7bc" version="1">Tir à l'aveugle</content>
-  <content contentuid="h3f23c59cg5062g7897g047dg8aa2c35442a2" version="1">Vous pouvez prendre une Action bonus et dépenser un Dé de risque pour obtenir la Vision aveugle d'une portée de 30 pieds jusqu'à la fin du tour actuel.</content>
+  <content contentuid="h3f23c59cg5062g7897g047dg8aa2c35442a2" version="1">Vous pouvez prendre une Action bonus et dépenser un Dé de risque pour obtenir la Vision aveugle d'une portée de 9 mètres jusqu'à la fin du tour actuel.</content>
   <content contentuid="h0c28325bgfcc5ga21cgf52eg7ebe1e5e3de6" version="1">Dés de risque</content>
   <content contentuid="ha02a83edg0b59g9fadg6c2ag3f1117de4840" version="1">Vous pouvez accomplir des exploits incroyables d'audace alimentés par des dés spéciaux appelés Dés de risque.</content>
   <content contentuid="h181a6b08gd85dg6c1eg30edgfaac60114965" version="1">Tir de grâce</content>
@@ -2912,11 +2995,11 @@ Au niveau 9 du Tireur d'élite, vos jets d'attaque avec des armes à distance r�
   <content contentuid="h99e9e197g55f2g72f5g3b37g75a3f15b60bc" version="1">Vous êtes un expert en armes à feu. Vous pouvez ajouter votre modificateur de caractéristique aux jets de dégâts des attaques d'arme effectuées avec des armes à feu.</content>
   <content contentuid="h4e6ec503g245cg8614g1c81g7087625fa70e" version="1">Expert en armes à feu</content>
   <content contentuid="h86b389a9gfe27g7353g9f20g12d9431a57fa" version="1">Vous êtes un expert en armes à feu. Vous pouvez ajouter votre modificateur de caractéristique aux jets de dégâts des attaques d'arme effectuées avec des armes à feu.</content>
-  <content contentuid="h61b78046g443bg1d02ge5bbgfe44da9ef621" version="4">Mousquet</content>
-  <content contentuid="h4b2511a0g4888gc3ffg4e1fgc9d9ee28927a" version="4">Une arme à feu à long canon conçue pour être utilisée à deux mains, un Mousquet délivre des tirs puissants et précis en tirant un seul projectile lourd sur de longues distances.</content>
+  <content contentuid="h61b78046g443bg1d02ge5bbgfe44da9ef621" version="11">Mousquet</content>
+  <content contentuid="h4b2511a0g4888gc3ffg4e1fgc9d9ee28927a" version="11">Une arme à feu à long canon conçue pour être utilisée à deux mains, un Mousquet délivre des tirs puissants et précis en tirant un seul projectile lourd sur de longues distances.</content>
   <content contentuid="hae35f153g7a35g4565ga666g79bb16da7dd3" version="1">Forme de dragon</content>
   <content contentuid="hb5de1336geb7cg937fg5ba9g13226b34f6df" version="1">Arme du souffle</content>
-  <content contentuid="h82f57f8fg4253ga79egce21gde7d5fe72f73" version="2">Vous pouvez utiliser une action pour exhaler une bouffée d'énergie puissante depuis l'intérieur de vous. Chaque créature dans un cône de 15 pieds doit effectuer un jet de sauvegarde de Dextérité contre votre DD de sauvegarde des sorts. Une créature subit des dégâts de Feu en cas d'échec, ou la moitié en cas de succès.</content>
+  <content contentuid="h82f57f8fg4253ga79egce21gde7d5fe72f73" version="2">Vous pouvez utiliser une action pour exhaler une bouffée d'énergie puissante depuis l'intérieur de vous. Chaque créature dans un cône de 4,50 mètres doit effectuer un jet de sauvegarde de Dextérité contre votre DD de sauvegarde des sorts. Une créature subit des dégâts de Feu en cas d'échec, ou la moitié en cas de succès.</content>
   <content contentuid="h6d46b975ga195gac49gab4cg2ff48ea0ff54" version="1">Votre arme du souffle s'améliore à certains niveaux. Au niveau 6, votre arme du souffle inflige 3d6 dégâts. Au niveau 10, elle inflige 4d6 dégâts.</content>
   <content contentuid="ha7a4dc42gd5c2g913bg0030gb9bacfc6f4d8" version="1">Forme de dragon</content>
   <content contentuid="hea98e86cg6f0eg6fa9gd366g94bd7a432ec2" version="2">Vous pouvez dépenser une utilisation de votre fonctionnalité Forme sauvage en tant qu'Action bonus pour vous transformer en une forme unique : votre Forme de dragon. Vous devenez un dragon de taille Moyenne dans cette forme, debout sur quatre pattes, mais vous conservez vos statistiques et sens normaux de personnage.
@@ -2970,13 +3053,13 @@ Une fois que vous avez lancé le sort avec cette fonctionnalité, vous ne pouvez
   <content contentuid="hb0de3a5fgafe3g904agae5fgdfc2d5a9d82b" version="1">Niveau 3 : Marque inébranlable</content>
   <content contentuid="h39e677d5ged8fgc431g5486g61bd08885fd5" version="1">Vous avez toujours le sort Marque du chasseur préparé. Vous pouvez le lancer un nombre de fois égal à votre modificateur de Force (minimum d'une fois), et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
   <content contentuid="hbb926017g2b0agbe90g66bcgbf207e483612" version="1">Niveau 7 : Manœuvre de protection</content>
-  <content contentuid="ha2bb03e3g700ag8cdagaff7gd4fdd097b625" version="1">Vous apprenez à repousser les frappes dirigées contre vous, votre monture ou d'autres créatures à proximité. Si vous ou une créature que vous pouvez voir à 5 pieds ou moins de vous êtes touché par une attaque, vous pouvez utiliser votre Réaction pour lancer 1d8 si vous maniez une arme de mêlée ou un bouclier. Ajoutez le résultat à la CA de la cible contre cette attaque, la faisant potentiellement rater.</content>
+  <content contentuid="ha2bb03e3g700ag8cdagaff7gd4fdd097b625" version="1">Vous apprenez à repousser les frappes dirigées contre vous, votre monture ou d'autres créatures à proximité. Si vous ou une créature que vous pouvez voir à 1,50 mètre ou moins de vous êtes touché par une attaque, vous pouvez utiliser votre Réaction pour lancer 1d8 si vous maniez une arme de mêlée ou un bouclier. Ajoutez le résultat à la CA de la cible contre cette attaque, la faisant potentiellement rater.</content>
   <content contentuid="hd234d1a5g51feg1581ga07ag43fc0a63f55a" version="1">Niveau 10 : Tenir la ligne</content>
-  <content contentuid="h96dd1a79g41bfg7310gfaedg7ce04dd1acf3" version="1">Vous devenez un maître pour bloquer vos ennemis. Les créatures provoquent une Attaque d'opportunité de votre part lorsqu'elles se déplacent de 5 pieds ou plus dans votre portée, et si vous touchez une créature avec une Attaque d'opportunité, la Vitesse de la cible est réduite à 0 jusqu'à la fin du tour actuel.</content>
+  <content contentuid="h96dd1a79g41bfg7310gfaedg7ce04dd1acf3" version="1">Vous devenez un maître pour bloquer vos ennemis. Les créatures provoquent une Attaque d'opportunité de votre part lorsqu'elles se déplacent de 1,50 mètre ou plus dans votre portée, et si vous touchez une créature avec une Attaque d'opportunité, la Vitesse de la cible est réduite à 0 jusqu'à la fin du tour actuel.</content>
   <content contentuid="h7d3eb606ga301ge0f4g8d8ag0eb706dd27d1" version="1">Manœuvre de protection</content>
-  <content contentuid="he7d011e0gaae4g9343gae55g467fb0606a35" version="1">Vous apprenez à repousser les frappes dirigées contre vous, votre monture ou d'autres créatures à proximité. Si vous ou une créature que vous pouvez voir à 5 pieds ou moins de vous êtes touché par une attaque, vous pouvez utiliser votre Réaction pour lancer 1d8 si vous maniez une arme de mêlée ou un bouclier. Ajoutez le résultat à la CA de la cible contre cette attaque, la faisant potentiellement rater.</content>
+  <content contentuid="he7d011e0gaae4g9343gae55g467fb0606a35" version="1">Vous apprenez à repousser les frappes dirigées contre vous, votre monture ou d'autres créatures à proximité. Si vous ou une créature que vous pouvez voir à 1,50 mètre ou moins de vous êtes touché par une attaque, vous pouvez utiliser votre Réaction pour lancer 1d8 si vous maniez une arme de mêlée ou un bouclier. Ajoutez le résultat à la CA de la cible contre cette attaque, la faisant potentiellement rater.</content>
   <content contentuid="hf11839f6g011fg9755gabadga421a00c9ed3" version="1">Tenir la ligne</content>
-  <content contentuid="h6d3bae27g9034g8149g3867g484287a79d30" version="1">Vous devenez un maître pour bloquer vos ennemis. Les créatures provoquent une Attaque d'opportunité de votre part lorsqu'elles se déplacent de 5 pieds ou plus dans votre portée, et si vous touchez une créature avec une Attaque d'opportunité, la Vitesse de la cible est réduite à 0 jusqu'à la fin du tour actuel.</content>
+  <content contentuid="h6d3bae27g9034g8149g3867g484287a79d30" version="1">Vous devenez un maître pour bloquer vos ennemis. Les créatures provoquent une Attaque d'opportunité de votre part lorsqu'elles se déplacent de 1,50 mètre ou plus dans votre portée, et si vous touchez une créature avec une Attaque d'opportunité, la Vitesse de la cible est réduite à 0 jusqu'à la fin du tour actuel.</content>
   <content contentuid="h19db7115g1409g1483g8306g3b0909c3bde9" version="1">Cavalier</content>
   <content contentuid="h7ac02ad8g0798gdcabg9abag78fd5b57ba92" version="1">Le Cavalier excelle au combat monté. Généralement né parmi la noblesse et élevé à la cour, un Cavalier est tout aussi à l'aise pour mener une charge de cavalerie que pour échanger des reparties lors d'un dîner d'État. Les Cavaliers apprennent également à protéger ceux dont ils ont la charge des dangers, servant souvent de protecteurs à leurs supérieurs et aux plus faibles. Poussés à réparer les torts ou à acquérir du prestige, nombre de ces guerriers quittent leur vie de confort pour s'embarquer dans de glorieuses aventures.</content>
   <content contentuid="h62929300g0a1ag65dcg0311gee7ce76b7030" version="1">Chevalier des runes</content>
@@ -2990,7 +3073,7 @@ Si une rune nécessite un jet de sauvegarde, son DD de sauvegarde est égal à 8
   <content contentuid="h234cd41egb166g8eb3g6939g36498884c3ea" version="1">Niveau 3 : Puissance du géant</content>
   <content contentuid="hffd4abcage782g546dgaeacgc8fe055bd42e" version="2">En tant qu'Action bonus, vous gagnez une puissance semblable à celle d'un géant pendant 1 minute. Vous devenez de taille Grande, avez l'Avantage aux tests de Force et aux jets de sauvegarde de Force, et vos attaques d'arme ou à mains nues infligent 1d6 dégâts supplémentaires lors d'un coup.</content>
   <content contentuid="h2c76a4f7g48d1g3368ga27agbd1576843d8d" version="1">Niveau 7 : Bouclier runique</content>
-  <content contentuid="h9f5052c1ga6c8ga38cg6399gbc4405cf0442" version="2">Vous apprenez à invoquer votre magie runique pour protéger vos alliés. Lorsqu'une autre créature que vous pouvez voir à 60 pieds ou moins de vous est touchée par un jet d'attaque, vous pouvez utiliser votre Réaction pour forcer l'attaquant à relancer le d20 et utiliser le nouveau résultat.</content>
+  <content contentuid="h9f5052c1ga6c8ga38cg6399gbc4405cf0442" version="2">Vous apprenez à invoquer votre magie runique pour protéger vos alliés. Lorsqu'une autre créature que vous pouvez voir à 18 mètres ou moins de vous est touchée par un jet d'attaque, vous pouvez utiliser votre Réaction pour forcer l'attaquant à relancer le d20 et utiliser le nouveau résultat.</content>
   <content contentuid="h4e152278g0424g0354g3000g79c86331ed68" version="1">Niveau 10 : Grande stature</content>
   <content contentuid="hdbd971c9g92f8ga84bg8f1eg267b38cd8ffc" version="1">Les dégâts supplémentaires que vous infligez avec votre fonctionnalité Puissance du géant passent à 1d8.</content>
   <content contentuid="hb3ae9e73g81e6g120dg8548g27684eff651f" version="1">Invoquer la rune de nuage</content>
@@ -3008,19 +3091,19 @@ Si une rune nécessite un jet de sauvegarde, son DD de sauvegarde est égal à 8
   <content contentuid="hea790591g5d78g720ag188bgcefd45615ff0" version="1">Invoquer la rune de colline</content>
   <content contentuid="h5873afb5ga1a1gb7ddgaea4gaf5ab082ffd4" version="1">Vous pouvez invoquer la rune en tant qu'Action bonus, gagnant la Résistance aux dégâts Contondants, Perforants et Tranchants pendant 1 minute.</content>
   <content contentuid="hea634b92g74a3g2000gc22bgfecaeff7c7dd" version="1">Invoquer la rune de tempête</content>
-  <content contentuid="h75559935g2e90ga5d1g57b2g1393773adde2" version="3">Vous pouvez invoquer la rune en tant qu'Action bonus pour entrer dans un état prophétique pendant 1 minute ou jusqu'à ce que vous soyez Neutralisé. Tant que cet état dure, lorsque vous ou une autre créature que vous pouvez voir à 60 pieds ou moins de vous effectuez un jet d'attaque, un jet de sauvegarde ou un test de caractéristique, vous pouvez utiliser votre Réaction pour que le jet ait l'Avantage ou le Désavantage.</content>
+  <content contentuid="h75559935g2e90ga5d1g57b2g1393773adde2" version="3">Vous pouvez invoquer la rune en tant qu'Action bonus pour entrer dans un état prophétique pendant 1 minute ou jusqu'à ce que vous soyez Neutralisé. Tant que cet état dure, lorsque vous ou une autre créature que vous pouvez voir à 18 mètres ou moins de vous effectuez un jet d'attaque, un jet de sauvegarde ou un test de caractéristique, vous pouvez utiliser votre Réaction pour que le jet ait l'Avantage ou le Désavantage.</content>
   <content contentuid="h3d68e61ag18degff1egcb3cg93abd525a72f" version="1">Rune de tempête</content>
-  <content contentuid="h70f68e2egfe60g8371gc262g13645f286d18" version="1">Vous pouvez invoquer la rune en tant qu'Action bonus pour entrer dans un état prophétique pendant 1 minute ou jusqu'à ce que vous soyez Neutralisé. Tant que cet état dure, lorsque vous ou une autre créature que vous pouvez voir à 60 pieds ou moins de vous effectuez un jet d'attaque, un jet de sauvegarde ou un test de caractéristique, vous pouvez utiliser votre Réaction pour que le jet ait l'Avantage ou le Désavantage.</content>
+  <content contentuid="h70f68e2egfe60g8371gc262g13645f286d18" version="1">Vous pouvez invoquer la rune en tant qu'Action bonus pour entrer dans un état prophétique pendant 1 minute ou jusqu'à ce que vous soyez Neutralisé. Tant que cet état dure, lorsque vous ou une autre créature que vous pouvez voir à 18 mètres ou moins de vous effectuez un jet d'attaque, un jet de sauvegarde ou un test de caractéristique, vous pouvez utiliser votre Réaction pour que le jet ait l'Avantage ou le Désavantage.</content>
   <content contentuid="ha67185a5gec5fg7accg1041g41f8330b1d17" version="1">Prophétie de tempête : Désavantage</content>
-  <content contentuid="hf2959cc8g6d39ge50dg36c2gf91080392da0" version="1">Lorsque vous ou une autre créature que vous pouvez voir à 60 pieds ou moins de vous effectuez un jet d'attaque, un jet de sauvegarde ou un test de caractéristique, vous pouvez utiliser votre Réaction pour que le jet ait le Désavantage.</content>
+  <content contentuid="hf2959cc8g6d39ge50dg36c2gf91080392da0" version="1">Lorsque vous ou une autre créature que vous pouvez voir à 18 mètres ou moins de vous effectuez un jet d'attaque, un jet de sauvegarde ou un test de caractéristique, vous pouvez utiliser votre Réaction pour que le jet ait le Désavantage.</content>
   <content contentuid="ha906615bge33ag2df4g32dbg148dd65b9aac" version="1">Prophétie de tempête : Avantage</content>
-  <content contentuid="h80b3909egdd5dg9771g4878g32dff4066380" version="1">Lorsque vous ou une autre créature que vous pouvez voir à 60 pieds ou moins de vous effectuez un jet d'attaque, un jet de sauvegarde ou un test de caractéristique, vous pouvez utiliser votre Réaction pour que le jet ait l'Avantage.</content>
+  <content contentuid="h80b3909egdd5dg9771g4878g32dff4066380" version="1">Lorsque vous ou une autre créature que vous pouvez voir à 18 mètres ou moins de vous effectuez un jet d'attaque, un jet de sauvegarde ou un test de caractéristique, vous pouvez utiliser votre Réaction pour que le jet ait l'Avantage.</content>
   <content contentuid="h1c85d7b8gf5dcge550gda8dgd5776880afb3" version="1">Prophétie de tempête : Avantage</content>
   <content contentuid="h8eb71fdcge67eg9086g4432gf36ff5890bba" version="1">Prophétie de tempête : Désavantage</content>
   <content contentuid="h87466615g2070gcbacg5d8ag5f7ab7b958fe" version="1">Puissance du géant</content>
   <content contentuid="ha0cc673dgbc99ga346g948dg56823a07cb44" version="1">Grandissez en taille pour devenir plus fort.</content>
   <content contentuid="h37b450b1g8badgbc5bg97c2g324b484cc3e8" version="1">Bouclier runique</content>
-  <content contentuid="hc87e44d6gbe9cg19ceg0681g7bf7a87f2bd0" version="1">Vous apprenez à invoquer votre magie runique pour protéger vos alliés. Lorsqu'une autre créature que vous pouvez voir à 60 pieds ou moins de vous est touchée par un jet d'attaque, vous pouvez utiliser votre Réaction pour forcer l'attaquant à relancer le d20 et utiliser le nouveau résultat.</content>
+  <content contentuid="hc87e44d6gbe9cg19ceg0681g7bf7a87f2bd0" version="1">Vous apprenez à invoquer votre magie runique pour protéger vos alliés. Lorsqu'une autre créature que vous pouvez voir à 18 mètres ou moins de vous est touchée par un jet d'attaque, vous pouvez utiliser votre Réaction pour forcer l'attaquant à relancer le d20 et utiliser le nouveau résultat.</content>
   <content contentuid="ha4dc5a17g4a69gb755g889cg187ead2dfb7f" version="1">Puissance du géant</content>
   <content contentuid="h4a3c73bbg633cg224dg4073g6346f0550299" version="1">Grande stature</content>
   <content contentuid="h59e2bd3dg4c8fgb3e9g4be1g17c0354f71d2" version="1">Rune</content>
@@ -3051,11 +3134,11 @@ Si une rune nécessite un jet de sauvegarde, son DD de sauvegarde est égal à 8
   <content contentuid="h4afbde24g3b4ag6245gdfc5gf40fbb6dd7b9" version="1">Niveau 3 : Bang, vous êtes mort !</content>
   <content contentuid="hf051b82fgb193ga37bg540ege6200dcbd93e" version="1">Vous pouvez utiliser la magie à la place des armes à feu.
 
-Pistolets-doigts. Vous apprenez le tour de magie Pistolets-doigts.
+Pistolets-doigts. Vous apprenez le sort mineur Pistolets-doigts.
 
 Tir arcanique. Lorsque vous touchez une cible avec une attaque Pistolets-doigts, vous pouvez dépenser un Dé de risque et l'ajouter au jet de dégâts.</content>
   <content contentuid="h368dfb6eg54d1g9117gae02g8877cb540a10" version="1">Niveau 6 : Tir-sort</content>
-  <content contentuid="hd3836cebg50efg96d2g4884gc1006821d8ef" version="1">Lorsque vous prenez l'action Attaquer lors de votre tour, vous pouvez remplacer l'une des attaques par un lancer d'un de vos tours de magie de Magicien dont le temps d'incantation est une action.</content>
+  <content contentuid="hd3836cebg50efg96d2g4884gc1006821d8ef" version="1">Lorsque vous prenez l'action Attaquer lors de votre tour, vous pouvez remplacer l'une des attaques par un lancer d'un de vos sorts mineurs de Magicien dont le temps d'incantation est une action.</content>
   <content contentuid="ha7014351gc454g307agb356g37500f5752d7" version="1">Niveau 10 : Contre-mage</content>
   <content contentuid="h4b3edb5dg700eg11d2gb46eg867808ec1738" version="2">Votre expérience dans le combat contre les lanceurs de sorts vous accorde les avantages suivants.
 
@@ -3069,9 +3152,9 @@ Aguerri contre la magie. Lorsque vous ratez un jet de sauvegarde contre un sort 
   <content contentuid="h5ef73b58ga233g8fccg4389gcd443dd5c7d7" version="1">Aguerri contre la magie</content>
   <content contentuid="hd771ba94g1544ge8bage691g562f72e6c038" version="1">Lorsque vous ratez un jet de sauvegarde contre un sort ou un effet magique, vous pouvez utiliser votre Réaction pour lancer 1d6 et l'ajouter au jet, transformant potentiellement l'échec en succès.</content>
   <content contentuid="h8b3f5c04g14b9gb9e9ga359g59e1d9f1e059" version="1">Tir perforant</content>
-  <content contentuid="h3ce77d91geeefg513cga446gb56d92a559cd" version="1">Que votre attaque touche ou rate la cible, l'arme ou les munitions se transforment en une Ligne d'énergie magique de 5 pieds de large qui s'étend jusqu'à la portée normale de l'arme. La Ligne inclut la cible initiale de l'attaque. Chaque créature dans la Ligne effectue un jet de sauvegarde de Dextérité, subissant des dégâts de Force égaux aux dégâts normaux de l'arme en cas d'échec, ou la moitié en cas de succès.</content>
+  <content contentuid="h3ce77d91geeefg513cga446gb56d92a559cd" version="1">Que votre attaque touche ou rate la cible, l'arme ou les munitions se transforment en une Ligne d'énergie magique de 1,50 mètre de large qui s'étend jusqu'à la portée normale de l'arme. La Ligne inclut la cible initiale de l'attaque. Chaque créature dans la Ligne effectue un jet de sauvegarde de Dextérité, subissant des dégâts de Force égaux aux dégâts normaux de l'arme en cas d'échec, ou la moitié en cas de succès.</content>
   <content contentuid="hcf85f5ddg214egc39bga0e8g7ee910e3ffec" version="1">Niveau 3 : Faire respecter la loi</content>
-  <content contentuid="h8bee263cg9f25gd0b6gbdeag2013628793ec" version="1">Vous pouvez utiliser votre Réaction lorsqu'un allié que vous pouvez voir à 60 pieds ou moins de vous est touché par une attaque. Dépensez un Dé de risque pour effectuer une attaque d'arme à distance contre l'attaquant. En cas d'utilisation, l'allié gagne des Points de vie temporaires égaux au résultat du Dé de risque.</content>
+  <content contentuid="h8bee263cg9f25gd0b6gbdeag2013628793ec" version="1">Vous pouvez utiliser votre Réaction lorsqu'un allié que vous pouvez voir à 18 mètres ou moins de vous est touché par une attaque. Dépensez un Dé de risque pour effectuer une attaque d'arme à distance contre l'attaquant. En cas d'utilisation, l'allié gagne des Points de vie temporaires égaux au résultat du Dé de risque.</content>
   <content contentuid="h2139a63fg2249g7d98g6477g5d54183f38fa" version="1">Niveau 3 : Regard d'acier</content>
   <content contentuid="h6630050ag4420g70e6g6f4fg79b677ca4518" version="1">Vous gagnez une confiance stoïque qui renforce votre résolution. Vous êtes Immunisé contre la condition Effrayé. Cet avantage est inactif lorsque vous avez la condition Neutralisé.</content>
   <content contentuid="h407e34cdg1410g60d5g4b25g40b46482b638" version="1">Niveau 6 : Viser les étoiles</content>
@@ -3079,7 +3162,7 @@ Aguerri contre la magie. Lorsque vous ratez un jet de sauvegarde contre un sort 
   <content contentuid="h7390394ag82b5g779agf749ga74a63ce3d77" version="1">Niveau 10 : Le long bras de la loi</content>
   <content contentuid="h72f4b7bfg9dc1g5310g811agafb995e4a1c4" version="1">Une fois par tour lorsque vous touchez une créature avec une attaque d'arme à distance, vous pouvez forcer la cible à effectuer un jet de sauvegarde de Force. En cas d'échec, la cible a la condition Entravé pendant 2 tours.</content>
   <content contentuid="haf0939dagb276gb13ag4577g77395d115791" version="1">Faire respecter la loi</content>
-  <content contentuid="hc1e53854g0170gb211geca0geb2971202e92" version="1">Vous pouvez utiliser votre Réaction lorsqu'un allié que vous pouvez voir à 60 pieds ou moins de vous est touché par une attaque. Dépensez un Dé de risque pour effectuer une attaque d'arme à distance contre l'attaquant. En cas d'utilisation, l'allié gagne des Points de vie temporaires égaux au résultat du Dé de risque.</content>
+  <content contentuid="hc1e53854g0170gb211geca0geb2971202e92" version="1">Vous pouvez utiliser votre Réaction lorsqu'un allié que vous pouvez voir à 18 mètres ou moins de vous est touché par une attaque. Dépensez un Dé de risque pour effectuer une attaque d'arme à distance contre l'attaquant. En cas d'utilisation, l'allié gagne des Points de vie temporaires égaux au résultat du Dé de risque.</content>
   <content contentuid="h371a2c88g5d5cg916fgf8e7gbccc5378504c" version="1">Faire respecter la loi</content>
   <content contentuid="hb2138320gcf6dg81c1g3662ge3c4c690607b" version="1">Gagnez des Points de vie temporaires égaux au résultat du dé de risque.</content>
   <content contentuid="h99d927b5gafddg8654g1453g82bbe0c6e89f" version="3">Illrigger</content>
@@ -3087,11 +3170,11 @@ Aguerri contre la magie. Lorsque vous ratez un jet de sauvegarde contre un sort 
 
 Les opérateurs d'élite de ces archidiables sont les illriggers. Chevaliers, assassins, mages et commandos de la terreur de l'Enfer, les illriggers commandent le champ de bataille, perturbent les factions ennemies et exécutent la volonté infernale de leur archidiable.</content>
   <content contentuid="h9b53ce98gbf9cg2509g1a23g24549bd6fad7" version="1">Niveau 1 : Interdit funeste</content>
-  <content contentuid="ha8eaee0fg754dg1d66g293cgf44cc84312b0" version="1">Vous obtenez la capacité de censurer les créatures avec le pouvoir de l'Enfer. Une fois à votre tour, vous pouvez placer un sceau magique sur une créature à 30 pieds ou moins de vous. Vous pouvez soit placer ce sceau lorsque vous touchez cette cible avec une attaque d'arme (aucune action requise), soit utiliser une Action bonus pour placer ce sceau sur une cible que vous pouvez voir à portée. Ce sceau dure jusqu'à ce qu'il soit brûlé. Une créature portant un ou plusieurs de vos sceaux est désignée comme une créature frappée d'interdit.
+  <content contentuid="ha8eaee0fg754dg1d66g293cgf44cc84312b0" version="1">Vous obtenez la capacité de censurer les créatures avec le pouvoir de l'Enfer. Une fois à votre tour, vous pouvez placer un sceau magique sur une créature à 9 mètres ou moins de vous. Vous pouvez soit placer ce sceau lorsque vous touchez cette cible avec une attaque d'arme (aucune action requise), soit utiliser une Action bonus pour placer ce sceau sur une cible que vous pouvez voir à portée. Ce sceau dure jusqu'à ce qu'il soit brûlé. Une créature portant un ou plusieurs de vos sceaux est désignée comme une créature frappée d'interdit.
 
 Vous ne pouvez placer qu'un nombre limité de sceaux avant de vous reposer, et vous récupérez tous les sceaux dépensés lorsque vous terminez un Repos court ou long. Vous pouvez avoir un maximum de trois sceaux au niveau 1, quatre sceaux au niveau 3, et cinq sceaux au niveau 7.
 
-Si une créature frappée d'interdit meurt, vous pouvez utiliser une Action bonus lors de votre tour pour déplacer tous les sceaux qui lui ont été apposés vers une nouvelle créature que vous pouvez voir à 30 pieds ou moins d'elle.</content>
+Si une créature frappée d'interdit meurt, vous pouvez utiliser une Action bonus lors de votre tour pour déplacer tous les sceaux qui lui ont été apposés vers une nouvelle créature que vous pouvez voir à 9 mètres ou moins d'elle.</content>
   <content contentuid="h0294b05egc63bg881age868g1c91eaec6dab" version="1">Sceau</content>
   <content contentuid="hc31eef37gcba0g3dd5g3558g3b4bd0528103" version="1">Vous obtenez la capacité de censurer les créatures avec le pouvoir de l'Enfer.</content>
   <content contentuid="hecedcd5eg3f81g2638g3af5gefcca2c219fb" version="1">Brûler les sceaux : Feu</content>
@@ -3113,19 +3196,19 @@ Une fois que vous atteignez le niveau 5 dans cette classe, votre connexion à vo
   <content contentuid="hb58aa744g9557g7770g99f4g200999b88429" version="2">Niveau 2 : Brutal</content>
   <content contentuid="h58aa4956gcc27g9d75g019cgd0340e796f47" version="2">Niveau 2 : Bravade</content>
   <content contentuid="hb80a53b8gbab4ge493ge6fcg80ca85f5cccd" version="1">Lorsque vous ne portez aucune armure, votre Classe d'armure est égale à 10 + votre modificateur de Dextérité + votre modificateur de Charisme. Vous pouvez utiliser un bouclier et bénéficier quand même de cet avantage.</content>
-  <content contentuid="h69a470cbg07f2g82ddg9603g8091c23a6a5a" version="1">Lorsque vous utilisez votre Interdit funeste pour placer ou brûler un sceau, sa portée est de 60 pieds au lieu de 30 pieds. Lorsque vous obtenez la fonctionnalité Conduit infernal au niveau 6, sa portée est de 30 pieds au lieu du contact.
+  <content contentuid="h69a470cbg07f2g82ddg9603g8091c23a6a5a" version="1">Lorsque vous utilisez votre Interdit funeste pour placer ou brûler un sceau, sa portée est de 18 mètres au lieu de 9 mètres. Lorsque vous obtenez la fonctionnalité Conduit infernal au niveau 6, sa portée est de 9 mètres au lieu du contact.
 
-De plus, effectuer une attaque à distance à 5 pieds ou moins d'une créature hostile n'impose pas le Désavantage au jet d'attaque.</content>
+De plus, effectuer une attaque à distance à 1,50 mètre ou moins d'une créature hostile n'impose pas le Désavantage au jet d'attaque.</content>
   <content contentuid="h67c6cf13g3c76g42a4gfac4g3b887eeb9730" version="1">Lorsque vous touchez une créature avec une attaque d'arme de mêlée, vous pouvez vous déplacer sans provoquer d'Attaques d'opportunité.</content>
   <content contentuid="hdc3b3befg7002g12f7g8757g9c5c9409d33c" version="1">Vous utilisez votre modificateur de Charisme à la place de la Force ou de la Dextérité pour les jets d'attaque et de dégâts que vous effectuez avec des armes de mêlée.</content>
-  <content contentuid="hf1d142d7g41e9g9a72g6d5cgf6c2fa588579" version="2">Vous gagnez un bonus de +1 aux jets de sauvegarde pour chaque créature hostile à 10 pieds ou moins de vous, jusqu'à un bonus maximum de +5.</content>
-  <content contentuid="hdeae353cg3e01gc0ceg92b4g4b51942b775d" version="2">Lorsque vous touchez une créature de taille Grande ou plus petite avec une attaque que vous effectuez avec une arme de mêlée maniée à deux mains, vous pouvez repousser la cible de 10 pieds horizontalement.</content>
+  <content contentuid="hf1d142d7g41e9g9a72g6d5cgf6c2fa588579" version="2">Vous gagnez un bonus de +1 aux jets de sauvegarde pour chaque créature hostile à 3 mètres ou moins de vous, jusqu'à un bonus maximum de +5.</content>
+  <content contentuid="hdeae353cg3e01gc0ceg92b4g4b51942b775d" version="2">Lorsque vous touchez une créature de taille Grande ou plus petite avec une attaque que vous effectuez avec une arme de mêlée maniée à deux mains, vous pouvez repousser la cible de 3 mètres horizontalement.</content>
   <content contentuid="h4645bf49gb7f4g564bgeb3fgfb357d560904" version="1">Maîtrise de combat : Mensonges</content>
   <content contentuid="hd7f9a6ddg5b45gf8acg0d89g98b6c796d969" version="1">Vous utilisez votre modificateur de Charisme à la place de la Force ou de la Dextérité pour les jets d'attaque et de dégâts que vous effectuez avec des armes de mêlée.</content>
   <content contentuid="hb8cf1d46g6834g9baagbf6dg50299be625eb" version="1">Maîtrise de combat</content>
   <content contentuid="h5f2491abg74f5g071bgce31ge29ac76995fd" version="1">Votre archidiable vous accorde une habileté extraordinaire dans une certaine forme de combat. Choisissez l'une des maîtrises de combat d'illrigger suivantes :</content>
   <content contentuid="h67853750g16c0g9b13gc3efgbaba43af6259" version="2">Niveau 2 : Sceau d'atténuation</content>
-  <content contentuid="hddb45062ge037g28d1g354fgec018a665978" version="1">Lorsqu'une créature que vous pouvez voir vous blesse ou blesse un allié à 30 pieds ou moins de vous, vous pouvez dépenser un sceau en tant que Réaction pour réduire les dégâts subis par la cible d'un montant égal à 1d10 + la moitié de votre niveau d'illrigger (arrondi à l'inférieur).</content>
+  <content contentuid="hddb45062ge037g28d1g354fgec018a665978" version="1">Lorsqu'une créature que vous pouvez voir vous blesse ou blesse un allié à 9 mètres ou moins de vous, vous pouvez dépenser un sceau en tant que Réaction pour réduire les dégâts subis par la cible d'un montant égal à 1d10 + la moitié de votre niveau d'illrigger (arrondi à l'inférieur).</content>
   <content contentuid="h565e4f77gf679gd18fgcb9bg38afc492e620" version="2">Niveau 2 : Tourmenter</content>
   <content contentuid="hc60731eeg14f1gbf2egea48g01b6d1ad45e8" version="1">Lorsque vous brûlez un sceau sur une créature frappée d'interdit, vous pouvez activer ce don (aucune action requise). La cible doit soustraire un nombre égal à votre bonus de maîtrise du résultat du jet de sauvegarde qu'elle effectue avant la fin de son prochain tour.</content>
   <content contentuid="h70a4510cgf224gfccfg83dbge051b2c47f34" version="2">Niveau 2 : Dévoreur d'âmes</content>
@@ -3133,11 +3216,13 @@ De plus, effectuer une attaque à distance à 5 pieds ou moins d'une créature h
   <content contentuid="h16cf04ffg2962g897ag364fgea809b7c8c16" version="2">Niveau 2 : Apathie du Styx</content>
   <content contentuid="haa0a6c9agc413g822cg52f2g69c530bc79d2" version="2">Lorsque vous brûlez un sceau sur une créature frappée d'interdit, vous pouvez inonder la cible d'un froid d'un autre monde. Jusqu'à la fin de son prochain tour, elle ne peut pas prendre d'Actions bonus ni de Réactions.</content>
   <content contentuid="hfa888bb3gb8a0ge2a8g81c2g00ae8844f692" version="4">Niveau 7 : Chaîne d'Achéron</content>
-  <content contentuid="h8993f01fgfd8fg8b11g17cdg458c682aad00" version="3">Nécessite le niveau 7 d'Illrigger ou plus.</content>
+  <content contentuid="h8993f01fgfd8fg8b11g17cdg458c682aad00" version="3">Nécessite le niveau 7 d'Illrigger ou plus.
+
+Lorsque vous utilisez une action bonus pour placer ou déplacer un sceau sur une créature de taille Grande ou inférieure, vous pouvez activer ce don (aucune action requise). Vous invoquez des chaînes infernales pour saisir la cible, la forçant à effectuer un jet de sauvegarde de Force. En cas d'échec, vous pouvez soit attirer la créature de 3 mètres vers vous, soit lui imposer la condition Agrippé jusqu'à la fin de votre prochain tour.</content>
   <content contentuid="h4087e43dg1626g7141gb492g08612b1d6f08" version="4">Niveau 7 : Canal embrasé</content>
   <content contentuid="h283a80a7gdc57ge48fg2323g0a19321fd070" version="2">Nécessite le niveau 7 d'Illrigger ou plus.
 
-Vous pouvez dépenser un sceau en tant qu'Action bonus pour vous téléporter jusqu'à 30 pieds vers un espace inoccupé que vous pouvez voir.</content>
+Vous pouvez dépenser un sceau en tant qu'Action bonus pour vous téléporter jusqu'à 9 mètres vers un espace inoccupé que vous pouvez voir.</content>
   <content contentuid="h5ead3298gb213gac53g0d3egaf553c018315" version="4">Niveau 7 : Linceul d'ombre</content>
   <content contentuid="ha9df2c62g25e2g2614g66dagfe3cb0e26aa5" version="2">Nécessite le niveau 7 d'Illrigger ou plus.
 
@@ -3145,18 +3230,18 @@ Vous pouvez dépenser un sceau en tant qu'Action bonus pour tisser un manteau d'
   <content contentuid="hf6bff230g1643g366bg93ffg3c9d643ce07c" version="4">Niveau 7 : Déchaîner l'Enfer</content>
   <content contentuid="h6c2e1510g127eg4a2eg3cbfg9e940ea8f6e8" version="2">Nécessite le niveau 7 d'Illrigger ou plus.
 
-Lorsque vous brûlez un ou plusieurs sceaux sur une créature frappée d'interdit, vous pouvez utiliser votre Réaction pour déclencher une explosion d'énergie infernale autour d'elle. Chaque créature de votre choix à 10 pieds ou moins de la cible doit effectuer un jet de sauvegarde de Dextérité. En cas d'échec, une créature subit la même quantité et le même type de dégâts que les sceaux ont infligés à la créature frappée d'interdit. En cas de succès, une créature subit la moitié des dégâts.</content>
+Lorsque vous brûlez un ou plusieurs sceaux sur une créature frappée d'interdit, vous pouvez utiliser votre Réaction pour déclencher une explosion d'énergie infernale autour d'elle. Chaque créature de votre choix à 3 mètres ou moins de la cible doit effectuer un jet de sauvegarde de Dextérité. En cas d'échec, une créature subit la même quantité et le même type de dégâts que les sceaux ont infligés à la créature frappée d'interdit. En cas de succès, une créature subit la moitié des dégâts.</content>
   <content contentuid="he8bb0a53gb20cg63a2g3f35gf408f22a699e" version="4">Niveau 7 : Tir vengeur</content>
   <content contentuid="h4455cd21gb4e4ga171g4a01gfd22b925fb9b" version="2">Nécessite le niveau 7 d'Illrigger ou plus.
 
-Lorsqu'une créature effectue une attaque à distance contre vous ou un allié que vous pouvez voir à 30 pieds ou moins de vous, vous pouvez dépenser un sceau en tant que Réaction pour effectuer une attaque d'arme à distance contre l'attaquant. Si votre attaque touche, elle inflige des dégâts supplémentaires égaux à la moitié de votre niveau d'illrigger (arrondi à l'inférieur).</content>
+Lorsqu'une créature effectue une attaque à distance contre vous ou un allié que vous pouvez voir à 9 mètres ou moins de vous, vous pouvez dépenser un sceau en tant que Réaction pour effectuer une attaque d'arme à distance contre l'attaquant. Si votre attaque touche, elle inflige des dégâts supplémentaires égaux à la moitié de votre niveau d'illrigger (arrondi à l'inférieur).</content>
   <content contentuid="h368ac3efg0988g4f4ag0fa9g6819e55d1577" version="1">Déchaîner l'Enfer : Feu</content>
   <content contentuid="hebd66c01g7f34g9436g6f68gde5a37620a3f" version="1">Déchaîner l'Enfer : Nécrotique</content>
   <content contentuid="had6ccb0dg99e0ge0b3gfe64g2cc75c0d28a0" version="1">Déchaîner l'Enfer : Feu</content>
-  <content contentuid="heca0b0d3g54dbgf86cg916cg906977301869" version="1">Lorsque vous brûlez un ou plusieurs sceaux sur une créature frappée d'interdit, vous pouvez utiliser votre Réaction pour déclencher une explosion d'énergie infernale autour d'elle. Chaque créature de votre choix à 10 pieds ou moins de la cible doit effectuer un jet de sauvegarde de Dextérité. En cas d'échec, une créature subit la même quantité et le même type de dégâts que les sceaux ont infligés à la créature frappée d'interdit. En cas de succès, une créature subit la moitié des dégâts.</content>
+  <content contentuid="heca0b0d3g54dbgf86cg916cg906977301869" version="1">Lorsque vous brûlez un ou plusieurs sceaux sur une créature frappée d'interdit, vous pouvez utiliser votre Réaction pour déclencher une explosion d'énergie infernale autour d'elle. Chaque créature de votre choix à 3 mètres ou moins de la cible doit effectuer un jet de sauvegarde de Dextérité. En cas d'échec, une créature subit la même quantité et le même type de dégâts que les sceaux ont infligés à la créature frappée d'interdit. En cas de succès, une créature subit la moitié des dégâts.</content>
   <content contentuid="hdad51f43g5e81g7f25g4fa0gb0809a43973d" version="1">Déchaîner l'Enfer : Nécrotique</content>
   <content contentuid="h3518e2eeg9593gae20g3e88gff65f6d3e6bb" version="1">Sceau d'atténuation</content>
-  <content contentuid="h0f8708dbgeff3g4172g8db1g4d944084b8c1" version="1">Lorsqu'une créature que vous pouvez voir vous blesse ou blesse un allié à 30 pieds ou moins de vous, vous pouvez dépenser un sceau en tant que Réaction pour réduire les dégâts subis par la cible d'un montant égal à 1d10 + la moitié de votre niveau d'illrigger (arrondi à l'inférieur).</content>
+  <content contentuid="h0f8708dbgeff3g4172g8db1g4d944084b8c1" version="1">Lorsqu'une créature que vous pouvez voir vous blesse ou blesse un allié à 9 mètres ou moins de vous, vous pouvez dépenser un sceau en tant que Réaction pour réduire les dégâts subis par la cible d'un montant égal à 1d10 + la moitié de votre niveau d'illrigger (arrondi à l'inférieur).</content>
   <content contentuid="he0219d6eg9988g1637g2557g9b2d2d0fa8aa" version="1">Tourmenter</content>
   <content contentuid="hc323cc9cg84e2g474bg5925g8922b79a3ba5" version="1">La cible doit soustraire un nombre égal au bonus de maîtrise de l'Illrigger du résultat du jet de sauvegarde qu'elle effectue avant la fin de son prochain tour.</content>
   <content contentuid="h84a9d67fge555g185dg5c83g4c97364a1cef" version="1">Dévoreur d'âmes</content>
@@ -3172,7 +3257,7 @@ Lorsqu'une créature effectue une attaque à distance contre vous ou un allié q
   <content contentuid="h2702a54eg25d6geee6g89b1g70955d610f89" version="1">Vous pouvez dépenser un sceau en tant qu'Action bonus pour tisser un manteau d'ombres semi-solides autour de vous-même ou d'une créature que vous touchez. La cible gagne un bonus de +2 à la CA pendant 1 minute.</content>
   <content contentuid="h5b9a73a3g7b6fg13b5gc7c3gdf58090d1c36" version="1">Tir vengeur</content>
   <content contentuid="hdcff639cge97ag87c0gca5dgb607adff562c" version="1">Tir vengeur</content>
-  <content contentuid="hc952c432g8c2cgbbacg18f8gfc587dff1d4d" version="1">Lorsqu'une créature effectue une attaque à distance contre vous ou un allié que vous pouvez voir à 30 pieds ou moins de vous, vous pouvez dépenser un sceau en tant que Réaction pour effectuer une attaque d'arme à distance contre l'attaquant. Si votre attaque touche, elle inflige des dégâts supplémentaires égaux à la moitié de votre niveau d'illrigger (arrondi à l'inférieur).</content>
+  <content contentuid="hc952c432g8c2cgbbacg18f8gfc587dff1d4d" version="1">Lorsqu'une créature effectue une attaque à distance contre vous ou un allié que vous pouvez voir à 9 mètres ou moins de vous, vous pouvez dépenser un sceau en tant que Réaction pour effectuer une attaque d'arme à distance contre l'attaquant. Si votre attaque touche, elle inflige des dégâts supplémentaires égaux à la moitié de votre niveau d'illrigger (arrondi à l'inférieur).</content>
   <content contentuid="h2ab85095gd8e1gd4f8g159bg5479bf29202f" version="1">Interdit</content>
   <content contentuid="he346a671g0b23g7417g4182g5a8d53b45077" version="1">Vous pouvez infuser vos sceaux de puissance magique infernale, améliorant leurs effets.
 
@@ -3206,20 +3291,20 @@ Loyauté Récompensée. Mes dons amènent mes alliés à dépendre de moi — et
 
 La Pitié Est Pouvoir. En accordant du secours à mes alliés, je prouve la grandeur de mon pouvoir. Chaque fois que je restaure la vie, cela rappelle à quelle vitesse je peux la retirer.</content>
   <content contentuid="h6266397ag443dg94a5g8c87g09accc415506" version="1">Niveau 3 : Exsanguiner</content>
-  <content contentuid="hacf9fc8fg665eg2cf7g70aaga3d8cc697843" version="2">Vous pouvez drainer les ennemis pour galvaniser vos alliés. Chaque fois que vous brûlez un ou plusieurs sceaux sur une créature, vous pouvez choisir un allié que vous pouvez voir à 30 pieds ou moins de vous. Cet allié gagne des Points de vie temporaires égaux au résultat d'un dé de dégâts de sceau.</content>
+  <content contentuid="hacf9fc8fg665eg2cf7g70aaga3d8cc697843" version="2">Vous pouvez drainer les ennemis pour galvaniser vos alliés. Chaque fois que vous brûlez un ou plusieurs sceaux sur une créature, vous pouvez choisir un allié que vous pouvez voir à 9 mètres ou moins de vous. Cet allié gagne des Points de vie temporaires égaux au résultat d'un dé de dégâts de sceau.</content>
   <content contentuid="hea106602g9f5dg8754g958dg4324799b9073" version="1">Exsanguiner</content>
-  <content contentuid="h8024deb6g1171ge522g2119g5c416be99cb1" version="2">Vous pouvez drainer les ennemis pour galvaniser vos alliés. Chaque fois que vous brûlez un ou plusieurs sceaux sur une créature, vous pouvez choisir un allié que vous pouvez voir à 30 pieds ou moins de vous. Cet allié gagne des Points de vie temporaires égaux au résultat d'un dé de dégâts de sceau.</content>
+  <content contentuid="h8024deb6g1171ge522g2119g5c416be99cb1" version="2">Vous pouvez drainer les ennemis pour galvaniser vos alliés. Chaque fois que vous brûlez un ou plusieurs sceaux sur une créature, vous pouvez choisir un allié que vous pouvez voir à 9 mètres ou moins de vous. Cet allié gagne des Points de vie temporaires égaux au résultat d'un dé de dégâts de sceau.</content>
   <content contentuid="hc90683f4gd5c1g16a2g970bg5f9a7ef90301" version="1">Gagne des Points de vie temporaires.</content>
   <content contentuid="hb5dc95fdga8fdga177gedf9g3d1def6b18b4" version="1">Exsanguiner</content>
-  <content contentuid="h8b8b45b5g6648g381bg1bccg8ba31a12abd5" version="1">Vous pouvez drainer les ennemis pour galvaniser vos alliés. Chaque fois que vous brûlez un ou plusieurs sceaux sur une créature, vous pouvez choisir un allié que vous pouvez voir à 30 pieds ou moins de vous. Cet allié gagne des Points de vie temporaires égaux au résultat d'un dé de dégâts de sceau.</content>
+  <content contentuid="h8b8b45b5g6648g381bg1bccg8ba31a12abd5" version="1">Vous pouvez drainer les ennemis pour galvaniser vos alliés. Chaque fois que vous brûlez un ou plusieurs sceaux sur une créature, vous pouvez choisir un allié que vous pouvez voir à 9 mètres ou moins de vous. Cet allié gagne des Points de vie temporaires égaux au résultat d'un dé de dégâts de sceau.</content>
   <content contentuid="hf1c1d608gab6fgea97g5ce7g12f4e4ddb16c" version="1">Niveau 3 : Bénédiction de Sutekh</content>
   <content contentuid="h16ca83e4gd87cge240g4682g2480a4a6ba19" version="1">Lorsque Sutekh vous accepte comme son illrigger, il vous accorde l'accès à son commandement sacrilège du sang et de la vie. Vous obtenez la maîtrise de la compétence Religion.</content>
   <content contentuid="h08b904f9gd5aeg7159g0bb5g4f1a264718cc" version="1">Niveau 3 : Galvaniser les alliés</content>
-  <content contentuid="h1e93a04fgfcb3ge71cg8edcg9d735d49cff7" version="1">En tant qu'Action bonus, vous restaurez un nombre total de Points de vie égal à cinq fois votre niveau d'illrigger, réparti comme vous le souhaitez entre vous-même et d'autres créatures à 30 pieds ou moins de vous.</content>
+  <content contentuid="h1e93a04fgfcb3ge71cg8edcg9d735d49cff7" version="1">En tant qu'Action bonus, vous restaurez un nombre total de Points de vie égal à cinq fois votre niveau d'illrigger, réparti comme vous le souhaitez entre vous-même et d'autres créatures à 9 mètres ou moins de vous.</content>
   <content contentuid="h3193c1b1g81cegd32cg4ceag8e352d5d18eb" version="1">Galvaniser les alliés</content>
-  <content contentuid="hf94f341dged44gb9bcged64g8666ae8b410e" version="1">En tant qu'Action bonus, vous restaurez un nombre total de Points de vie égal à cinq fois votre niveau d'illrigger, réparti comme vous le souhaitez entre vous-même et d'autres créatures à 30 pieds ou moins de vous.</content>
+  <content contentuid="hf94f341dged44gb9bcged64g8666ae8b410e" version="1">En tant qu'Action bonus, vous restaurez un nombre total de Points de vie égal à cinq fois votre niveau d'illrigger, réparti comme vous le souhaitez entre vous-même et d'autres créatures à 9 mètres ou moins de vous.</content>
   <content contentuid="ha3823257g1d27g9d0egeff1gb7b607bf03f2" version="1">Galvaniser les alliés</content>
-  <content contentuid="h331a5a4cg366cg82a3g63e0g6899f199c8bb" version="1">En tant qu'Action bonus, vous restaurez un nombre total de Points de vie égal à cinq fois votre niveau d'illrigger, réparti comme vous le souhaitez entre vous-même et d'autres créatures à 30 pieds ou moins de vous.</content>
+  <content contentuid="h331a5a4cg366cg82a3g63e0g6899f199c8bb" version="1">En tant qu'Action bonus, vous restaurez un nombre total de Points de vie égal à cinq fois votre niveau d'illrigger, réparti comme vous le souhaitez entre vous-même et d'autres créatures à 9 mètres ou moins de vous.</content>
   <content contentuid="h51e32293ge4aagbb61g14d2g23c2e8863236" version="1">Niveau 7 : Sang pour sang</content>
   <content contentuid="h450bf76dg7e82gc1f2g03a3g2f6003609ae8" version="1">Chaque fois qu'un allié subit des dégâts d'une créature frappée d'interdit, cette créature frappée d'interdit subit des dégâts Nécrotiques égaux à votre bonus de maîtrise.</content>
   <content contentuid="h36291e60ge6ddg0237g008dgbfdf54c658c5" version="1">Sang pour sang</content>
@@ -3284,20 +3369,20 @@ Les Soldats Meurent. Je ne me soucie pas des vies de mes soldats, car ce sont de
   <content contentuid="hdc9bc8a1g4363gafc5g0aa8g3cf81d9f7f39" version="1">Lorsque Dispater vous accepte comme son illrigger, vous obtenez la maîtrise des armures lourdes.</content>
   <content contentuid="h764b69fagcd7ag05fdgf7dag5bd26082ad00" version="2">Niveau 3 : Dévastateur</content>
   <content contentuid="hed5241fcg4e7bg125eg7f8fg43f7f8fbd64a" version="2">Niveau 3 : Grand stratège</content>
-  <content contentuid="hcac28d23geb38gd19fge1c7gd81fdc6dc09b" version="2">Vous pouvez ordonner à vos alliés de suivre votre formation (aucune action requise). Choisissez un nombre de créatures à 60 pieds ou moins de vous pouvant vous entendre, jusqu'à votre bonus de maîtrise. Chaque cible peut immédiatement se déplacer jusqu'à sa Vitesse sans provoquer d'Attaques d'opportunité.</content>
-  <content contentuid="h8dc48af4gcdf0gdb45g88c4g86ba48d298cb" version="1">En tant qu'action, vous invoquez l'autorité de Dispater. Vous effectuez une attaque d'arme et choisissez un nombre de créatures consentantes jusqu'à votre bonus de maîtrise que vous pouvez voir à 30 pieds ou moins de vous. Chaque créature que vous choisissez peut utiliser une Réaction pour effectuer une attaque d'arme ou lancer un tour de magie infligeant des dégâts avec un temps d'incantation de 1 action.
+  <content contentuid="hcac28d23geb38gd19fge1c7gd81fdc6dc09b" version="2">Vous pouvez ordonner à vos alliés de suivre votre formation (aucune action requise). Choisissez un nombre de créatures à 18 mètres ou moins de vous pouvant vous entendre, jusqu'à votre bonus de maîtrise. Chaque cible peut immédiatement se déplacer jusqu'à sa Vitesse sans provoquer d'Attaques d'opportunité.</content>
+  <content contentuid="h8dc48af4gcdf0gdb45g88c4g86ba48d298cb" version="1">En tant qu'action, vous invoquez l'autorité de Dispater. Vous effectuez une attaque d'arme et choisissez un nombre de créatures consentantes jusqu'à votre bonus de maîtrise que vous pouvez voir à 9 mètres ou moins de vous. Chaque créature que vous choisissez peut utiliser une Réaction pour effectuer une attaque d'arme ou lancer un sort mineur infligeant des dégâts avec un temps d'incantation de 1 action.
 
 Une fois que vous avez utilisé cette action, vous ne pouvez plus l'utiliser jusqu'à ce que vous terminiez un Repos court ou long.</content>
   <content contentuid="h9dbc5d36ge613gcbd5ga51cg3c2f03e86ea8" version="2">Niveau 7 : Suprématie de Dispater</content>
   <content contentuid="hb48d28a7g8fd1g0221gb778gd0ba3bcb5fb5" version="1">Vos attaques contre les créatures frappées d'interdit réalisent un Coup critique sur un résultat de 19 ou 20.</content>
   <content contentuid="h1e5932b4g971fg88dcg9f73g49b5740e78e1" version="2">Niveau 11 : Vous mourez sur mon ordre !</content>
-  <content contentuid="h98e2c15eg1bb0g6b5fg7c81ge9b4199a5810" version="1">Lorsqu'un allié à 30 pieds ou moins de vous pouvant vous entendre tombe à 0 Point de vie sans être tué immédiatement, vous pouvez utiliser votre Réaction pour lui crier un ordre, le faisant tomber à 1 Point de vie à la place. Une fois que vous avez utilisé cette Réaction, vous ne pouvez plus le faire jusqu'à ce que vous terminiez un Repos court ou long.</content>
+  <content contentuid="h98e2c15eg1bb0g6b5fg7c81ge9b4199a5810" version="1">Lorsqu'un allié à 9 mètres ou moins de vous pouvant vous entendre tombe à 0 Point de vie sans être tué immédiatement, vous pouvez utiliser votre Réaction pour lui crier un ordre, le faisant tomber à 1 Point de vie à la place. Une fois que vous avez utilisé cette Réaction, vous ne pouvez plus le faire jusqu'à ce que vous terminiez un Repos court ou long.</content>
   <content contentuid="hac72ef57geda5gbcb7gefd0gd8f3ef7ecd35" version="1">Dévastateur</content>
-  <content contentuid="h81b4dc8dg3da9gf440gb6ccgfc1f97fafdf6" version="1">En tant qu'action, vous invoquez l'autorité de Dispater. Vous effectuez une attaque d'arme et choisissez un nombre de créatures consentantes jusqu'à votre bonus de maîtrise que vous pouvez voir à 30 pieds ou moins de vous. Chaque créature que vous choisissez peut utiliser une Réaction pour effectuer une attaque d'arme ou lancer un tour de magie infligeant des dégâts avec un temps d'incantation de 1 action.</content>
+  <content contentuid="h81b4dc8dg3da9gf440gb6ccgfc1f97fafdf6" version="1">En tant qu'action, vous invoquez l'autorité de Dispater. Vous effectuez une attaque d'arme et choisissez un nombre de créatures consentantes jusqu'à votre bonus de maîtrise que vous pouvez voir à 9 mètres ou moins de vous. Chaque créature que vous choisissez peut utiliser une Réaction pour effectuer une attaque d'arme ou lancer un sort mineur infligeant des dégâts avec un temps d'incantation de 1 action.</content>
   <content contentuid="ha7727e9ag0c15g6933gae63g6fa84b4bf2d4" version="1">Grand stratège</content>
-  <content contentuid="h820d0d49g5c04gb627g8857g7f344163dd3d" version="1">Vous pouvez ordonner à vos alliés de suivre votre formation (aucune action requise). Choisissez un nombre de créatures à 60 pieds ou moins de vous pouvant vous entendre, jusqu'à votre bonus de maîtrise. Chaque cible peut immédiatement se déplacer jusqu'à sa Vitesse sans provoquer d'Attaques d'opportunité.</content>
+  <content contentuid="h820d0d49g5c04gb627g8857g7f344163dd3d" version="1">Vous pouvez ordonner à vos alliés de suivre votre formation (aucune action requise). Choisissez un nombre de créatures à 18 mètres ou moins de vous pouvant vous entendre, jusqu'à votre bonus de maîtrise. Chaque cible peut immédiatement se déplacer jusqu'à sa Vitesse sans provoquer d'Attaques d'opportunité.</content>
   <content contentuid="h56bd8cdag4e64g6c53ga757gdf3238045217" version="1">Dévastateur</content>
-  <content contentuid="h33401633g747fg999fg84bcgb4b2b4d7449f" version="1">Peut utiliser une Réaction pour effectuer une attaque d'arme ou lancer un tour de magie infligeant des dégâts avec un temps d'incantation de 1 action.</content>
+  <content contentuid="h33401633g747fg999fg84bcgb4b2b4d7449f" version="1">Peut utiliser une Réaction pour effectuer une attaque d'arme ou lancer un sort mineur infligeant des dégâts avec un temps d'incantation de 1 action.</content>
   <content contentuid="h3ead5e5egb4bfg7aa8g3997g651f56f21c32" version="1">Grand stratège</content>
   <content contentuid="h228f43e7g05d6g74e4g3a8agd9f46890dde0" version="1">Peut immédiatement se déplacer jusqu'à sa Vitesse sans provoquer d'Attaques d'opportunité.</content>
   <content contentuid="h452f19f2ga929gf880gace7g93748aa82758" version="1">Dévastateur : Attaque d'arme de mêlée</content>
@@ -3305,7 +3390,7 @@ Une fois que vous avez utilisé cette action, vous ne pouvez plus l'utiliser jus
   <content contentuid="h744333c6g715ag75dcgbd4dg06fc4b9c2830" version="1">Vous mourez sur mon ordre !</content>
   <content contentuid="h8fa05c7bg2b56g954cgddfag9aa1c78d686f" version="1">Vous mourez sur mon ordre !</content>
   <content contentuid="h28ffe78cgda09gea22ga11cg170716172528" version="2">Vous mourez sur mon ordre !</content>
-  <content contentuid="h47a016e4g2442g9c66ga3b8gb2f05f217dc0" version="2">Lorsqu'un allié à 30 pieds ou moins de vous pouvant vous entendre tombe à 0 Point de vie sans être tué immédiatement, vous pouvez utiliser votre Réaction pour lui crier un ordre, le faisant tomber à 1 Point de vie à la place. Une fois que vous avez utilisé cette Réaction, vous ne pouvez plus le faire jusqu'à ce que vous terminiez un Repos court ou long.</content>
+  <content contentuid="h47a016e4g2442g9c66ga3b8gb2f05f217dc0" version="2">Lorsqu'un allié à 9 mètres ou moins de vous pouvant vous entendre tombe à 0 Point de vie sans être tué immédiatement, vous pouvez utiliser votre Réaction pour lui crier un ordre, le faisant tomber à 1 Point de vie à la place. Une fois que vous avez utilisé cette Réaction, vous ne pouvez plus le faire jusqu'à ce que vous terminiez un Repos court ou long.</content>
   <content contentuid="h4dc2f45dg35b4g1e82ga16cg73f1f783e261" version="1">Analgésique</content>
   <content contentuid="hf1e041c0ga156g608cg02dfg22c1dad1bf3a" version="1">Les soldats de la mort lourdement blindés de l'Enfer, les Analgésiques servent Dispater, menant depuis l'avant chaque grande bataille infernale.
 
@@ -3335,21 +3420,21 @@ L'Hésitation est l'Échec. Bien que je m'appuie habituellement sur des agents, 
   <content contentuid="h07d4538fg06e1g87c9geff7gba8b3b97a65f" version="1">Tueur de l'ombre</content>
   <content contentuid="hf4eda0d1g9d77gcfb5g49f3g7e6523196336" version="1">Les ombres sont votre compagne, vous aidant dans vos exploits. Vous bénéficiez des avantages suivants :
 
-Vous obtenez la vision dans le noir à 60 pieds. Si vous possédez déjà la vision dans le noir, sa portée augmente de 60 pieds.
-Votre vitesse de déplacement augmente de 10 pieds.
+Vous obtenez la vision dans le noir à 18 mètres. Si vous possédez déjà la vision dans le noir, sa portée augmente de 18 mètres.
+Votre vitesse de déplacement augmente de 3 mètres.
 Vous avez l'Avantage aux tests de Dextérité (Discrétion) effectués pour vous cacher. Chaque fois que vous effectuez un jet de sauvegarde de Dextérité pour ne subir que la moitié des dégâts d'un effet, vous ne subissez aucun dégât si vous réussissez le jet de sauvegarde, et la moitié des dégâts si vous échouez.</content>
   <content contentuid="h5265c616g7dacgad00gefc6ge34e7ec6e7f4" version="1">Tueur de l'ombre</content>
   <content contentuid="h9b666f81g3924gf39eg6868gd20519f6b190" version="1">Les ombres sont votre compagne, vous aidant dans vos exploits. Vous bénéficiez des avantages suivants :
 
-Vous obtenez la vision dans le noir à 60 pieds. Si vous possédez déjà la vision dans le noir, sa portée augmente de 60 pieds.
-Votre vitesse de déplacement augmente de 10 pieds.
+Vous obtenez la vision dans le noir à 18 mètres. Si vous possédez déjà la vision dans le noir, sa portée augmente de 18 mètres.
+Votre vitesse de déplacement augmente de 3 mètres.
 Vous avez l'Avantage aux tests de Dextérité (Discrétion) effectués pour vous cacher. Chaque fois que vous effectuez un jet de sauvegarde de Dextérité pour ne subir que la moitié des dégâts d'un effet, vous ne subissez aucun dégât si vous réussissez le jet de sauvegarde, et la moitié des dégâts si vous échouez.</content>
   <content contentuid="h59478469g65f2gdc36g0515g15430765aa77" version="2">Niveau 11 : Tueur de l'ombre</content>
   <content contentuid="hecbd9ffcg2be8gbb16g7102g34164bd0d262" version="2">Les ombres sont votre compagne, vous aidant dans vos exploits. Vous bénéficiez des avantages suivants :
 
-Vous obtenez la vision dans le noir à 60 pieds. Si vous possédez déjà la vision dans le noir, sa portée augmente de 60 pieds.
+Vous obtenez la vision dans le noir à 18 mètres. Si vous possédez déjà la vision dans le noir, sa portée augmente de 18 mètres.
 Vous pouvez voir normalement dans les ténèbres, aussi bien magiques que non magiques.
-Votre vitesse de déplacement augmente de 10 pieds.
+Votre vitesse de déplacement augmente de 3 mètres.
 Vous avez l'Avantage aux tests de Dextérité (Discrétion) effectués pour vous cacher. Chaque fois que vous effectuez un jet de sauvegarde de Dextérité pour ne subir que la moitié des dégâts d'un effet, vous ne subissez aucun dégât si vous réussissez le jet de sauvegarde, et la moitié des dégâts si vous échouez.</content>
   <content contentuid="h2a979e60g8047g338bg7d21g17a10ae143c0" version="2">Vous comprenez le pouvoir de frapper depuis les ombres. Une fois par tour, lorsque vous touchez une créature frappée d'interdit avec une attaque d'arme de mêlée et que vous avez l'Avantage au jet d'attaque, vous pouvez lancer un nombre de d4 égal à votre bonus de maîtrise et infliger des dégâts supplémentaires égaux au total obtenu.</content>
   <content contentuid="h29339e6ag5488gb3c9gf071g0b4a21da192a" version="2">En tant qu'Action bonus, enroulez une corde d'ombre autour de la gorge d'une créature pour commencer à l'&lt;LSTag Type="Status" Tooltip="GARROTE_TARGET_HUMANOID"&gt;Étrangler&lt;/LSTag&gt;.</content>
@@ -3368,7 +3453,7 @@ Les Maîtres des ombres ont juré de ne pas révéler leur véritable allégeanc
   <content contentuid="h913a1845g6aeeg56e5g1083g84f2c46ab26a" version="1">Feu infernal</content>
   <content contentuid="h6ee711f7gf822ge79eg39abg3424b665f17d" version="1">Vous créez une éruption de feu infernal couvant autour d'une créature que vous pouvez voir à portée.</content>
   <content contentuid="h65da4e4ag4859ga026g9095g2e8a3e5e278f" version="1">Lame vengeresse</content>
-  <content contentuid="hee7efdd5g7678gd390g9d02gfa6d6bde145c" version="1">Vous brandissez l'arme utilisée pour lancer le sort et effectuez une attaque de mêlée avec elle contre une créature à 5 pieds ou moins de vous. Si vous touchez, la cible subit les effets normaux de l'attaque d'arme et irradie ensuite une sombre aura d'énergie jusqu'au début de votre prochain tour. Si la cible effectue une attaque ou lance un sort avant cela, elle subit [1] dégâts et le sort prend fin.</content>
+  <content contentuid="hee7efdd5g7678gd390g9d02gfa6d6bde145c" version="1">Vous brandissez l'arme utilisée pour lancer le sort et effectuez une attaque de mêlée avec elle contre une créature à 1,50 mètre ou moins de vous. Si vous touchez, la cible subit les effets normaux de l'attaque d'arme et irradie ensuite une sombre aura d'énergie jusqu'au début de votre prochain tour. Si la cible effectue une attaque ou lance un sort avant cela, elle subit [1] dégâts et le sort prend fin.</content>
   <content contentuid="h849f035fg71b5g26c9g150agde667249cbbd" version="1">Lame vengeresse</content>
   <content contentuid="h0e4fe523gebe1g273cg1125g0d10a917732c" version="1">L'entité affectée subira [1] dégâts lorsqu'elle effectuera une attaque ou lancera un sort.</content>
   <content contentuid="hdbf6d84ag617agac46g1387g023f6c217ca0" version="1">Lame vengeresse</content>
@@ -3410,7 +3495,7 @@ La Magie est à Mes Ordres. La ruse est aussi puissante que l'acier. Je manie le
   <content contentuid="h136b52acg55efge3ecge543gaf51e46232a0" version="1">Lame-magie</content>
   <content contentuid="h79e8f4bbg9c6eg622cg3144g7c3d86633f1e" version="1">Vous pouvez lancer le sort une fois par Repos court sans dépenser une action.</content>
   <content contentuid="ha475d6ebg3a6bgaa0fgbbb4g76088c3aea4b" version="2">Niveau 7 : Versatilité infernale</content>
-  <content contentuid="h31f01a11ge447g9caegdcb4g2adfe1ce29e6" version="1">Une fois par tour, vous pouvez lancer l'un de vos tours de magie d'illrigger à la place de l'une de vos attaques accordées par votre fonctionnalité Attaque supplémentaire.</content>
+  <content contentuid="h31f01a11ge447g9caegdcb4g2adfe1ce29e6" version="1">Une fois par tour, vous pouvez lancer l'un de vos sorts mineurs d'illrigger à la place de l'une de vos attaques accordées par votre fonctionnalité Attaque supplémentaire.</content>
   <content contentuid="h9727eb4bg1c42g18b1gb937gf2efc10d9fec" version="2">Niveau 7 : Sceaux axiomatiques</content>
   <content contentuid="h2bafe613g30e6g3792g15edgaa3d3658c4b6" version="1">Les secrets d'Asmodeus vous permettent d'infuser vos sceaux de puissance manifeste. Lorsque vous brûlez un ou plusieurs sceaux pour infliger des dégâts à une créature, vous pouvez activer ce don (aucune action requise) pour ajouter votre modificateur de Charisme (minimum 1) au jet de dégâts de chaque sceau.</content>
   <content contentuid="h528f5094gf88ag08d3ge649gc14b423059e7" version="2">Niveau 11 : Soumettre</content>
@@ -3420,19 +3505,19 @@ La Magie est à Mes Ordres. La ruse est aussi puissante que l'acier. Je manie le
   <content contentuid="h4272602ag3fa1g398bgb969g13be228622d0" version="1">Obsolète</content>
   <content contentuid="h1fb22109gb584g03f6g66f8g5a967386d305" version="1">Obsolète</content>
   <content contentuid="hd9a3ce8dg39a9gb357gf766g5a7a8e8a2b47" version="1">Initié à la magie : Clerc</content>
-  <content contentuid="h0df39a9dg1cfag178cg75f0g6adabe0323af" version="1">Vous apprenez 2 &lt;LSTag Tooltip="Cantrip"&gt;tours de magie&lt;/LSTag&gt; et un sort de niveau 1 de la liste de sorts de clerc.</content>
+  <content contentuid="h0df39a9dg1cfag178cg75f0g6adabe0323af" version="1">Vous apprenez 2 &lt;LSTag Tooltip="Cantrip"&gt;sorts mineurs&lt;/LSTag&gt; et un sort de niveau 1 de la liste de sorts de clerc.</content>
   <content contentuid="hafe8b652g4e6agf0fdg68cdgfa9f15790432" version="1">Initié à la magie : Druide</content>
-  <content contentuid="h65af80fagec9bg5351g2f9agc30e65db33e7" version="1">Vous apprenez 2 &lt;LSTag Tooltip="Cantrip"&gt;tours de magie&lt;/LSTag&gt; et un sort de niveau 1 de la liste de sorts de druide.</content>
+  <content contentuid="h65af80fagec9bg5351g2f9agc30e65db33e7" version="1">Vous apprenez 2 &lt;LSTag Tooltip="Cantrip"&gt;sorts mineurs&lt;/LSTag&gt; et un sort de niveau 1 de la liste de sorts de druide.</content>
   <content contentuid="hc0b48f30g3f17g3a7fg830dgd6bcb23043d6" version="1">Obsolète</content>
   <content contentuid="h3199ad9dg3293g80a6g74adg1bf55e642821" version="1">Obsolète</content>
   <content contentuid="h14abb3cdgc934g76a7g47aeg2111983c2f7a" version="1">Obsolète</content>
   <content contentuid="hd8bfa253g9a70g0b3dga7f3g8b52b646dc9a" version="1">Obsolète</content>
   <content contentuid="h01e4f65cg7f45g4509g7911g655523dbfc23" version="1">Initié à la magie : Magicien</content>
-  <content contentuid="hf53d0a43g624eg7762g6910g0264f0ae7c73" version="1">Vous apprenez 2 &lt;LSTag Tooltip="Cantrip"&gt;tours de magie&lt;/LSTag&gt; et un sort de niveau 1 de la liste de sorts de magicien.</content>
+  <content contentuid="hf53d0a43g624eg7762g6910g0264f0ae7c73" version="1">Vous apprenez 2 &lt;LSTag Tooltip="Cantrip"&gt;sorts mineurs&lt;/LSTag&gt; et un sort de niveau 1 de la liste de sorts de magicien.</content>
   <content contentuid="hb45ab210g4dfeg44aage273g11ab2c83f7b8" version="1">Sceaux protecteurs</content>
   <content contentuid="hd8757627g198cg4659gbdcbgf8c916e4b023" version="1">Lorsque vous utilisez votre Action bonus pour placer le sceau d'un illrigger sur une créature, ou lorsque vous brûlez un sceau placé sur une créature, vous bénéficiez des effets de Protection des lames pendant 2 tours.</content>
-  <content contentuid="h6fbb1933ge0e0gc26ag9144gcde944d43651" version="1">En tant qu'action magique, vous présentez votre Symbole sacré et dépensez une utilisation de votre Canalisation divine pour émettre un éclair de lumière dans une Émanation de 30 pieds prenant sa source en vous. Toute Obscurité magique — telle que celle créée par le sort Ténèbres — dans cette zone est dissipée. De plus, chaque créature de votre choix dans cette zone doit effectuer un jet de sauvegarde de Constitution, subissant des dégâts Radieux égaux à 2d10 plus votre niveau de clerc en cas d'échec, ou la moitié des dégâts en cas de succès.</content>
-  <content contentuid="h42e7e44fge041g864egc55fgbbdba0e4da67" version="1">Chaque fois que vous subissez des dégâts Radieux, votre attaquant subit des dégâts de Force égaux à son bonus de maîtrise.</content>
+  <content contentuid="h6fbb1933ge0e0gc26ag9144gcde944d43651" version="1">En tant qu'action magique, vous présentez votre Symbole sacré et dépensez une utilisation de votre Conduit divin pour émettre un éclair de lumière dans une Émanation de 9 mètres prenant sa source en vous. Toute Obscurité magique — telle que celle créée par le sort Ténèbres — dans cette zone est dissipée. De plus, chaque créature de votre choix dans cette zone doit effectuer un jet de sauvegarde de Constitution, subissant des dégâts Radiants égaux à 2d10 plus votre niveau de clerc en cas d'échec, ou la moitié des dégâts en cas de succès.</content>
+  <content contentuid="h42e7e44fge041g864egc55fgbbdba0e4da67" version="1">Chaque fois que vous subissez des dégâts Radiants, votre attaquant subit des dégâts de Force égaux à son bonus de maîtrise.</content>
   <content contentuid="h40874a69g2e20g65d7g2444g9bccdb153fa5" version="5">Vrai Nom</content>
   <content contentuid="h00c98c60g1486ge30fge973g756a8dffc456" version="5">"L'arme connue sous le nom de Vrai Nom est liée à l'histoire des Sept Cités. Lorsque des diables forgeaient un pacte, le bénéficiaire scellait son vrai nom dans la lame, la laissant à l'offreur. Si le pacte était rompu, la lame révèle ce nom, accordant un pouvoir sur le traître.
 
@@ -3457,16 +3542,16 @@ J'ai cherché ce nom pendant des siècles. Quand je le trouverai, la lame — et
 
 Allumer. Vous allumez une source lumineuse, comme une bougie, une torche ou un petit feu de camp.
 Éteindre. Vous éteignez une source lumineuse, comme une bougie, une torche ou un petit feu de camp.
-Nettoyer. Vous nettoyez instantanément un objet de taille ne dépassant pas 1 pied cube.</content>
+Nettoyer. Vous nettoyez instantanément un objet de taille ne dépassant pas 30 cm cube.</content>
   <content contentuid="ha1bc5cf5g9a11g73a8g06b2g71e2ab12d1d2" version="1">Vous allumez une source lumineuse, comme une bougie, une torche ou un petit feu de camp.</content>
   <content contentuid="h42a9eafag659dgb810gad4egb8a174c73524" version="1">Vous éteignez une source lumineuse, comme une bougie, une torche ou un petit feu de camp.</content>
-  <content contentuid="ha704fba0g722ag5d54g1576g599bf886f456" version="1">Vous nettoyez instantanément un objet de taille ne dépassant pas 1 pied cube.</content>
+  <content contentuid="ha704fba0g722ag5d54g1576g599bf886f456" version="1">Vous nettoyez instantanément un objet de taille ne dépassant pas 30 cm cube.</content>
   <content contentuid="h1a950eaag6cb3g9b5cgfb98gc721a9abd164" version="1">Invoquer un fée : Bonnet rouge</content>
   <content contentuid="h7223d543gf408g50fagb634g0ce2909ad820" version="1">Pas féérique</content>
   <content contentuid="ha15a12feg6a51ge73cg4860ged2d9bd42e58" version="1">Bonus de caractéristique de lancement de sorts de l'invocateur</content>
   <content contentuid="hbc64cea5g7abcg4ee4g6f8cg7e90db0c0465" version="1">Invoquer une bête : Aigle géant</content>
   <content contentuid="h05ec30e1g135dg784fg23d3gbe0b26cab88f" version="1">Niveau 3 : Illusions améliorées</content>
-  <content contentuid="h6ac5e4a1g208fg4753g01cegcda7a5d0e025" version="2">Vous pouvez lancer des sorts d'Illusion sans fournir de composantes Verbales. De plus, lorsque vous lancez un sort d'Illusion avec une portée de 10 pieds ou plus, sa portée augmente de 50 %. Vous pouvez lancer &lt;LSTag Type="Spell" Tooltip="Target_ImprovedMinorIllusion"&gt;Illusion mineure&lt;/LSTag&gt; en tant qu'Action bonus.</content>
+  <content contentuid="h6ac5e4a1g208fg4753g01cegcda7a5d0e025" version="2">Vous pouvez lancer des sorts d'Illusion sans fournir de composantes Verbales. De plus, lorsque vous lancez un sort d'Illusion avec une portée de 3 mètres ou plus, sa portée augmente de 50 %. Vous pouvez lancer &lt;LSTag Type="Spell" Tooltip="Target_ImprovedMinorIllusion"&gt;Illusion mineure&lt;/LSTag&gt; en tant qu'Action bonus.</content>
   <content contentuid="hacd218b6g8afbg65f2g4b21g9d52b7e777f8" version="1">Niveau 6 : Créatures fantasmatiques</content>
   <content contentuid="h9ec6f533ga820gcfd6g8b9fgb737db30a70b" version="2">Vous avez toujours les sorts Invoquer une bête et Invoquer un fée préparés. Vous pouvez lancer la version Illusion de chaque sort sans dépenser d'emplacement de sort. Une fois que vous avez lancé l'un ou l'autre sort sans emplacement de sort, vous devez terminer un Repos long avant de pouvoir lancer le sort de cette façon à nouveau.</content>
   <content contentuid="h6057aef1gc72eg192ag3affgca7098f7a4c4" version="1">Invoquer une bête : Aigle géant (Illusion)</content>
@@ -3480,7 +3565,7 @@ Armure naturelle. Vous avez des écailles, des plaques ou une peau épaisse qui 
 
 Armes naturelles. Vous avez des griffes, des crocs, des cornes ou quelque autre arme naturelle que vous pouvez utiliser pour effectuer des Frappes à mains nues qui infligent 1d6 dégâts sur un coup.
 
-Vision nocturne. Vous avez la Vision dans le noir avec une portée de 60 pieds. Si vous avez déjà la Vision dans le noir, sa portée augmente de 30 pieds.</content>
+Vision nocturne. Vous avez la Vision dans le noir avec une portée de 18 mètres. Si vous avez déjà la Vision dans le noir, sa portée augmente de 9 mètres.</content>
   <content contentuid="ha288579eg93c9g19b4gd809gcbf44c5b3b6b" version="1">Don : Torseur de charmes</content>
   <content contentuid="h02d99bfegfef1g8e2dg60b7g277ac219dbc2" version="1">Vous connaissez des remèdes populaires et des malédictions transmis par les enseignements des Vieilles Voies, et vous pouvez les impartir dans de petits charmes en osier que vous tissez. Vous bénéficiez des avantages suivants.
 
@@ -3488,19 +3573,19 @@ Vous avez toujours les sorts Bénédiction et Maléfice préparés. De plus, vou
   <content contentuid="h62e3caedgde0fgd173g13ddg989c09ea72d8" version="1">Don : Gardien des tombes</content>
   <content contentuid="he41177dagaf29g13c8gc756g66414bcb409d" version="1">L'étude des rites funéraires et le soin du repos des morts ont fait de vous un conduit entre les mondes des vivants et des morts. Vous bénéficiez des avantages suivants.
 
-Canalisation divine. Vous gagnez une utilisation de la fonctionnalité Canalisation divine de la classe de Clerc, et vous pouvez créer l'effet Renvoi des morts-vivants avec elle. Si vous avez déjà une Canalisation divine, vous ajoutez cette utilisation à la fonctionnalité d'une classe de votre choix.</content>
+Conduit divin. Vous gagnez une utilisation de la fonctionnalité Conduit divin de la classe de Clerc, et vous pouvez créer l'effet Renvoi des morts-vivants avec elle. Si vous avez déjà un Conduit divin, vous ajoutez cette utilisation à la fonctionnalité d'une classe de votre choix.</content>
   <content contentuid="h5edcd5f5g2597g4cb6g5ebcg6f37e6b6f496" version="1">Expérience</content>
   <content contentuid="h2ba4fa20gb5a4gcf6fg0c48g86e73cad2928" version="1">Don : Altéré
 
 Vous avez été altéré de façon permanente d'une manière drastique et physique, peut-être même rendu monstrueux. Une fusion blasphématoire de science, d'alchimie et de magie vous a changé, peut-être pour guérir une maladie irrécupérable, ou pour tester les limites de votre biologie. Le processus fut un succès, du moins jusqu'à un certain point, mais le changement a laissé sa marque sur vous. La déformation indélébile de votre forme peut être une source de peur pour ceux qui ne comprennent pas ce qu'ils voient.
 
-Altéré. Vous gagnez une armure naturelle (CA 10 + modificateurs de Dextérité et de Constitution), des armes naturelles (frappes à mains nues de 1d6) et la vision dans le noir jusqu'à 60 pieds (ou +30 pieds si vous l'avez déjà).</content>
+Altéré. Vous gagnez une armure naturelle (CA 10 + modificateurs de Dextérité et de Constitution), des armes naturelles (frappes à mains nues de 1d6) et la vision dans le noir jusqu'à 18 mètres (ou +9 mètres si vous l'avez déjà).</content>
   <content contentuid="h8de8eb2bg4b97gfd23gf17fg132f6e2c9157" version="1">Gardien du Repos</content>
   <content contentuid="h7d405f4ag1770gee29gfd7egc0479b1be286" version="1">Don : Gardien des tombes
 
 Dans un endroit plus proche des terres des morts que des vivants, ceux qui veillent sur le repos éternel et la disposition des défunts sont tenus dans un mélange d'haute estime et d'appréhension. Vous avez exercé le métier de fossoyeur, de croque-mort et d'embaumeur. Il y a des moments où vous avez été le seul à dire un mot aimable en l'honneur de ceux qui sont partis. Les déprédations des Morts-vivants vous sont bien connues, et vous ne tolérez pas leur ingérence dans le repos de vos charges.
 
-Gardien des tombes. Vous gagnez une utilisation de la fonctionnalité Canalisation divine de la classe de Clerc, et vous pouvez créer l'effet Renvoi des morts-vivants avec elle. Si vous avez déjà une Canalisation divine, vous ajoutez cette utilisation à la fonctionnalité d'une classe de votre choix.</content>
+Gardien des tombes. Vous gagnez une utilisation de la fonctionnalité Conduit divin de la classe de Clerc, et vous pouvez créer l'effet Renvoi des morts-vivants avec elle. Si vous avez déjà un Conduit divin, vous ajoutez cette utilisation à la fonctionnalité d'une classe de votre choix.</content>
   <content contentuid="h49b1f4ebg0b80g1cbbg3266g01728d057db5" version="1">Don : Sorcellerie rapide</content>
   <content contentuid="h485ec73fg065ag11a4g6c56g26237d4aa777" version="1">Don : Défiant la mort</content>
   <content contentuid="h04a42f0bg5327gaeb5gd711g78bbff1f0780" version="1">Si un effet vous tuerait directement sans jets de sauvegarde contre la mort ou vous réduirait directement à 0 Point de vie sans infliger de dégâts, vous êtes à la place réduit à un nombre de Points de vie égal à votre niveau. Vous ne pouvez plus utiliser cet avantage jusqu'à ce que vous terminiez un Repos long.</content>
@@ -3526,11 +3611,13 @@ Armure naturelle. Vous avez des écailles, des plaques ou une peau épaisse qui 
 
 Armes naturelles. Vous avez des griffes, des crocs, des cornes ou quelque autre arme naturelle que vous pouvez utiliser pour effectuer des Frappes à mains nues qui infligent 1d6 dégâts sur un coup.
 
-Vision nocturne. Vous avez la Vision dans le noir avec une portée de 60 pieds. Si vous avez déjà la Vision dans le noir, sa portée augmente de 30 pieds.</content>
+Vision nocturne. Vous avez la Vision dans le noir avec une portée de 18 mètres. Si vous avez déjà la Vision dans le noir, sa portée augmente de 9 mètres.</content>
   <content contentuid="h83fd0391g6b2fgac96ga1a2gb0b7edabeb3b" version="1">Vous connaissez des remèdes populaires et des malédictions transmis par les enseignements des Vieilles Voies, et vous pouvez les impartir dans de petits charmes en osier que vous tissez. Vous bénéficiez des avantages suivants.
 
 Vous avez toujours les sorts Bénédiction et Maléfice préparés. De plus, vous gagnez un emplacement de sort de niveau 1 qui peut être utilisé pour les lancer.</content>
-  <content contentuid="h894a8c5dg5c28g7d23gb198gb51499628687" version="1">L'étude des rites funéraires et le soin du repos des morts ont fait de vous un conduit entre les mondes des vivants et des morts. Vous bénéficiez des avantages suivants.</content>
+  <content contentuid="h894a8c5dg5c28g7d23gb198gb51499628687" version="1">L'étude des rites funéraires et le soin du repos des morts ont fait de vous un conduit entre les mondes des vivants et des morts. Vous bénéficiez des avantages suivants.
+
+Canal divin. Vous gagnez une utilisation de la fonctionnalité Conduit divin de la classe de Clerc, et vous pouvez créer l'effet Renvoi des morts-vivants avec elle. Si vous avez déjà Conduit divin, vous ajoutez cette utilisation à la fonctionnalité d'une classe de votre choix.</content>
   <content contentuid="h09b18db4g2c3fg8d01g01b6g0d3e69735925" version="1">Si un effet vous tuerait directement sans jets de sauvegarde contre la mort ou vous réduirait directement à 0 Point de vie sans infliger de dégâts, vous êtes à la place réduit à un nombre de Points de vie égal à votre niveau. Vous ne pouvez plus utiliser cet avantage jusqu'à ce que vous terminiez un Repos long.</content>
   <content contentuid="h46ad0c90g0874gdcd5g9dbdg6328d1abaf2f" version="1">Vous pouvez lancer plus d'un sort qui utilise un emplacement de sort pendant votre tour.</content>
   <content contentuid="h8c3059c7g991dgb256g6789g777eedf802cd" version="1">Domaine Astral</content>
@@ -3539,16 +3626,16 @@ Vous avez toujours les sorts Bénédiction et Maléfice préparés. De plus, vou
   <content contentuid="h6da1597ag642dg0e69g9c1cg73fd7e25fe9f" version="1">Niveau 3 : Sorts du Domaine Astral</content>
   <content contentuid="h1b7aecd7g65c1g83b6g50ddg7fe12c1c16a8" version="1">Votre connexion au Domaine Astral garantit que vous avez toujours certains sorts préparés. Lorsque vous atteignez des niveaux de Clerc spécifiques, comme indiqué dans le tableau des sorts du Domaine Astral, vous gagnez automatiquement les sorts listés et ils sont toujours préparés pour vous. Au 3e niveau, vous gagnez Flou, Trait de lumière, Invisibilité, Foulée allongée et Feu follet stellaire. Au 5e niveau, vous gagnez Clignotement et Lenteur. Au 7e niveau, vous gagnez Bannissement et Porte dimensionnelle. Au 9e niveau, vous gagnez Dissipation du bien et du mal et Mur de pierre.</content>
   <content contentuid="h84a93262ga4eag809fg7a75gd6a9a6da35cf" version="1">Niveau 3 : Créer un vide</content>
-  <content contentuid="h520a3350gab70g330fge64fgd34f7914b820" version="1">En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Canalisation divine pour ouvrir une déchirure planaire en un point que vous pouvez voir à 60 pieds ou moins de vous, créant un puissant vide dans une Sphère de 15 pieds de rayon centrée sur ce point. Chaque créature dans la zone doit effectuer un jet de sauvegarde de Dextérité. En cas d'échec, une créature subit des dégâts de Force égaux à 1d8 plus votre niveau de clerc et est tirée jusqu'à 15 pieds vers le point. En cas de succès, une créature ne subit que la moitié des dégâts de Force. La déchirure disparaît ensuite.</content>
+  <content contentuid="h520a3350gab70g330fge64fgd34f7914b820" version="1">En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Conduit divin pour ouvrir une déchirure planaire en un point que vous pouvez voir à 18 mètres ou moins de vous, créant un puissant vide dans une Sphère de 4,50 mètres de rayon centrée sur ce point. Chaque créature dans la zone doit effectuer un jet de sauvegarde de Dextérité. En cas d'échec, une créature subit des dégâts de Force égaux à 1d8 plus votre niveau de clerc et est tirée jusqu'à 4,50 mètres vers le point. En cas de succès, une créature ne subit que la moitié des dégâts de Force. La déchirure disparaît ensuite.</content>
   <content contentuid="hf2358cb4g9ac5g070fg4962g945473af7540" version="1">Niveau 3 : Portée planaire</content>
-  <content contentuid="hea8f653bga035g6444ga74bg7a2cc46f5a2b" version="1">Vous pouvez créer et atteindre à travers de brèves brèches dans le tissu de la réalité. Lorsque vous lancez un sort ayant une portée de Toucher, vous pouvez lui donner une portée de 30 pieds à la place. Vous pouvez utiliser cette fonctionnalité un nombre de fois égal à votre modificateur de Sagesse (minimum une fois), et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
+  <content contentuid="hea8f653bga035g6444ga74bg7a2cc46f5a2b" version="1">Vous pouvez créer et atteindre à travers de brèves brèches dans le tissu de la réalité. Lorsque vous lancez un sort ayant une portée de Toucher, vous pouvez lui donner une portée de 9 mètres à la place. Vous pouvez utiliser cette fonctionnalité un nombre de fois égal à votre modificateur de Sagesse (minimum une fois), et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
   <content contentuid="h02d3ddc5gfa53g6d67g4b7cgfd71aa6b71d7" version="1">Niveau 6 : Échange spatial</content>
-  <content contentuid="h15e226b3g215bge214g85e0gbbc2eafde5c5" version="1">Vous avez toujours le sort Pas brumeux préparé. Vous pouvez le lancer en dépensant une utilisation de votre Canalisation divine plutôt qu'un emplacement de sort. Lorsque vous le lancez de cette façon, vous pouvez choisir un espace à 30 pieds ou moins de vous occupé par une créature. Si cette créature est consentante, vous vous téléportez tous les deux, échangeant vos places ; cet effet échoue s'il n'y a pas assez de place pour vous ou la créature pour vous téléporter là.</content>
+  <content contentuid="h15e226b3g215bge214g85e0gbbc2eafde5c5" version="1">Vous avez toujours le sort Pas brumeux préparé. Vous pouvez le lancer en dépensant une utilisation de votre Conduit divin plutôt qu'un emplacement de sort. Lorsque vous le lancez de cette façon, vous pouvez choisir un espace à 9 mètres ou moins de vous occupé par une créature. Si cette créature est consentante, vous vous téléportez tous les deux, échangeant vos places ; cet effet échoue s'il n'y a pas assez de place pour vous ou la créature pour vous téléporter là.</content>
   <content contentuid="h0058e102gbba8ge20eg2cd0gc0bfb13819ea" version="1">Créer un vide</content>
-  <content contentuid="h62513dd3g7a62g4659g151cg25df749019af" version="1">En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Canalisation divine pour ouvrir une déchirure planaire en un point que vous pouvez voir à 60 pieds ou moins de vous, créant un puissant vide dans une Sphère de 15 pieds de rayon centrée sur ce point. Chaque créature dans la zone doit effectuer un jet de sauvegarde de Dextérité. En cas d'échec, une créature subit des dégâts de Force égaux à 1d8 plus votre niveau de clerc et est tirée jusqu'à 15 pieds vers le point. En cas de succès, une créature ne subit que la moitié des dégâts de Force. La déchirure disparaît ensuite.</content>
+  <content contentuid="h62513dd3g7a62g4659g151cg25df749019af" version="1">En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Conduit divin pour ouvrir une déchirure planaire en un point que vous pouvez voir à 18 mètres ou moins de vous, créant un puissant vide dans une Sphère de 4,50 mètres de rayon centrée sur ce point. Chaque créature dans la zone doit effectuer un jet de sauvegarde de Dextérité. En cas d'échec, une créature subit des dégâts de Force égaux à 1d8 plus votre niveau de clerc et est tirée jusqu'à 4,50 mètres vers le point. En cas de succès, une créature ne subit que la moitié des dégâts de Force. La déchirure disparaît ensuite.</content>
   <content contentuid="h9ce455eag578bgd8baged3cg2295ac52dd7b" version="1">Portée planaire</content>
   <content contentuid="hc2e55bdeg5106gd40agd099gff2986e993e4" version="1">Échange spatial</content>
-  <content contentuid="h8e4177f4g16c3g3fc7g9a6eg1f1682c821e8" version="1">Vous pouvez choisir un espace à 30 pieds ou moins de vous occupé par une créature. Si cette créature est consentante, vous vous téléportez tous les deux, échangeant vos places.</content>
+  <content contentuid="h8e4177f4g16c3g3fc7g9a6eg1f1682c821e8" version="1">Vous pouvez choisir un espace à 9 mètres ou moins de vous occupé par une créature. Si cette créature est consentante, vous vous téléportez tous les deux, échangeant vos places.</content>
   <content contentuid="h42221b4agb3bdgef46gaa3ag9261ebba0bea" version="1">Cercle des Indomptés</content>
   <content contentuid="h7620f19ag43c9g05a4g36acg0cd45d849578" version="1">Le Cercle des Indomptés est un ordre de Druides qui ont abandonné les enseignements patients de leurs prédécesseurs, décidant plutôt de prendre les armes pour défendre les contrées sauvages. Ces Druides combatifs forment des milices et exploitent la fureur de la nature elle-même pour chasser de force tout mal envahissant qui menace leurs terres sacrées.
 
@@ -3564,7 +3651,7 @@ Au 3e niveau, vous avez toujours Frappe des rets, Gourdin, Frappe brillante et F
   <content contentuid="h7fe6e3e8gb94ag15c5g406eg227fcfa3c807" version="1">Niveau 6 : Maîtrise du Gourdin</content>
   <content contentuid="h7e8ca440g858fg8122g6567g8dbda7a1b2f0" version="1">Vous pouvez attaquer deux fois avec l'arme au lieu d'une seule fois lorsque vous effectuez l'action Attaquer à votre tour.</content>
   <content contentuid="hd5f1b8cag18ffgb6f6g47ffg3b8c0b38f590" version="1">Niveau 10 : Druide de guerre</content>
-  <content contentuid="hf86fda08gd41fg7378gec9bg99ec11e5214f" version="1">Lorsque vous effectuez l'action Attaquer à votre tour, vous pouvez remplacer l'une des attaques par le lancement de l'un de vos tours de magie de Druide dont le temps d'incantation est une action.</content>
+  <content contentuid="hf86fda08gd41fg7378gec9bg99ec11e5214f" version="1">Lorsque vous effectuez l'action Attaquer à votre tour, vous pouvez remplacer l'une des attaques par le lancement de l'un de vos sorts mineurs de Druide dont le temps d'incantation est une action.</content>
   <content contentuid="h33d907d8gd0a0gaee7g061fg578448183f33" version="1">Gourdin amélioré</content>
   <content contentuid="h698d6323ge92fg1fd9g8d8bg36d7db994d94" version="1">Récupération sauvage</content>
   <content contentuid="hc24409fagede8g0aaag1ad3g32c2949bb667" version="2">En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Forme sauvage pour récupérer un nombre de Points de vie égal à 2d6 plus votre niveau de Druide. Cette guérison augmente de 1d6 lorsque vous atteignez les niveaux de Druide 5 (3d6 plus votre niveau de Druide) et 10 (4d6 plus votre niveau de Druide).</content>
@@ -3583,7 +3670,7 @@ Création d'un objet. Lorsque vous terminez un Repos long, vous pouvez créer un
 
 Lorsque vous atteignez le 6e et le 10e niveau dans cette classe, le nombre d'objets magiques que vous pouvez créer à la fin d'un Repos long passe à trois et quatre, respectivement.</content>
   <content contentuid="h37074410gf258g6103g5302g429531067671" version="1">Niveau 7 : Éclair de génie</content>
-  <content contentuid="h470004cfg4199g24dfg3a04ge1085900eaf7" version="2">Lorsque vous ou une créature que vous pouvez voir à 30 pieds ou moins de vous ratez un jet de sauvegarde, vous pouvez prendre une Réaction pour ajouter un bonus au résultat, le faisant potentiellement réussir. Le bonus est égal à votre modificateur d'Intelligence (minimum de +1).
+  <content contentuid="h470004cfg4199g24dfg3a04ge1085900eaf7" version="2">Lorsque vous ou une créature que vous pouvez voir à 9 mètres ou moins de vous ratez un jet de sauvegarde, vous pouvez prendre une Réaction pour ajouter un bonus au résultat, le faisant potentiellement réussir. Le bonus est égal à votre modificateur d'Intelligence (minimum de +1).
 
 Vous pouvez prendre cette Réaction un nombre de fois égal à votre modificateur d'Intelligence (minimum une fois). Vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
   <content contentuid="h1dd30fd2g8d32g2cf1g4cbdg6df0134f3697" version="1">Niveau 11 : Objet stockant des sorts</content>
@@ -3629,7 +3716,7 @@ La création de chaque objet magique répliqué nécessite que vous ayez atteint
   <content contentuid="h0824e195g8da3g869egd6degc36598f5aef9" version="1">Le porteur peut percevoir les créatures invisibles.</content>
   <content contentuid="h01a7e7b1gea71g6833g6445g5ed1f1a2308b" version="1">Éclair de génie</content>
   <content contentuid="h80f08a5dg837cg81beg15d7g69a6566d7630" version="1">Éclair de génie</content>
-  <content contentuid="h19fba472g52a7gb564g247bg818863c03630" version="1">Lorsque vous ou une créature que vous pouvez voir à 30 pieds ou moins de vous ratez un jet de sauvegarde, vous pouvez prendre une Réaction pour ajouter un bonus au résultat, le faisant potentiellement réussir. Le bonus est égal à votre modificateur d'Intelligence (minimum de +1).
+  <content contentuid="h19fba472g52a7gb564g247bg818863c03630" version="1">Lorsque vous ou une créature que vous pouvez voir à 9 mètres ou moins de vous ratez un jet de sauvegarde, vous pouvez prendre une Réaction pour ajouter un bonus au résultat, le faisant potentiellement réussir. Le bonus est égal à votre modificateur d'Intelligence (minimum de +1).
 
 Vous pouvez prendre cette Réaction un nombre de fois égal à votre modificateur d'Intelligence (minimum une fois). Vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
   <content contentuid="h5c3ca15ege3b3ga7adg9a8fg26776947cb0a" version="1">Reproduire un objet magique</content>
@@ -3713,30 +3800,32 @@ Lorsque vous atteignez certains niveaux d'Artificier, vous pouvez préparer un �
 
 Beaucoup de barbares qui suivent cette voie le font pour absorber en eux-mêmes la magie des ombres néfaste afin de protéger les autres de son influence. Un groupe plus restreint consomme l'ombre simplement parce qu'ils ne peuvent résister à sa tentation omniprésente.</content>
   <content contentuid="h69753443g4b64g24dfg671fg01f0a6c73022" version="1">Niveau 3 : Fumée d'ombre</content>
-  <content contentuid="h214e9d1dg45fcg6388gdc9cg6130d7c87cf2" version="2">Pendant que vous êtes en Rage, une fois par tour, vous pouvez émettre des vrilles de fumée d'ombre. La fumée s'étend à 10 pieds de vous dans toutes les directions. Toute créature autre que vous se trouvant dans la fumée est Aveuglée.</content>
+  <content contentuid="h214e9d1dg45fcg6388gdc9cg6130d7c87cf2" version="2">Pendant que vous êtes en Rage, une fois par tour, vous pouvez émettre des vrilles de fumée d'ombre. La fumée s'étend à 3 mètres de vous dans toutes les directions. Toute créature autre que vous se trouvant dans la fumée est Aveuglée.</content>
   <content contentuid="h491afa5eg7b34g23f1g71d1gd3a73f1a0484" version="1">Fumée d'ombre</content>
-  <content contentuid="hc17eba4eg936fg2851g0508gb73011778121" version="1">Pendant que vous êtes en Rage, une fois par tour, vous pouvez émettre des vrilles de fumée d'ombre. La fumée s'étend à 10 pieds de vous dans toutes les directions. Toute créature autre que vous se trouvant dans la fumée est Aveuglée.</content>
+  <content contentuid="hc17eba4eg936fg2851g0508gb73011778121" version="1">Pendant que vous êtes en Rage, une fois par tour, vous pouvez émettre des vrilles de fumée d'ombre. La fumée s'étend à 3 mètres de vous dans toutes les directions. Toute créature autre que vous se trouvant dans la fumée est Aveuglée.</content>
   <content contentuid="h99712a6fge628ga06eg47b4ga89071e28928" version="1">Brouillard rampant</content>
   <content contentuid="hba39350fgd122gc25bgbeaegca4f83c67943" version="1">Téléportez-vous vers un endroit inoccupé et obscurci. Avant ou après la téléportation, vous pouvez effectuer une attaque.</content>
   <content contentuid="h941c15f0g2e60g0e9fg218dge166bea3e8ed" version="1">Consommer les ténèbres</content>
   <content contentuid="h1a71759egf1c8g9a25g2327g7210d3bcea88" version="1">Pendant votre Rage, vous pouvez vous nourrir des ombres autour de vous pour restaurer votre vitalité. Dans une lumière faible ou les ténèbres, vous pouvez utiliser une Action bonus pour récupérer des Points de vie égaux à 1d12 + votre modificateur de Constitution.</content>
   <content contentuid="h69bf67ebgf486g254dg8139gcbbd39d66230" version="2">Niveau 6 : Brouillard rampant</content>
-  <content contentuid="h158135d1g6fa7g983eg619eg5cb15bc27602" version="1">Vous pouvez vous désintégrer en une brume d'ombre brute puis vous réassembler ailleurs. En tant qu'action, vous vous téléportez magiquement, avec tout l'équipement que vous portez ou transportez, jusqu'à 30 pieds vers un espace inoccupé et obscurci que vous pouvez voir. Avant ou après la téléportation, vous pouvez effectuer une attaque.</content>
+  <content contentuid="h158135d1g6fa7g983eg619eg5cb15bc27602" version="1">Vous pouvez vous désintégrer en une brume d'ombre brute puis vous réassembler ailleurs. En tant qu'action, vous vous téléportez magiquement, avec tout l'équipement que vous portez ou transportez, jusqu'à 9 mètres vers un espace inoccupé et obscurci que vous pouvez voir. Avant ou après la téléportation, vous pouvez effectuer une attaque.</content>
   <content contentuid="he97e3b0fg6f9cg22aag0fc7gb7945f9ceb17" version="1">Niveau 10 : Consommer les ténèbres</content>
   <content contentuid="h4d7a4652g2bf4gcf0dg7e2bg038ddc3b14d4" version="1">Pendant votre Rage, vous pouvez vous nourrir des ombres autour de vous pour restaurer votre vitalité. Dans une lumière faible ou les ténèbres, vous pouvez utiliser une Action bonus pour récupérer des Points de vie égaux à 1d12 + votre modificateur de Constitution.</content>
   <content contentuid="hf54abe92g0c59g3206g795cg205f29ea03b8" version="1">Une arme que vous tenez est imprégnée de la puissance de la nature. Pour la durée, vous pouvez utiliser votre caractéristique de lancement de sorts à la place de la Force pour les jets d'attaque et de dégâts des attaques de mêlée avec cette arme, et le dé de dégâts de l'arme devient un d8. Si l'attaque inflige des dégâts, il s'agit de dégâts de Force.
 
-Le sort prend fin prématurément si vous le lancez à nouveau ou si vous lâchez l'arme.</content>
+Le sort prend fin prématurément si vous le lancez à nouveau ou si vous lâchez l'arme.
+
+Amélioration de sort mineur. Le dé de dégâts change lorsque vous atteignez les niveaux 5 (d10), 10 (d12).</content>
   <content contentuid="hf61e69c2g84a1g28cdg2869gee89659329d6" version="1">Un Gourdin ou un Bâton que vous tenez est imprégné de la puissance de la nature. Pour la durée, vous pouvez utiliser votre caractéristique de lancement de sorts à la place de la Force pour les jets d'attaque et de dégâts des attaques de mêlée avec cette arme, et le dé de dégâts de l'arme devient un d8. Si l'attaque inflige des dégâts, il s'agit de dégâts de Force.
 
 Le sort prend fin prématurément si vous le lancez à nouveau ou si vous lâchez l'arme.
 
-Amélioration de tour de magie. Le dé de dégâts change lorsque vous atteignez les niveaux 5 (d10), 10 (d12).</content>
+Amélioration de sort mineur. Le dé de dégâts change lorsque vous atteignez les niveaux 5 (d10), 10 (d12).</content>
   <content contentuid="h925aafd9gec3fg0bb7g12d0g081af9525fe1" version="1">Nécessite l'harmonisation par un Paladin</content>
   <content contentuid="h345d4909g3905g0fc0g06eag48597d9a0ed4" version="1">Avenger sacré</content>
   <content contentuid="ha4f758dfga2beg1ec7gcda5g49ccf54aa751" version="4">Nécessite l'harmonisation par un Paladin.
 
-Lorsque vous touchez un Fiélon ou un Mort-vivant avec lui, cette créature subit 1d10 dégâts Radieux supplémentaires. Pendant que vous tenez l'arme dégainée, elle crée une Émanation de 10 pieds prenant sa source en vous. Vous et toutes les créatures qui vous sont Favorables dans l'Émanation avez la &lt;LSTag Tooltip="Resistant"&gt;Résistance&lt;/LSTag&gt; aux dégâts des sorts.</content>
+Lorsque vous touchez un Fiélon ou un Mort-vivant avec lui, cette créature subit 1d10 dégâts Radiants supplémentaires. Pendant que vous tenez l'arme dégainée, elle crée une Émanation de 3 mètres prenant sa source en vous. Vous et toutes les créatures qui vous sont Favorables dans l'Émanation avez la &lt;LSTag Tooltip="Resistant"&gt;Résistance&lt;/LSTag&gt; aux dégâts des sorts.</content>
   <content contentuid="h88763505g272bg1df5g5d45gfa5ef421bfec" version="3">Avenger sacré</content>
   <content contentuid="h82e54036g01e7gb257g91ffg62632d82ab08" version="3">Un avenger sacré était un type rare d'épée forgé pour combattre le mal sous toutes ses formes. Ils étaient très prisés par les paladins de tous les Royaumes. Ils possédaient de grands et magnifiques pouvoirs qui n'étaient pleinement réalisés qu'entre les mains d'un saint guerrier bienveillant.
 
@@ -3759,7 +3848,7 @@ Chaque modèle comprend une arme spéciale. Lorsque vous attaquez avec cette arm
   <content contentuid="hcc906553g972bg8298gd9cfga6a42e0fdb7c" version="2">Vous pouvez personnaliser votre Armure arcanique. Ce faisant, choisissez l'un des modèles d'armure suivants : Dreadnaught, Gardien ou Infiltrateur. Le modèle que vous choisissez vous accorde des avantages spéciaux pendant que vous le portez. Chaque modèle comprend une arme spéciale. Lorsque vous attaquez avec cette arme, vous pouvez ajouter votre modificateur d'Intelligence, à la place de votre modificateur de Force ou de Dextérité, aux jets d'attaque et de dégâts.</content>
   <content contentuid="he2a10ea7ge923ge756g16a5gec995e896057" version="1">Vous concevez votre armure pour en faire un colosse redoutable au combat. Elle possède les caractéristiques suivantes :
 
-Démolisseur de Force. Une masse destructrice ou un marteau de forgeron arcanique dépasse de votre armure. Le démolisseur compte comme une arme de mêlée simple dotée de la propriété Allonge, et il inflige 1d10 dégâts de Force sur un coup. Si vous touchez une créature d'au moins une taille inférieure à la vôtre avec le démolisseur, vous pouvez la repousser jusqu'à 10 pieds en ligne droite loin de vous ou la tirer jusqu'à 10 pieds vers vous.
+Démolisseur de Force. Une masse destructrice ou un marteau de forgeron arcanique dépasse de votre armure. Le démolisseur compte comme une arme de mêlée simple dotée de la propriété Allonge, et il inflige 1d10 dégâts de Force sur un coup. Si vous touchez une créature d'au moins une taille inférieure à la vôtre avec le démolisseur, vous pouvez la repousser jusqu'à 3 mètres en ligne droite loin de vous ou la tirer jusqu'à 3 mètres vers vous.
 Stature de géant. En tant qu'Action bonus, vous transformez et agrandissez votre armure pendant 1 minute.</content>
   <content contentuid="h59b9ca7dgb3a7g13d9gaca8g5cb0cc11512f" version="1">Vous concevez votre armure pour être en première ligne du conflit. Elle possède les caractéristiques suivantes :
 
@@ -3768,14 +3857,14 @@ Champ défensif. Lorsque vous êtes Ensanglanté, vous pouvez prendre une Action
   <content contentuid="h9d97ea6eg0369g70aag3edegb0ac7465f9b3" version="3">Vous personnalisez votre armure pour des missions plus discrètes. Elle possède les caractéristiques suivantes :
 
 Lance-éclairs. Un nœud semblable à une gemme apparaît sur votre armure, à partir duquel vous pouvez tirer des éclairs. Le lanceur compte comme une arme à distance simple, et il inflige 1d6 dégâts Foudre sur un coup. Une fois par tour, lorsque vous touchez une créature avec le lanceur, vous pouvez lui infliger 1d6 dégâts Foudre supplémentaires.
-Pas motorisés. Votre Vitesse augmente de 5 pieds.
+Pas motorisés. Votre Vitesse augmente de 1,50 mètre.
 Champ d'atténuation. Vous avez l'Avantage aux tests de Dextérité (Discrétion).</content>
   <content contentuid="hae5b8629gb6dege582gb0b6g59da26e4eb55" version="1">Niveau 9 : Armurier amélioré</content>
   <content contentuid="hf03822e2g7af0g67edg9165g36461a798fbc" version="4">Votre Armure arcanique gagne des avantages supplémentaires selon son modèle, comme détaillé ci-dessous.
 
-Dreadnaught. Le dé de dégâts de votre Démolisseur de Force augmente à 2d6 dégâts de Force. De plus, votre allonge augmente de 10 pieds.
+Dreadnaught. Le dé de dégâts de votre Démolisseur de Force augmente à 2d6 dégâts de Force. De plus, votre allonge augmente de 3 mètres.
 
-Gardien. Le dé de dégâts de votre Pulsation de tonnerre augmente à 1d10 dégâts de Tonnerre. De plus, chaque fois qu'une créature que vous pouvez voir se déplace à 5 pieds ou moins de vous, vous pouvez effectuer une Attaque d'opportunité contre elle.
+Gardien. Le dé de dégâts de votre Pulsation de tonnerre augmente à 1d10 dégâts de Tonnerre. De plus, chaque fois qu'une créature que vous pouvez voir se déplace à 1,50 mètre ou moins de vous, vous pouvez effectuer une Attaque d'opportunité contre elle.
 
 Infiltrateur. Le dé de dégâts de votre Lance-éclairs augmente à 2d6 dégâts Foudre. Toute créature qui subit des dégâts Foudre de votre Lance-éclairs devient Choquée.</content>
   <content contentuid="h47131d60gec85gc936gc2dcgea0e6754c6e8" version="1">Armurier</content>
@@ -3784,9 +3873,9 @@ Infiltrateur. Le dé de dégâts de votre Lance-éclairs augmente à 2d6 dégât
   <content contentuid="ha42bd3d5g2ce4ga800g2fcbg8d6d528c77c2" version="1">Gardien</content>
   <content contentuid="heba7c958g5e2egaf60gaed7g5b1af3b11e89" version="1">Infiltrateur</content>
   <content contentuid="h097afcaegbffcg54c6g7e95g39e866fdaad8" version="1">Démolisseur de Force : Repousser</content>
-  <content contentuid="h4fbaa426ge15cg76e8g135bg063e1212f51b" version="1">Si vous touchez une créature d'au moins une taille inférieure à la vôtre avec le démolisseur, vous pouvez la repousser jusqu'à 10 pieds en ligne droite loin de vous.</content>
+  <content contentuid="h4fbaa426ge15cg76e8g135bg063e1212f51b" version="1">Si vous touchez une créature d'au moins une taille inférieure à la vôtre avec le démolisseur, vous pouvez la repousser jusqu'à 3 mètres en ligne droite loin de vous.</content>
   <content contentuid="hc997bdabg8c5dg07ceg15dfgb0f9460ee068" version="1">Démolisseur de Force : Tirer</content>
-  <content contentuid="h885fc7c4ga223g5fe2g45e3gcecbe30e37ae" version="1">Si vous touchez une créature d'au moins une taille inférieure à la vôtre avec le démolisseur, vous pouvez la tirer jusqu'à 10 pieds vers vous.</content>
+  <content contentuid="h885fc7c4ga223g5fe2g45e3gcecbe30e37ae" version="1">Si vous touchez une créature d'au moins une taille inférieure à la vôtre avec le démolisseur, vous pouvez la tirer jusqu'à 3 mètres vers vous.</content>
   <content contentuid="hd6af5f68g9087g1e07g293bga2e94a2ef0a2" version="1">Pulsation de tonnerre</content>
   <content contentuid="h1ec14486gf908gc063g0557g6983b686c4ae" version="1">Une créature touchée par la pulsation a le Désavantage aux jets d'attaque contre des cibles autres que vous jusqu'au début de votre prochain tour.</content>
   <content contentuid="h1deb9510g66e8g1014ga617g42de42c8b1ba" version="1">Lance-éclairs</content>
@@ -3822,20 +3911,20 @@ Infiltrateur. Le dé de dégâts de votre Lance-éclairs augmente à 2d6 dégât
   <content contentuid="h3b11a6dfg7408ga680gbdf9g27b20bb02003" version="1">Niveau 9 : Canon explosif</content>
   <content contentuid="hb63bc4e3g2375g28c1gc6f9g87176ffa864b" version="2">Le Canon occulte que vous créez est désormais plus destructeur, accordant les avantages suivants.
 
-Détonation. Lorsque vous subissez des dégâts, vous pouvez utiliser votre Réaction pour ordonner au canon de détoner. Chaque créature ennemie à 20 pieds ou moins de vous doit effectuer un jet de sauvegarde de Dextérité contre votre DD de sort, subissant 3d10 dégâts de Force en cas d'échec, ou la moitié en cas de succès. Vous pouvez utiliser cette capacité une fois par Repos court.
+Détonation. Lorsque vous subissez des dégâts, vous pouvez utiliser votre Réaction pour ordonner au canon de détoner. Chaque créature ennemie à 6 mètres ou moins de vous doit effectuer un jet de sauvegarde de Dextérité contre votre DD de sort, subissant 3d10 dégâts de Force en cas d'échec, ou la moitié en cas de succès. Vous pouvez utiliser cette capacité une fois par Repos court.
 
 Puissance de feu. Les jets de dégâts du canon, ainsi que le nombre de Points de vie temporaires accordés par Protecteur, augmentent de 1d8.</content>
   <content contentuid="h3f377196g65a7g4515g06e5gba317fd59da5" version="1">Baliste de Force</content>
-  <content contentuid="h8f981f57g7f1bga2f4ge878g2c2d2bc07d69" version="1">Effectuez une attaque de sort à distance prenant sa source dans le canon contre une créature ou un objet. En cas de coup, la cible subit des dégâts de Force, et si la cible est une créature, elle est repoussée jusqu'à 5 pieds du canon.</content>
+  <content contentuid="h8f981f57g7f1bga2f4ge878g2c2d2bc07d69" version="1">Effectuez une attaque de sort à distance prenant sa source dans le canon contre une créature ou un objet. En cas de coup, la cible subit des dégâts de Force, et si la cible est une créature, elle est repoussée jusqu'à 1,50 mètre du canon.</content>
   <content contentuid="h03d65a32ga8ccg59e0g4ea5g3121ef238425" version="1">Lance-flammes</content>
-  <content contentuid="h567842fbg3adcgb2d8ga509g4f0c4fef8cc5" version="1">Le canon projette du feu dans un Cône de 15 pieds. Chaque créature dans cette zone effectue un jet de sauvegarde de Dextérité contre votre DD de sort, subissant des dégâts de Feu en cas d'échec ou la moitié en cas de succès. Les objets inflammables dans le Cône qui ne sont pas portés ou transportés commencent à brûler.</content>
+  <content contentuid="h567842fbg3adcgb2d8ga509g4f0c4fef8cc5" version="1">Le canon projette du feu dans un Cône de 4,50 mètres. Chaque créature dans cette zone effectue un jet de sauvegarde de Dextérité contre votre DD de sort, subissant des dégâts de Feu en cas d'échec ou la moitié en cas de succès. Les objets inflammables dans le Cône qui ne sont pas portés ou transportés commencent à brûler.</content>
   <content contentuid="h702ee012gf2cegac5agc807g4f790f5c4902" version="1">Protecteur</content>
   <content contentuid="ha08d7455g92d8ge864g1342g92dbae05a2cd" version="1">Protecteur</content>
-  <content contentuid="hc3d7957egbf1cga0f8gde92g70f35f4c410f" version="1">Le canon émet une bouffée d'énergie positive qui lui accorde, ainsi qu'à chaque créature de votre choix à 10 pieds ou moins du canon, un nombre de Points de vie temporaires égal à 1d8 plus votre modificateur d'Intelligence (minimum de +1).</content>
+  <content contentuid="hc3d7957egbf1cga0f8gde92g70f35f4c410f" version="1">Le canon émet une bouffée d'énergie positive qui lui accorde, ainsi qu'à chaque créature de votre choix à 3 mètres ou moins du canon, un nombre de Points de vie temporaires égal à 1d8 plus votre modificateur d'Intelligence (minimum de +1).</content>
   <content contentuid="h65882d15gbcc1g0a95g4036g27f23ffa539c" version="1">Détonation</content>
   <content contentuid="hd790e5deg5793ge1d8gfbc7gad8509c9beea" version="1">Canon explosif</content>
   <content contentuid="h01831d81g2d20g8c48g5e5eg10559d708494" version="1">Détonation</content>
-  <content contentuid="hab1f563cgd118gb03bg41b5g1316f04ab315" version="1">Lorsque vous subissez des dégâts, vous pouvez utiliser votre Réaction pour ordonner au canon de détoner. Chaque créature ennemie à 20 pieds ou moins de vous doit effectuer un jet de sauvegarde de Dextérité contre votre DD de sort, subissant 3d10 dégâts de Force en cas d'échec, ou la moitié en cas de succès. Vous pouvez utiliser cette capacité une fois par Repos court.</content>
+  <content contentuid="hab1f563cgd118gb03bg41b5g1316f04ab315" version="1">Lorsque vous subissez des dégâts, vous pouvez utiliser votre Réaction pour ordonner au canon de détoner. Chaque créature ennemie à 6 mètres ou moins de vous doit effectuer un jet de sauvegarde de Dextérité contre votre DD de sort, subissant 3d10 dégâts de Force en cas d'échec, ou la moitié en cas de succès. Vous pouvez utiliser cette capacité une fois par Repos court.</content>
   <content contentuid="h57be1335ga707gde5ag1346g356ac10f28b0" version="2">Faucille de lune</content>
   <content contentuid="h2d267dedgfd4eg89d7g9e6eg23e63c2ef056" version="2">Cette faucille à lame d'argent brille doucement de la lumière de la lune.</content>
   <content contentuid="ha29a53f0gdcdag13d4g65a6g4969c1a596e5" version="1">Nécessite l'harmonisation par un Druide ou un Rôdeur</content>
@@ -3843,13 +3932,13 @@ Puissance de feu. Les jets de dégâts du canon, ainsi que le nombre de Points d
   <content contentuid="h9c04874bg78bdgf61ag7978g3898f2f266ca" version="1">Nécessite l'harmonisation par un Druide ou un Rôdeur.
 
 Lorsque vous lancez un sort qui restaure des Points de vie, vous pouvez lancer un d4 et ajouter le résultat au montant de Points de vie restaurés.</content>
-  <content contentuid="h463f00d2g43d4g6387ga3e8g5af46bc31369" version="2">Éclat mental (Persistant)</content>
+  <content contentuid="h463f00d2g43d4g6387ga3e8g5af46bc31369" version="2">Piqûre mentale (Persistant)</content>
   <content contentuid="h0e4f0ac6g2f7egd603gf1dfgbe7d59c073b3" version="1">Cercle des Rêves</content>
   <content contentuid="h59958a6fg7ff5g9780g1b47g688c0909621b" version="1">Les Druides membres du Cercle des Rêves viennent de régions ayant de forts liens avec le Royaumes féerique et ses royaumes oniriques. La protection du monde naturel par les druides constitue une alliance naturelle entre eux et les fées de bon alignement. Ces druides cherchent à remplir le monde d'une merveille onirique. Leur magie guérit les blessures et apporte la joie aux cœurs abattus, et les royaumes qu'ils protègent sont des lieux brillants et fructueux, où rêve et réalité se confondent et où les fatigués peuvent trouver du repos.</content>
   <content contentuid="h853388a0g259bga78age028g6a93fbf44c57" version="1">Niveau 3 : Baume de la Cour d'été</content>
   <content contentuid="hfdecb2bbgb554g7caage8a5ga7a203a6533c" version="1">Vous êtes imprégné des bénédictions de la Cour d'été. Vous êtes une source d'énergie qui offre un répit face aux blessures. Vous disposez d'une réserve d'énergie féerique représentée par un nombre de d6 égal à votre niveau de druide.
 
-En tant qu'Action bonus, vous pouvez choisir une créature que vous pouvez voir à 60 pieds ou moins de vous et dépenser un nombre de ces dés égal à la moitié de votre niveau de druide ou moins. Lancez les dés dépensés et additionnez-les. La cible récupère un nombre de Points de vie égal au total. La cible gagne également 1 Point de vie temporaire par dé dépensé.
+En tant qu'Action bonus, vous pouvez choisir une créature que vous pouvez voir à 18 mètres ou moins de vous et dépenser un nombre de ces dés égal à la moitié de votre niveau de druide ou moins. Lancez les dés dépensés et additionnez-les. La cible récupère un nombre de Points de vie égal au total. La cible gagne également 1 Point de vie temporaire par dé dépensé.
 
 Vous récupérez tous les dés dépensés lorsque vous terminez un Repos long.</content>
   <content contentuid="h6002b32ag74ffg3470g0a2cg9afe92b897e5" version="1">Niveau 6 : Foyer de Clair de lune et d'Ombre</content>
@@ -3857,13 +3946,13 @@ Vous récupérez tous les dés dépensés lorsque vous terminez un Repos long.</
 
 Jusqu'à ce que vous terminiez votre prochain Repos long, vous et vos alliés gagnez un bonus de +5 aux tests de Dextérité (Discrétion) et de Sagesse (Perception).</content>
   <content contentuid="h86d67657g9bf6g0b50g5e7cg56cc562e49a6" version="1">Niveau 10 : Chemins cachés</content>
-  <content contentuid="h8a84376bg7fbdg24c6g9d95gf3e5c6364f83" version="1">Vous pouvez utiliser les voies cachées et magiques que certaines fées utilisent pour traverser l'espace en un clin d'œil. En tant qu'Action bonus à votre tour, vous pouvez vous téléporter jusqu'à 30 pieds vers un espace inoccupé que vous pouvez voir. Vous pouvez aussi utiliser votre action pour téléporter une créature consentante que vous touchez jusqu'à 30 pieds vers un espace inoccupé que vous pouvez voir.
+  <content contentuid="h8a84376bg7fbdg24c6g9d95gf3e5c6364f83" version="1">Vous pouvez utiliser les voies cachées et magiques que certaines fées utilisent pour traverser l'espace en un clin d'œil. En tant qu'Action bonus à votre tour, vous pouvez vous téléporter jusqu'à 9 mètres vers un espace inoccupé que vous pouvez voir. Vous pouvez aussi utiliser votre action pour téléporter une créature consentante que vous touchez jusqu'à 9 mètres vers un espace inoccupé que vous pouvez voir.
 
 Vous pouvez utiliser cette fonctionnalité un nombre de fois égal à votre modificateur de Sagesse (minimum une fois), et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
   <content contentuid="h2871d8a1gc38dg55beg842agaf4d3298bdd3" version="1">Baume de la Cour d'été</content>
   <content contentuid="h90bafc33g2849g9ffbg6757g0471be69d9b7" version="1">Chemins cachés</content>
   <content contentuid="h37aa6b9dgff7fg4b1bgab52g38d4828960cd" version="1">Baume de la Cour d'été</content>
-  <content contentuid="he20dfbbag75a3gc426g332eg26d5f5687c72" version="1">En tant qu'Action bonus, vous pouvez choisir une créature que vous pouvez voir à 60 pieds ou moins de vous et dépenser un nombre de ces dés égal à la moitié de votre niveau de druide ou moins. Lancez les dés dépensés et additionnez-les. La cible récupère un nombre de Points de vie égal au total. La cible gagne également 1 Point de vie temporaire par dé dépensé.</content>
+  <content contentuid="he20dfbbag75a3gc426g332eg26d5f5687c72" version="1">En tant qu'Action bonus, vous pouvez choisir une créature que vous pouvez voir à 18 mètres ou moins de vous et dépenser un nombre de ces dés égal à la moitié de votre niveau de druide ou moins. Lancez les dés dépensés et additionnez-les. La cible récupère un nombre de Points de vie égal au total. La cible gagne également 1 Point de vie temporaire par dé dépensé.</content>
   <content contentuid="h8ae6911fg454ag4837gb124g3854cf3dde9a" version="1">Baume de la Cour d'été</content>
   <content contentuid="h25cebc5cgd794gb02fg2941g193df53c964f" version="1">Foyer de Clair de lune et d'Ombre</content>
   <content contentuid="hd876484bg06deg6a8egb4b1gc6a59e051290" version="1">Jusqu'à ce que vous terminiez votre prochain Repos court ou long, vous et vos alliés gagnez un bonus de +5 aux tests de Dextérité (Discrétion) et de Sagesse (Perception).</content>
@@ -3896,7 +3985,7 @@ Jusqu'à ce que vous terminiez votre prochain Repos long, vous et vos alliés ga
   <content contentuid="h621fd279gebdag777dg35cdge79dc6dc09a3" version="1">Vous obtenez la maîtrise d'une compétence de votre choix.</content>
   <content contentuid="hffb15f0dg8d46g8ce2g4665g6ab0e628d277" version="1">Sens aiguisés</content>
   <content contentuid="hff4e6b44g07dbg7d46g1dfbg11ee89aaef5b" version="1">Vous avez la maîtrise de la compétence Perspicacité, Perception ou Survie.</content>
-  <content contentuid="h66fbaf70g36bcg4313g969fgfabc9b4f1f69" version="4">Vous pouvez lancer l'un de vos tours de magie dont le temps d'incantation est une action à la place de l'une de ces attaques.</content>
+  <content contentuid="h66fbaf70g36bcg4313g969fgfabc9b4f1f69" version="4">Vous pouvez lancer l'un de vos sorts mineurs dont le temps d'incantation est une action à la place de l'une de ces attaques.</content>
   <content contentuid="h131208e0g1b65g0338gbc3dg9af0e2d478df" version="1">Précision elfique</content>
   <content contentuid="h5807bc17g3e71g7234g30c2gf7b6a4fe91da" version="1">Chaque fois que vous avez l'Avantage à un jet d'attaque utilisant la Dextérité, l'Intelligence, la Sagesse ou le Charisme, vous pouvez relancer l'un des dés une fois.</content>
   <content contentuid="h34159b25g04efg5336ga815g3000f32dc549" version="1">Vœu d'inimitié</content>
@@ -3941,7 +4030,7 @@ Connaissance des armes. Vous obtenez la maîtrise des armes de guerre. Vous pouv
   <content contentuid="h41d2ff5cgefb3g4750gfbbfg9ce76cd22456" version="1">Niveau 3 : Défenseur d'acier</content>
   <content contentuid="h0844a944gf85ag2577g8e77g23dcd6a6e387" version="1">Votre bricolage vous a donné un compagnon : un Défenseur d'acier. Il vous est favorable, à vous et à vos compagnons, et obéit à vos ordres. S'il est mort, vous pouvez utiliser vos outils de forgeron en tant qu'action et dépenser un emplacement de sort de niveau 1 ou supérieur pour le ranimer.</content>
   <content contentuid="h7b9311b6gf2bag9d7eg4407g3cb8f90b5541" version="1">Déflexion d'attaque</content>
-  <content contentuid="hda3785acgb4c8g1e09g6f52ga7964ee4a86e" version="1">Lorsqu'une créature que le défenseur peut voir à 5 pieds ou moins de lui effectue un jet d'attaque contre une cible autre que le défenseur, la créature déclenchante effectue le jet d'attaque avec le Désavantage.</content>
+  <content contentuid="hda3785acgb4c8g1e09g6f52ga7964ee4a86e" version="1">Lorsqu'une créature que le défenseur peut voir à 1,50 mètre ou moins de lui effectue un jet d'attaque contre une cible autre que le défenseur, la créature déclenchante effectue le jet d'attaque avec le Désavantage.</content>
   <content contentuid="hf909a1bage22fg8286gcfedg0f187d283bee" version="1">Déchirure de Force</content>
   <content contentuid="h0830e0b7g5f29g2f2egddefgdf29c01c0374" version="1">Défenseur d'acier</content>
   <content contentuid="he182f30fgc762gfc22g6adegda911d4ae8ea" version="1">Votre bricolage vous a donné un compagnon, un Défenseur d'acier.</content>
@@ -3951,7 +4040,7 @@ Connaissance des armes. Vous obtenez la maîtrise des armes de guerre. Vous pouv
   <content contentuid="h6d2cfddegb7bag99e2g6ffbg6a101cdf219d" version="1">Niveau 9 : Décharge arcanique</content>
   <content contentuid="h1ad514dega841gc35dg8804ga474e60b45ea" version="2">Lorsque vous touchez une cible avec un jet d'attaque utilisant une arme magique, ou lorsque votre Défenseur d'acier touche une cible, vous pouvez canaliser de l'énergie magique à travers le coup pour libérer de l'Énergie destructrice. La cible subit 2d6 dégâts de Force supplémentaires.
 
-Vous pouvez aussi libérer de l'Énergie restauratrice en choisissant une créature ou un objet que vous pouvez voir à 30 pieds ou moins de vous. De l'énergie curative se déverse sur le destinataire choisi, lui restaurant 2d6 Points de vie.</content>
+Vous pouvez aussi libérer de l'Énergie restauratrice en choisissant une créature ou un objet que vous pouvez voir à 9 mètres ou moins de vous. De l'énergie curative se déverse sur le destinataire choisi, lui restaurant 2d6 Points de vie.</content>
   <content contentuid="h4f02276agb1b7g8939g8d33g4138f4f9a52f" version="1">Vous pouvez utiliser cette énergie un nombre de fois égal à votre modificateur d'Intelligence (minimum une fois), mais vous ne pouvez le faire qu'une seule fois par tour. Vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
   <content contentuid="hfcff03d7g3b43gc2c2g568eg228ec39a2a92" version="2">Énergie destructrice</content>
   <content contentuid="h7a33c7b9g8cc0g6c2bg348fg50d1aa50e0f5" version="2">Lorsque vous touchez une cible avec un jet d'attaque utilisant une arme magique, vous pouvez canaliser de l'énergie magique à travers le coup pour libérer de l'Énergie destructrice. La cible subit 2d6 dégâts de Force supplémentaires.</content>
@@ -3960,7 +4049,7 @@ Vous pouvez aussi libérer de l'Énergie restauratrice en choisissant une créat
   <content contentuid="h2a2d4c40ge64cg5bd8gb073g4424cebf9004" version="1">Lorsque votre Défenseur d'acier touche une cible, vous pouvez canaliser de l'énergie magique à travers le coup pour libérer de l'Énergie destructrice. La cible subit 2d6 dégâts de Force supplémentaires.</content>
   <content contentuid="h10e88f31ga340g7220g57cagf79b60b98df3" version="1">Décharge arcanique</content>
   <content contentuid="h214b31e4g1222g89d1g1c98g859dc68c80f1" version="1">Énergie restauratrice</content>
-  <content contentuid="hde43de07gcaa5gae30g5a72gf42e5fc93579" version="1">Choisissez une créature ou un objet que vous pouvez voir à 30 pieds ou moins de la cible. De l'énergie curative se déverse sur le destinataire choisi, lui restaurant 2d6 Points de vie.</content>
+  <content contentuid="hde43de07gcaa5gae30g5a72gf42e5fc93579" version="1">Choisissez une créature ou un objet que vous pouvez voir à 9 mètres ou moins de la cible. De l'énergie curative se déverse sur le destinataire choisi, lui restaurant 2d6 Points de vie.</content>
   <content contentuid="h2f2351eagc707g9459g9834g51d1c7e9978b" version="1">Chasseur de monstres</content>
   <content contentuid="h0869d35bg1af1g491egad72g2bce5ad0bb7c" version="1">Les Chasseurs de monstres sont des professionnels qualifiés, spécialisés dans l'identification, le pistage et l'élimination des monstres qui menacent les vies et les moyens de subsistance des habitants d'Etharis.
 
@@ -3968,7 +4057,7 @@ Chaque Chasseur de monstres s'entraîne selon une méthode différente pour ces 
   <content contentuid="h601d5cbag2cd7g2d2ag51c7gedc8460d73bd" version="1">Niveau 2 : Riposte calculée</content>
   <content contentuid="h1acefdf8gda2eg7c3cg5653ge46c213d3330" version="1">Vous avez appris que le moyen le plus efficace d'abattre un monstre est de frapper sa zone la plus vulnérable au bon moment. Trop tôt, et votre attaque rebondit. Trop tard, et le monstre pourrait vous éventrer.
 
-Lorsqu'une créature que vous pouvez voir à 60 pieds ou moins de vous cible vous ou une autre créature avec une attaque de mêlée ou à distance, vous pouvez utiliser votre Réaction avant le jet d'attaque pour effectuer une attaque avec une arme ou une Frappe à mains nues contre cette créature.</content>
+Lorsqu'une créature que vous pouvez voir à 18 mètres ou moins de vous cible vous ou une autre créature avec une attaque de mêlée ou à distance, vous pouvez utiliser votre Réaction avant le jet d'attaque pour effectuer une attaque avec une arme ou une Frappe à mains nues contre cette créature.</content>
   <content contentuid="h7ed746cbg5755g06c8gb2c6g038076d2cf1f" version="1">Niveau 5 : Frappe experte</content>
   <content contentuid="h0d363bf9gf18dg388dg3b8ag596235a95087" version="1">Vous apprenez les faiblesses des monstres afin de savoir exactement où frapper pour infliger le maximum de dégâts. Vous pouvez ajouter votre modificateur d'Intelligence aux jets d'attaque et de dégâts de vos armes et Frappes à mains nues.</content>
   <content contentuid="he9610900g31c5gc311g6350gf54444ec26ce" version="1">Niveau 6 : Chasse aux monstres améliorée</content>
@@ -3994,14 +4083,14 @@ Les dégâts deviennent 4d6 lorsque vous atteignez le niveau 11 de Chasseur de m
   <content contentuid="h99831797g4294g8465g0eb9g7df78a5c76a0" version="1">Combat rapproché</content>
   <content contentuid="h23954313g9d62ge28ag34a3ga9b81bf374a2" version="2">Lorsque vous touchez une créature avec un jet d'attaque utilisant une arme de mêlée, vous pouvez utiliser votre Réaction pour infliger [1] dégâts supplémentaires. Cette créature a le Désavantage à son prochain jet d'attaque avant le début de votre prochain tour.</content>
   <content contentuid="h313bab3cg67c1gfa03ge6f3g354db3046e48" version="1">Riposte calculée (Mêlée)</content>
-  <content contentuid="h2f932b68g4347ga354g521cgc438d3f99c6d" version="1">Lorsqu'une créature que vous pouvez voir à 60 pieds ou moins de vous vous cible ou cible une autre créature avec une attaque de mêlée ou à distance, vous pouvez utiliser votre Réaction avant le jet d'attaque pour effectuer une attaque avec une arme ou une Frappe à mains nues contre cette créature.</content>
+  <content contentuid="h2f932b68g4347ga354g521cgc438d3f99c6d" version="1">Lorsqu'une créature que vous pouvez voir à 18 mètres ou moins de vous vous cible ou cible une autre créature avec une attaque de mêlée ou à distance, vous pouvez utiliser votre Réaction avant le jet d'attaque pour effectuer une attaque avec une arme ou une Frappe à mains nues contre cette créature.</content>
   <content contentuid="he03aadf1g28cbg5549g778fgff77ace6f7ba" version="1">Riposte calculée (Distance)</content>
   <content contentuid="he571e586gc384gf9bbg0231g7c7be2144adc" version="1">Disparaître dans l'obscurité et devenir &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt;.</content>
   <content contentuid="h87d3e26ag5e53gdf92g801cg4e8c26aac78e" version="1">Mage guerrier : Lame vibrante</content>
   <content contentuid="ha738254bg5dbag724ag511ag8d59cf1fed09" version="1">Mage guerrier : Lame de flamme verte</content>
   <content contentuid="h7e0866bbgdec1g07c2g7725gef3c6eb68247" version="1">Mage guerrier : Coup juste</content>
   <content contentuid="h664f7fdag1793g4256gd73cga50bae7c538a" version="1">Mage guerrier : Lame vengeresse</content>
-  <content contentuid="h67a39d88g2da4ga80bg2675g4c2a3e61a8ce" version="1">Mage guerrier : Choc électrique</content>
+  <content contentuid="h67a39d88g2da4ga80bg2675g4c2a3e61a8ce" version="1">Mage guerrier : Poigne électrique</content>
   <content contentuid="h58d3ea5cg20f9gc47cg638cg148f2229c69f" version="1">Lancer un sort sur une créature qui sort de la portée.</content>
   <content contentuid="hb9127c70g1995gf222g6ab6g02340332c0ad" version="1">Viking</content>
   <content contentuid="he18e2299gab76g9494gca06g85d28e4049b1" version="1">Les Vikings sont des guerriers et des marins aguerris qui sillonnent les mers des Terres du Nord pour la gloire et le pillage. En tant que partisans de la Voie du Pillard, ils ont leur propre sens de l'honneur, mais ils peuvent être impitoyables lors des raids et des guerres. Les Vikings sont connus pour leur maîtrise de la lance et de la hache, et pour leur conviction qu'ils peuvent gagner une place spéciale dans les halls des morts grâce à leurs actes de valeur au combat.</content>
@@ -4017,7 +4106,7 @@ Les dégâts deviennent 4d6 lorsque vous atteignez le niveau 11 de Chasseur de m
   <content contentuid="h318d1b8eg0580g3d5cgacf3g81c76726bcd3" version="1">Vous êtes habitué aux conditions rudes et aux monstres féroces des Terres du Nord. Vous avez la Résistance aux dégâts de Froid. Vous avez l'Avantage aux jets d'attaque contre les Dragons, les Géants et les créatures de taille Grande ou plus.</content>
   <content contentuid="haa63297agabf6g8665gd863gccf514e607f5" version="1">Surpris</content>
   <content contentuid="h5a9a1666gd0c6gb6d5g9f5dga7c149830daa" version="1">Surpris</content>
-  <content contentuid="hd31e4d13g939ag101eg9e56g93956331fc9c" version="1">Chaque créature de votre choix dans une Sphère de 5 pieds de rayon centrée sur un point à portée doit réussir un jet de sauvegarde de Sagesse ou acquérir l'état Neutralisé jusqu'à la fin de son prochain tour, moment auquel elle doit répéter le jet. Si la cible échoue au second jet, elle acquiert l'état Inconscient pour la durée. Le sort prend fin sur une cible si elle subit des dégâts ou si quelqu'un à 5 pieds ou moins d'elle effectue une action pour la sortir de l'effet du sort.</content>
+  <content contentuid="hd31e4d13g939ag101eg9e56g93956331fc9c" version="1">Chaque créature de votre choix dans une Sphère de 1,50 mètre de rayon centrée sur un point à portée doit réussir un jet de sauvegarde de Sagesse ou acquérir l'état Neutralisé jusqu'à la fin de son prochain tour, moment auquel elle doit répéter le jet. Si la cible échoue au second jet, elle acquiert l'état Inconscient pour la durée. Le sort prend fin sur une cible si elle subit des dégâts ou si quelqu'un à 1,50 mètre ou moins d'elle effectue une action pour la sortir de l'effet du sort.</content>
   <content contentuid="h1311946eg0f6eg3884gb766ga518b4884a4d" version="1">Surpris</content>
   <content contentuid="hdaea4751gf57bg4b28g0266g1e1630af444e" version="1">Ne peut pas effectuer d'&lt;LSTag Tooltip="Action"&gt;actions&lt;/LSTag&gt; ni de réactions.</content>
   <content contentuid="hebdf4ecbgcaabg1a81g42d5g735a9adcf945" version="5">Elfe des glaces</content>
@@ -4037,7 +4126,7 @@ La vérité est à peine meilleure. Les Dévoreurs ont passé leurs jours à con
   <content contentuid="h529b8a58gb300g1753gdff4gbd3ce84b211c" version="1">Niveau 10 : Faim dévorante</content>
   <content contentuid="h90ab5cd5g9998gb661g7d18ga57aad811d98" version="2">Votre faim pour votre ennemi vous permet de vous nourrir de son essence pendant la bataille. Lorsque vous infligez des dégâts à une créature avec une attaque de mêlée utilisant une arme, vous gagnez 6 Points de vie temporaires.</content>
   <content contentuid="h2f0d1be4g0c48gc8dag5d46gb63613816d4b" version="1">Sang acide</content>
-  <content contentuid="hcae93600g722fg2de2g2f0fg60184d7ba2f0" version="1">Pendant 1 minute, votre sang devient acide. Chaque fois qu'une créature vous touche avec une attaque alors qu'elle est à 5 pieds ou moins de vous, elle subit 2d6 dégâts d'Acide.</content>
+  <content contentuid="hcae93600g722fg2de2g2f0fg60184d7ba2f0" version="1">Pendant 1 minute, votre sang devient acide. Chaque fois qu'une créature vous touche avec une attaque alors qu'elle est à 1,50 mètre ou moins de vous, elle subit 2d6 dégâts d'Acide.</content>
   <content contentuid="hfb4b4347g41f8gc00fg03eagf4da78649103" version="1">Perspicacité</content>
   <content contentuid="h55f2832cg60b4gcd10g11f2g30f9e75aa0b9" version="1">Pendant 1 heure, vous avez l'Avantage aux tests de Perspicacité, d'Intimidation et de Persuasion.</content>
   <content contentuid="h0332a04eg8429g6f00gada3gf49674ee7d97" version="1">Vol</content>
@@ -4059,7 +4148,7 @@ La vérité est à peine meilleure. Les Dévoreurs ont passé leurs jours à con
   <content contentuid="h14ef410eg91c7g8763gfe5bge988b17c4434" version="1">Résistance</content>
   <content contentuid="ha9065fa0gda11g9fbag0a9fgd56f197c42ac" version="1">Pendant 1 minute, vous avez la Résistance aux dégâts Contondants, Perforants et Tranchants.</content>
   <content contentuid="h18dea430g0a51g9ce2g9dc4g23ab4802a3ec" version="1">Sang acide</content>
-  <content contentuid="h5b8f7438g5b18gdde5gc4dfga7996a555481" version="1">Pendant 1 minute, votre sang devient acide. Chaque fois qu'une créature vous touche avec une attaque alors qu'elle est à 5 pieds ou moins de vous, elle subit 2d6 dégâts d'Acide.</content>
+  <content contentuid="h5b8f7438g5b18gdde5gc4dfga7996a555481" version="1">Pendant 1 minute, votre sang devient acide. Chaque fois qu'une créature vous touche avec une attaque alors qu'elle est à 1,50 mètre ou moins de vous, elle subit 2d6 dégâts d'Acide.</content>
   <content contentuid="h65822f22g5c0agbed4ga2dfg8ecf26db28f0" version="1">Perspicacité</content>
   <content contentuid="h1865c71ag5eb9gf397gb7e8g3c4fd9f68123" version="1">Pendant 1 heure, vous avez l'Avantage aux tests de Perspicacité, d'Intimidation et de Persuasion.</content>
   <content contentuid="h803ef2b4g9d5fg6bf7gcdfbge5aa148caa9d" version="1">Vol</content>
@@ -4084,13 +4173,13 @@ La vérité est à peine meilleure. Les Dévoreurs ont passé leurs jours à con
   <content contentuid="hf384310bg4b63gee6dga622g694c2ded1d00" version="1">Le prochain jet d'attaque effectué contre la cible avant le début du prochain tour du worgloup a l'Avantage.</content>
   <content contentuid="h39511b28g3843gdb43gabc4g14a37310891b" version="1">Si la cible est une créature de taille Moyenne ou inférieure, elle acquiert l'état À terre.</content>
   <content contentuid="h3f843ebcg8610ga557g917ag613b7d8001e7" version="1">Niveau 2 : Vigueur diabolique</content>
-  <content contentuid="h18b3f8afg5a28g03a8gaefdg39fb7c01b1f4" version="1">Prérequis : Sorcier niveau 2+</content>
+  <content contentuid="h18b3f8afg5a28g03a8gaefdg39fb7c01b1f4" version="1">Prérequis : Niveau 2+ Occultiste</content>
   <content contentuid="he55ef41cg489dg2db3ga14bg076c3922f5be" version="1">Niveau 3 : Acolyte de l'occulte</content>
   <content contentuid="h718ebc53g9616gcdc4ge2bcg846a784062a6" version="1">Vous obtenez la maîtrise de la compétence Arcanes.</content>
   <content contentuid="h6d45afc8gf3a4g9b53ge55cgee1e8ff20f84" version="1">Niveau 3 : Interférence arcanique</content>
-  <content contentuid="h5524efc2g3048g863bg33c2g18cfc27aae3e" version="1">Lorsqu'une créature que vous pouvez voir à 60 pieds ou moins de vous lance un sort ou effectue une attaque de sort, vous pouvez utiliser Riposte calculée contre cette créature avant que le sort ne soit lancé.</content>
+  <content contentuid="h5524efc2g3048g863bg33c2g18cfc27aae3e" version="1">Lorsqu'une créature que vous pouvez voir à 18 mètres ou moins de vous lance un sort ou effectue une attaque de sort, vous pouvez utiliser Riposte calculée contre cette créature avant que le sort ne soit lancé.</content>
   <content contentuid="hb92bcd84g4cddg1b78g08b9g7f8b71b93820" version="1">Interférence arcanique (Mêlée)</content>
-  <content contentuid="hd1a7279cg4593g3e07ge351g2791a15d3b14" version="1">Lorsqu'une créature que vous pouvez voir à 60 pieds ou moins de vous lance un sort ou effectue une attaque de sort, vous pouvez utiliser Riposte calculée contre cette créature avant que le sort ne soit lancé.</content>
+  <content contentuid="hd1a7279cg4593g3e07ge351g2791a15d3b14" version="1">Lorsqu'une créature que vous pouvez voir à 18 mètres ou moins de vous lance un sort ou effectue une attaque de sort, vous pouvez utiliser Riposte calculée contre cette créature avant que le sort ne soit lancé.</content>
   <content contentuid="h3b16b3ffg2270g1432g326dg3d651266daf9" version="1">Interférence arcanique (Distance)</content>
   <content contentuid="h24d8b18eg6581ged0bg11fbge247a09545db" version="1">Niveau 7 : Chasseur de mages</content>
   <content contentuid="hbc96befbg7948g8e5cgd0a9g9e23446bdc7b" version="1">Vous avez l'Avantage aux jets de sauvegarde contre les sorts. De plus, lorsque vous infligez des dégâts à une créature qui se concentre, elle a le Désavantage au jet de sauvegarde qu'elle effectue pour maintenir sa Concentration.</content>
@@ -4099,26 +4188,26 @@ La vérité est à peine meilleure. Les Dévoreurs ont passé leurs jours à con
   <content contentuid="hb94ed556g5e70g8c49g722fge57833fe8a79" version="1">Guilde des Occultistes</content>
   <content contentuid="ha52e0ea7g613bg7d1egefc0gbcb5735e1445" version="1">À Etharis, il y a ceux qui craignent la magie, et ceux qui cherchent à la comprendre. Les Chasseurs de monstres de la Guilde des Occultistes savent que les gens des deux côtés sont également dangereux. Un Occultiste enquête sur l'arcane, le surnaturel et l'étrange, tout en évitant l'influence de la superstition ou de l'idéologie. Malgré leur réputation de chasseurs de mages, les Occultistes ne brûlent pas leurs ennemis sur le bûcher — les Occultistes les passent au fil de l'épée, car c'est à ça que servent les épées. La connaissance et la magie donnent aux Occultistes un avantage sur leurs adversaires mystiques. Leurs sorts sont utilisés pour détecter et se défendre contre les arcanes dangereux, et, avant tout, la magie est utilisée pour détruire des monstres qui ne peuvent pas être blessés par l'acier.</content>
   <content contentuid="hd5511bb2gf4b8g0709g6e56g92eaa3079df9" version="1">Niveau 3 : Sorts du domaine de l'Apocalypse</content>
-  <content contentuid="h3b8a1f9dg4458ga3d3ga263gf4e1b90b9524" version="1">Votre connexion à ce domaine divin vous assure d'avoir toujours certains sorts prêts. Lorsque vous atteignez un niveau de Clerc spécifié dans le tableau des sorts du domaine de l'Apocalypse, vous avez désormais toujours les sorts listés préparés.</content>
+  <content contentuid="h3b8a1f9dg4458ga3d3ga263gf4e1b90b9524" version="1">Votre connexion à ce domaine divin vous assure d'avoir toujours certains sorts prêts. Lorsque vous atteignez un niveau de Clerc spécifié dans le tableau des sorts du domaine de l'Apocalypse, vous avez désormais toujours les sorts listés préparés. Au 3e niveau, vous avez toujours Ténèbres, Représailles infernales, Force fantasmagorique et Vague tonnante préparés. Au 5e niveau, Faim d'Hadar et Terreur s'y ajoutent. Au 7e niveau, vous gagnez Flétrissement et Tempête de grêle, et au 9e niveau, Brume mortelle et Fléau d'insectes.</content>
   <content contentuid="h7c50337fg49e2g1d8agf87ag04e30ad44c96" version="1">Au 3e niveau, vous avez toujours Ténèbres, Représailles infernales, Force fantasmagorique et Vague de tonnerre préparés. Au 5e niveau, Faim de Hadar et Terreur sont ajoutés. Au 7e niveau, vous gagnez Flétrissement et Tempête de grêle, et au 9e niveau, Nuage mortel et Fléau d'insectes.</content>
   <content contentuid="h46ff1dc0g3fb4g0e61g3544g195538ce2ff9" version="1">Niveau 3 : Visions d'annihilation</content>
-  <content contentuid="h55235fc0g6321g25e2gcdefgc2244237ac56" version="3">Vous gagnez la capacité de prédire le destin d'une créature. En tant qu'Action bonus, choisissez une créature que vous pouvez voir à 120 pieds ou moins de vous. Jusqu'au début de votre prochain tour, les jets d'attaque contre cette créature ont l'Avantage.</content>
+  <content contentuid="h55235fc0g6321g25e2gcdefgc2244237ac56" version="3">Vous gagnez la capacité de prédire le destin d'une créature. En tant qu'Action bonus, choisissez une créature que vous pouvez voir à 36 mètres ou moins de vous. Jusqu'au début de votre prochain tour, les jets d'attaque contre cette créature ont l'Avantage.</content>
   <content contentuid="h947ed943ge9abg4881g2010ge2b6da6351b6" version="1">Vous pouvez utiliser cette fonctionnalité un nombre de fois égal à votre modificateur de Sagesse (minimum une fois). Vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
   <content contentuid="h751150e3g3292g3e58g402ag01d32ccf9a11" version="1">Niveau 3 : Chant du Destin</content>
-  <content contentuid="h469b91e3g1e80g366cg1b58gaf7e45b960a9" version="1">Vous pouvez utiliser votre Conduit divin pour hâter le destin d'une créature. En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Conduit divin pour choisir une créature que vous pouvez voir à 120 pieds ou moins de vous. Pendant 10 minutes, les jets d'attaque contre la créature peuvent obtenir un Coup critique sur un résultat de 19 ou 20 sur le d20.</content>
+  <content contentuid="h469b91e3g1e80g366cg1b58gaf7e45b960a9" version="1">Vous pouvez utiliser votre Conduit divin pour hâter le destin d'une créature. En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Conduit divin pour choisir une créature que vous pouvez voir à 36 mètres ou moins de vous. Pendant 10 minutes, les jets d'attaque contre la créature peuvent obtenir un Coup critique sur un résultat de 19 ou 20 sur le d20.</content>
   <content contentuid="h936af976g86a3g55a5gd932g3abc43fa4172" version="1">Niveau 6 : Tout sera poussière</content>
-  <content contentuid="h0eff4b29g54dbgb8d1gfe4ege253bef014b6" version="1">Vous pouvez utiliser votre Conduit divin pour tordre le destin d'une créature. En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Conduit divin pour choisir une créature que vous pouvez voir à 120 pieds ou moins de vous. Cette créature a le Désavantage au prochain jet de sauvegarde qu'elle effectue contre vos sorts avant la fin de votre prochain tour.</content>
+  <content contentuid="h0eff4b29g54dbgb8d1gfe4ege253bef014b6" version="1">Vous pouvez utiliser votre Conduit divin pour tordre le destin d'une créature. En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Conduit divin pour choisir une créature que vous pouvez voir à 36 mètres ou moins de vous. Cette créature a le Désavantage au prochain jet de sauvegarde qu'elle effectue contre vos sorts avant la fin de votre prochain tour.</content>
   <content contentuid="hf24a59b2g7e92gd5b5g78b7gd7fdcf01dfd9" version="1">Domaine de l'Apocalypse</content>
   <content contentuid="h9db7ea7cgcffdgdbaeg920dgbe5a72481ab8" version="1">Apocalypse</content>
   <content contentuid="h38a12140g389dg5222g5edag43885ca9c8ce" version="1">Peu de dieux adoptent le Domaine de l'Apocalypse, mais en temps de guerre, de maladie ou de bouleversement social, ses Clercs apparaissent à la tête de cultes sinistres qui proclament la mort imminente du monde. Les fidèles du Domaine de l'Apocalypse sont généralement des apostats et des hérétiques exclus des ordres religieux pour leur conviction fanatique en la fin de toutes choses.
 
 L'origine exacte de leur pouvoir divin déroute les anciens des religions établies. Parfois, ces Clercs tirent leurs pouvoirs des dieux du destin, de la mort ou du changement. Plus souvent, cependant, ils semblent puiser leur pouvoir dans le cafard collectif d'une population face au désastre. Peut-être que la mort du monde est vraiment imminente, et ces visionnaires ont trouvé un moyen de puiser dans l'apocalypse alors qu'elle approche.</content>
   <content contentuid="hf9a730dcg1eb4gd9edg0aa7gb17398270505" version="1">Visions d'annihilation</content>
-  <content contentuid="hb07fc0ddg58b4ga6acgedc3gd632be720493" version="2">Vous gagnez la capacité de prédire le destin d'une créature. En tant qu'Action bonus, choisissez une créature que vous pouvez voir à 120 pieds ou moins de vous. Jusqu'au début de votre prochain tour, les jets d'attaque contre cette créature ont l'Avantage.</content>
+  <content contentuid="hb07fc0ddg58b4ga6acgedc3gd632be720493" version="2">Vous gagnez la capacité de prédire le destin d'une créature. En tant qu'Action bonus, choisissez une créature que vous pouvez voir à 36 mètres ou moins de vous. Jusqu'au début de votre prochain tour, les jets d'attaque contre cette créature ont l'Avantage.</content>
   <content contentuid="h99f00500gb9adga785g718fgd903fd641999" version="1">Chant du Destin</content>
   <content contentuid="h3475c9ecg2cbcge436gbedfg439982b16a38" version="1">Tout sera poussière</content>
-  <content contentuid="h7ffa0044gb8c8g868fg7f1fgf74e697c363e" version="1">Vous pouvez utiliser votre Conduit divin pour hâter le destin d'une créature. En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Conduit divin pour choisir une créature que vous pouvez voir à 120 pieds ou moins de vous. Pendant 10 minutes, les jets d'attaque contre la créature peuvent obtenir un Coup critique sur un résultat de 19 ou 20 sur le d20.</content>
-  <content contentuid="h420df6cbg0932g5e3dgc009g752d63452593" version="1">Vous pouvez utiliser votre Conduit divin pour tordre le destin d'une créature. En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Conduit divin pour choisir une créature que vous pouvez voir à 120 pieds ou moins de vous. Cette créature a le Désavantage au prochain jet de sauvegarde qu'elle effectue contre vos sorts avant la fin de votre prochain tour.</content>
+  <content contentuid="h7ffa0044gb8c8g868fg7f1fgf74e697c363e" version="1">Vous pouvez utiliser votre Conduit divin pour hâter le destin d'une créature. En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Conduit divin pour choisir une créature que vous pouvez voir à 36 mètres ou moins de vous. Pendant 10 minutes, les jets d'attaque contre la créature peuvent obtenir un Coup critique sur un résultat de 19 ou 20 sur le d20.</content>
+  <content contentuid="h420df6cbg0932g5e3dgc009g752d63452593" version="1">Vous pouvez utiliser votre Conduit divin pour tordre le destin d'une créature. En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Conduit divin pour choisir une créature que vous pouvez voir à 36 mètres ou moins de vous. Cette créature a le Désavantage au prochain jet de sauvegarde qu'elle effectue contre vos sorts avant la fin de votre prochain tour.</content>
   <content contentuid="h35cd62dfga45eg5034g1f95gaecba58e13b1" version="1">Visions d'annihilation</content>
   <content contentuid="h28e871c2gfcbag2b14g8a07g144683a3a46e" version="1">Visions d'annihilation</content>
   <content contentuid="hc4bc1dcdga064g5d98g2982gae11fa7e91d9" version="2">Cible du Chant du Destin</content>
@@ -4133,18 +4222,18 @@ L'origine exacte de leur pouvoir divin déroute les anciens des religions établ
   <content contentuid="h22c0c858g3d5ag38b5g51dbg5e6023f8d885" version="1">Niveau 3 : Créer de la glace</content>
   <content contentuid="ha3545489g1d38g6fa3g0526g220227ae59ac" version="1">Vous pouvez prendre une Action bonus pour créer magiquement un terrain glacé sur jusqu'à cinq espaces. Les espaces couverts de glace deviennent un Terrain difficile et persistent jusqu'à la fin de votre prochain tour. Lorsque vous prenez cette Action bonus, vous pouvez dépenser un ou plusieurs Points de sorcellerie pour geler cinq espaces supplémentaires pour chaque Point de sorcellerie dépensé.</content>
   <content contentuid="h1e52530fgb6a1g58bcg28c8gf49958042c31" version="1">Niveau 3 : Sorts du Givre</content>
-  <content contentuid="h78ec0f4cgdceeg4a48gd10ag8d7fa8a15f49" version="1">Lorsque vous atteignez un niveau d'Ensorceleur spécifié dans le tableau des sorts du Givre, vous avez désormais toujours les sorts listés préparés.</content>
+  <content contentuid="h78ec0f4cgdceeg4a48gd10ag8d7fa8a15f49" version="1">Lorsque vous atteignez un niveau d'Ensorceleur spécifié dans le tableau des sorts du Givre, vous avez désormais toujours les sorts listés préparés. Au 3e niveau, vous apprenez Cécité, Couteau de glace, Pas brumeux et Sommeil. Au 5e niveau, vous ajoutez Tempête de neige fondue et Lenteur. Au 7e niveau, vous gagnez Bouclier de feu et Tempête de grêle. Enfin, au 9e niveau, vous pouvez lancer Cône de froid et Invocation d'élémentaire.</content>
   <content contentuid="h633e7853gfe5cgc83fg46c5g12d2c8161229" version="2">Au 3e niveau, vous apprenez Cécité, Lame de givre, Pas brumeux et Sommeil. Au 5e niveau, vous ajoutez Tempête de grésil et Lenteur. Au 7e niveau, vous gagnez Bouclier de feu et Tempête de grêle. Enfin, au 9e niveau, vous pouvez lancer Cône de froid et Appel d'élémentaire.</content>
   <content contentuid="he29b881cg8be9ge597gaa47ge013dbcb923e" version="1">Niveau 3 : Corps gelé</content>
-  <content contentuid="h4d2eb6abgde1bg02e5g7229g271d5c3cc35b" version="1">Votre peau prend une légère lueur cristalline semblable à de la glace. Votre maximum de Points de vie augmente de 3, et il augmente de 1 chaque fois que vous gagnez un autre niveau d'Ensorceleur. De plus, le Terrain difficile composé de glace ou de neige ne vous coûte pas de mouvement supplémentaire, et lorsque vous marchez sur la glace, vous ne dépensez qu'1 pied de mouvement pour chaque 2 pieds que vous parcourez.</content>
+  <content contentuid="h4d2eb6abgde1bg02e5g7229g271d5c3cc35b" version="1">Votre peau prend une légère lueur cristalline semblable à de la glace. Votre maximum de Points de vie augmente de 3, et il augmente de 1 chaque fois que vous gagnez un autre niveau d'Ensorceleur. De plus, le Terrain difficile composé de glace ou de neige ne vous coûte pas de mouvement supplémentaire, et lorsque vous marchez sur la glace, vous ne dépensez qu'30 cm de mouvement pour chaque 60 cm que vous parcourez.</content>
   <content contentuid="h41c12c6fg7222ge59egf356g102fa92de375" version="1">Niveau 6 : Cœur de glace</content>
-  <content contentuid="h46113845g2cf8g2693g39begd296035270d7" version="2">Lorsque vous infligez des dégâts de Froid à une créature de taille Grande ou inférieure avec un sort, vous pouvez tenter de la figer sur place. Si vous le faites, la Vitesse de cette créature est réduite de 15 pieds. Lorsque vous infligez des dégâts de Froid avec un sort, vous ajoutez votre modificateur de Charisme aux dégâts. Vous avez la Résistance aux dégâts de Froid.</content>
+  <content contentuid="h46113845g2cf8g2693g39begd296035270d7" version="2">Lorsque vous infligez des dégâts de Froid à une créature de taille Grande ou inférieure avec un sort, vous pouvez tenter de la figer sur place. Si vous le faites, la Vitesse de cette créature est réduite de 4,50 mètres. Lorsque vous infligez des dégâts de Froid avec un sort, vous ajoutez votre modificateur de Charisme aux dégâts. Vous avez la Résistance aux dégâts de Froid.</content>
   <content contentuid="hafa97bceg97c0gc97dgfa9fg414b6341027f" version="1">Cœur de glace</content>
-  <content contentuid="he015bc92g41b1g4d83gfa46ge61a66471197" version="1">La Vitesse est réduite de 15 pieds.</content>
+  <content contentuid="he015bc92g41b1g4d83gfa46ge61a66471197" version="1">La Vitesse est réduite de 4,50 mètres.</content>
   <content contentuid="h2be99baag9938gfc17g13cfg590c60db09e5" version="1">Sorcellerie du Givre</content>
   <content contentuid="hb8891366g1f90g73e0ge8d1ge4a2ec9f47e0" version="1">Votre magie est créée par des fragments de l'Évercœur, le centre et la force motrice derrière les terres désolées de l'Éverglacier en expansion. Ce pouvoir en vous pourrait être transmis par des ancêtres qui protégeaient le noyau magique du glacier, ou il pourrait vous avoir été imposé lors d'une rencontre fortuite avec la glace enchantée elle-même. Quelle que soit la source de votre pouvoir, vous êtes une créature de froid incarné.</content>
   <content contentuid="h2c47e364g0a41g1229g1e15g9ee56517f25c" version="1">Tranchefoudre</content>
-  <content contentuid="hfdadc829g334eg78cegcbaegac19146a68cc" version="1">Vous pouvez prendre une action Magique pour déchaîner un rayon d'éclair concentré depuis la lame en une Ligne de 60 pieds de long et 5 pieds de large. Chaque créature dans la Ligne doit effectuer un jet de sauvegarde de Dextérité DD 15, subissant 4d6 dégâts Foudre en cas d'échec ou la moitié en cas de succès.</content>
+  <content contentuid="hfdadc829g334eg78cegcbaegac19146a68cc" version="1">Vous pouvez prendre une action Magique pour déchaîner un rayon d'éclair concentré depuis la lame en une Ligne de 18 mètres de long et 1,50 mètre de large. Chaque créature dans la Ligne doit effectuer un jet de sauvegarde de Dextérité DD 15, subissant 4d6 dégâts Foudre en cas d'échec ou la moitié en cas de succès.</content>
   <content contentuid="h9191c661g0d83g945ag7a11gb64ae36d522c" version="2">Tranchefoudre</content>
   <content contentuid="he90d9b36g7ae9g73fcg730cg7f11303ec293" version="2">Forgée à partir d'acier touché par la tempête, cette lame fendue crépite d'éclairs captifs, portant la fureur d'une tempête dans son tranchant brillant.</content>
   <content contentuid="h5fe7400ag82f7g6073g3bcbgd343cec9bd16" version="1">Cette arme accorde un bonus de +[1] aux jets d'attaque, aux jets de dégâts, au &lt;LSTag Tooltip="SpellDifficultyClass"&gt;DD de sort&lt;/LSTag&gt; et aux &lt;LSTag Tooltip="AttackRoll"&gt;jets d'attaque&lt;/LSTag&gt; de sort.</content>
@@ -4155,8 +4244,8 @@ L'origine exacte de leur pouvoir divin déroute les anciens des religions établ
 
 La magie de ce domaine permet également à ces Clercs de retarder la mort un temps. Mais ce n'est qu'un délai de la mort, et non un refus de celle-ci, car la tombe réclamera toujours son dû.</content>
   <content contentuid="h2cb62f22g7258gc3fcg2b1cgccb378b2f59e" version="1">Niveau 3 : Sorts du domaine de la Tombe</content>
-  <content contentuid="he090be9bg8385g1850g97abg87aecc9a4555" version="1">Votre connexion à ce domaine divin vous assure d'avoir toujours certains sorts prêts. Lorsque vous atteignez un niveau de Clerc spécifié dans le tableau des sorts du domaine de la Tombe, vous avez désormais toujours les sorts listés préparés.</content>
-  <content contentuid="h32554089g3cb1g5105g77b7g4afa486c46cf" version="2">Le Domaine de la Tombe accorde les sorts suivants à mesure que vous gagnez des niveaux de Clerc : Protection contre le Mal et le Bien, Vie factice, Restauration mineure, Rayon d'affaiblissement et Stabilisation au 3e niveau ; Rappel à la vie et Toucher vampirique au 5e niveau ; Flétrissement et Sauvegarde contre la mort au 7e niveau ; et Dissipation du Mal et du Bien et Soin de groupe au 9e niveau.</content>
+  <content contentuid="he090be9bg8385g1850g97abg87aecc9a4555" version="1">Votre connexion à ce domaine divin vous assure d'avoir toujours certains sorts prêts. Lorsque vous atteignez un niveau de Clerc spécifié dans le tableau des sorts du domaine de la Tombe, vous avez désormais toujours les sorts listés préparés. Le Domaine de la Tombe accorde les sorts suivants à mesure que vous gagnez des niveaux de Clerc : Protection contre le mal et le bien, Simulacre de vie, Restauration partielle, Rayon affaiblissant et Stabilisation au 3e niveau ; Retour à la vie et Baiser du vampire au 5e niveau ; Flétrissement et Protection contre la mort au 7e niveau ; et Dissipation du mal et du bien et Soins de groupe au 9e niveau.</content>
+  <content contentuid="h32554089g3cb1g5105g77b7g4afa486c46cf" version="2">Le Domaine de la Tombe accorde les sorts suivants à mesure que vous gagnez des niveaux de Clerc : Protection contre le mal et le bien, Simulacre de vie, Restauration partielle, Rayon affaiblissant et Stabilisation au 3e niveau ; Rappel à la vie et Toucher vampirique au 5e niveau ; Flétrissement et Sauvegarde contre la mort au 7e niveau ; et Dissipation du Mal et du Bien et Soin de groupe au 9e niveau.</content>
   <content contentuid="h9091248cg6df4gf72fg6f2ag70c577bab5c1" version="1">Niveau 3 : Cercle de la mortalité</content>
   <content contentuid="h3c269efagf9cbgfc7dga3bag5ea715ef1024" version="1">Vous pouvez manipuler l'équilibre entre la vie et la mort, vous accordant les avantages suivants.
 
@@ -4166,13 +4255,13 @@ Retour à la vie. Vous pouvez lancer Stabilisation en tant qu'Action bonus.
 
 De plus, lorsque vous lanceriez normalement un ou plusieurs dés pour restaurer des Points de vie à une créature à 0 Point de vie avec un sort ou un Conduit divin, vous ne lancez pas ces dés. À la place, la créature récupère des Points de vie égaux à votre niveau de Clerc.</content>
   <content contentuid="h794dc21ag8b55ga792g3b31g88988c279134" version="1">Niveau 3 : Chemin vers la tombe</content>
-  <content contentuid="hf7e85ad5gadc6g23b3ge9bdgb92b56e72159" version="2">En tant qu'Action bonus, vous présentez votre Symbole sacré et dépensez une utilisation de Conduit divin pour maudire une créature que vous pouvez voir à 30 pieds ou moins de vous jusqu'au début de votre prochain tour. Pendant la malédiction, la créature a le Désavantage aux jets d'attaque et aux jets de sauvegarde.
+  <content contentuid="hf7e85ad5gadc6g23b3ge9bdgb92b56e72159" version="2">En tant qu'Action bonus, vous présentez votre Symbole sacré et dépensez une utilisation de Conduit divin pour maudire une créature que vous pouvez voir à 9 mètres ou moins de vous jusqu'au début de votre prochain tour. Pendant la malédiction, la créature a le Désavantage aux jets d'attaque et aux jets de sauvegarde.
 
 Lorsque vous ou un allié que vous pouvez voir touchez la cible maudite avec un jet d'attaque, vous pouvez mettre fin à la malédiction prématurément (aucune action requise) pour infliger des dégâts Nécrotiques ou Radieux supplémentaires (au choix) égaux à votre niveau de Clerc.</content>
   <content contentuid="h345ec71fg8b14gc4a2ge4f4g2ae275d3a891" version="1">Niveau 6 : Sentinelle au seuil de la mort</content>
-  <content contentuid="hb5512cccg4740g2f7dg76e9gd4d73b16a044" version="2">Lorsque vous ou une créature Ensanglantée que vous pouvez voir à 60 pieds ou moins de vous est touchée par un jet d'attaque, vous pouvez utiliser votre Réaction pour réduire de moitié les dégâts de cette attaque (arrondi à l'inférieur).</content>
+  <content contentuid="hb5512cccg4740g2f7dg76e9gd4d73b16a044" version="2">Lorsque vous ou une créature Ensanglantée que vous pouvez voir à 18 mètres ou moins de vous est touchée par un jet d'attaque, vous pouvez utiliser votre Réaction pour réduire de moitié les dégâts de cette attaque (arrondi à l'inférieur).</content>
   <content contentuid="h9f30b48cgc586g9ffdge56fg532847cbc56f" version="1">Chemin vers la tombe</content>
-  <content contentuid="h348d60dcgba3eg7259gaac2g9675ec8837a8" version="2">En tant qu'Action bonus, vous présentez votre Symbole sacré et dépensez une utilisation de Conduit divin pour maudire une créature que vous pouvez voir à 30 pieds ou moins de vous jusqu'au début de votre prochain tour. Pendant la malédiction, la créature a le Désavantage aux jets d'attaque et aux jets de sauvegarde.
+  <content contentuid="h348d60dcgba3eg7259gaac2g9675ec8837a8" version="2">En tant qu'Action bonus, vous présentez votre Symbole sacré et dépensez une utilisation de Conduit divin pour maudire une créature que vous pouvez voir à 9 mètres ou moins de vous jusqu'au début de votre prochain tour. Pendant la malédiction, la créature a le Désavantage aux jets d'attaque et aux jets de sauvegarde.
 
 Lorsque vous ou un allié que vous pouvez voir touchez la cible maudite avec un jet d'attaque, vous pouvez mettre fin à la malédiction prématurément (aucune action requise) pour infliger des dégâts Nécrotiques ou Radieux supplémentaires (au choix) égaux à votre niveau de Clerc.</content>
   <content contentuid="h95548fa8ge81cgbc76g7f69g8ac91ac34610" version="1">Chemin vers la tombe</content>
@@ -4181,12 +4270,12 @@ Lorsque vous ou un allié que vous pouvez voir touchez la cible maudite avec un 
   <content contentuid="h5085414dg5773gb367g17ffg56d92264887f" version="1">Lorsque vous ou un allié que vous pouvez voir touchez la cible maudite avec un jet d'attaque, vous pouvez mettre fin à la malédiction prématurément (aucune action requise) pour que l'attaque inflige des dégâts Nécrotiques ou Radieux supplémentaires (au choix) égaux à votre niveau de Clerc.</content>
   <content contentuid="h7fbdaf7cgb9dfg7914g321dg56535e4ef83f" version="1">Chemin vers la tombe (Nécrotique)</content>
   <content contentuid="h5412be87gc0d6gd027g88dbg46cccbb5f405" version="1">Sentinelle au seuil de la mort</content>
-  <content contentuid="h34c68c98gf84cgb2fcgd117g22156d427b46" version="2">Lorsque vous ou une créature Ensanglantée que vous pouvez voir à 60 pieds ou moins de vous est touchée par un jet d'attaque, vous pouvez utiliser votre Réaction pour réduire de moitié les dégâts de cette attaque (arrondi à l'inférieur).</content>
+  <content contentuid="h34c68c98gf84cgb2fcgd117g22156d427b46" version="2">Lorsque vous ou une créature Ensanglantée que vous pouvez voir à 18 mètres ou moins de vous est touchée par un jet d'attaque, vous pouvez utiliser votre Réaction pour réduire de moitié les dégâts de cette attaque (arrondi à l'inférieur).</content>
   <content contentuid="h40fa14d1gcd8ag4b04g332cg14f014f79df1" version="1">Vous pouvez utiliser cette fonctionnalité un nombre de fois égal à votre modificateur de Sagesse (minimum une fois). Vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
   <content contentuid="h75e81993g498fgad1ag49c0g16b6f5c596f1" version="1">Sentinelle au seuil de la mort</content>
   <content contentuid="h8186b8ecg7248g13b4ge3fbga7dd7bb29966" version="1">Sentinelle au seuil de la mort</content>
   <content contentuid="hf4f2bdedgddf2g2241g30f8g9a81f5a1e39e" version="1">Sentinelle au seuil de la mort</content>
-  <content contentuid="h7d224144gf1bcgdd1cg66e2g767541b3331e" version="1">Lorsque vous ou une créature Ensanglantée que vous pouvez voir à 60 pieds ou moins de vous est touchée par un jet d'attaque, vous pouvez utiliser votre Réaction pour réduire de moitié les dégâts de cette attaque (arrondi à l'inférieur).</content>
+  <content contentuid="h7d224144gf1bcgdd1cg66e2g767541b3331e" version="1">Lorsque vous ou une créature Ensanglantée que vous pouvez voir à 18 mètres ou moins de vous est touchée par un jet d'attaque, vous pouvez utiliser votre Réaction pour réduire de moitié les dégâts de cette attaque (arrondi à l'inférieur).</content>
   <content contentuid="h766f65e6g3d16g5e40g74e7ga8f8668f8d89" version="1">Chemin vers la tombe (Radieux)</content>
   <content contentuid="hbdf05572gfd6fgc2b8g94f7ga66183c724c7" version="1">Chemin vers la tombe (Nécrotique)</content>
   <content contentuid="hc89a1458g2a97g6f71g4ec2g2f90e1ca5dcf" version="1">Attrait de la mort</content>
@@ -4196,15 +4285,15 @@ Lorsque vous ou un allié que vous pouvez voir touchez la cible maudite avec un 
   <content contentuid="h9a3aa8d6g3cb8g0884g6d9eg5f6c2e19ad7b" version="1">Niveau 3 : Courroux du Sauvage</content>
   <content contentuid="hdce7e79bg8885g6824g9637g6951304ec5c7" version="1">Niveau 7 : Puissance affamée</content>
   <content contentuid="hf0a74333g96ebgca45ge544g1b9f0f8411cb" version="1">Niveau 11 : Pourriture et Violence</content>
-  <content contentuid="h02a16612g51dege910g582fg8824be4f2aee" version="1">Lorsque vous atteignez un niveau de Rôdeur spécifié dans le tableau des sorts du Gardien Creux, vous avez désormais toujours le sort listé préparé.</content>
+  <content contentuid="h02a16612g51dege910g582fg8824be4f2aee" version="1">Lorsque vous atteignez un niveau de Rôdeur spécifié dans le tableau des sorts du Gardien Creux, vous avez désormais toujours le sort listé préparé. Châtiment courroucé au 3e niveau, Invoquer une monture au 5e niveau et Esprits gardiens au 9e niveau.</content>
   <content contentuid="hd23192ffgdf59ga725g1c97g7e364650fe0c" version="1">Châtiment courroucé au 3e niveau, Invocation de monture au 5e niveau et Gardiens spirituels au 9e niveau.</content>
   <content contentuid="h4d2b70ecgee46g15a5g5c0bga91856311ba5" version="1">Vous puisez votre pouvoir dans les horreurs étranges et anciennes de la terre, vous faisant pousser des excroissances contre nature, comme des bois ensanglantés ou des crocs putrides, ou faisant s'allonger ou se tordre votre ombre autour de vous. En tant qu'Action bonus, vous pouvez dépenser une utilisation d'Ennemi juré pour vous transformer en une forme macabre, gagnant les avantages suivants pendant 1 minute ou jusqu'à ce que vous ayez l'état Neutralisé, mouriez ou mettiez fin à la transformation (aucune action requise).
 
 Armure ancestrale. Vous gagnez un bonus de +1 à la CA, car votre corps est enveloppé d'écorce pourrie et de poils bestials. Ce bonus passe à +2 lorsque vous atteignez le niveau 11 de Rôdeur.
 
-Rétribution rôdeuse. Immédiatement après qu'une créature que vous pouvez voir à 5 pieds ou moins de vous vous inflige des dégâts ou inflige des dégâts à l'un de vos alliés, vous pouvez effectuer une Attaque d'opportunité contre cette créature.
+Rétribution rôdeuse. Immédiatement après qu'une créature que vous pouvez voir à 1,50 mètre ou moins de vous vous inflige des dégâts ou inflige des dégâts à l'un de vos alliés, vous pouvez effectuer une Attaque d'opportunité contre cette créature.
 
-Aura inquiétante. Lorsque vous vous transformez et au début de chacun de vos tours suivants, chaque créature de votre choix dans une Émanation de 10 pieds prenant sa source en vous effectue un jet de sauvegarde de Sagesse contre votre DD de sort. En cas d'échec, une créature acquiert l'état Effrayé jusqu'au début de votre prochain tour.</content>
+Aura inquiétante. Lorsque vous vous transformez et au début de chacun de vos tours suivants, chaque créature de votre choix dans une Émanation de 3 mètres prenant sa source en vous effectue un jet de sauvegarde de Sagesse contre votre DD de sort. En cas d'échec, une créature acquiert l'état Effrayé jusqu'au début de votre prochain tour.</content>
   <content contentuid="h197a4fbbg54d8g3303g20b2ga713257e8f7a" version="1">Vous gagnez un bonus aux jets de sauvegarde de Constitution égal à votre modificateur de Sagesse (minimum de +1).
 
 De plus, une fois par tour lorsque vous touchez une créature avec un jet d'attaque pendant que vous êtes transformé grâce au Courroux du Sauvage, vous récupérez un nombre de Points de vie égal à 1d10 plus votre modificateur de Sagesse, à condition que vous soyez Ensanglanté lorsque vous touchez.</content>
@@ -4218,22 +4307,22 @@ Coups sinistres. Lorsque vous touchez une créature qui a l'état Effrayé avec 
 
 Armure ancestrale. Vous gagnez un bonus de +1 à la CA, car votre corps est enveloppé d'écorce pourrie et de poils bestials. Ce bonus passe à +2 lorsque vous atteignez le niveau 11 de Rôdeur.
 
-Rétribution rôdeuse. Immédiatement après qu'une créature que vous pouvez voir à 5 pieds ou moins de vous vous inflige des dégâts ou inflige des dégâts à l'un de vos alliés, vous pouvez effectuer une Attaque d'opportunité contre cette créature.
+Rétribution rôdeuse. Immédiatement après qu'une créature que vous pouvez voir à 1,50 mètre ou moins de vous vous inflige des dégâts ou inflige des dégâts à l'un de vos alliés, vous pouvez effectuer une Attaque d'opportunité contre cette créature.
 
-Aura inquiétante. Lorsque vous vous transformez et au début de chacun de vos tours suivants, chaque créature de votre choix dans une Émanation de 10 pieds prenant sa source en vous effectue un jet de sauvegarde de Sagesse contre votre DD de sort. En cas d'échec, une créature acquiert l'état Effrayé jusqu'au début de votre prochain tour.</content>
+Aura inquiétante. Lorsque vous vous transformez et au début de chacun de vos tours suivants, chaque créature de votre choix dans une Émanation de 3 mètres prenant sa source en vous effectue un jet de sauvegarde de Sagesse contre votre DD de sort. En cas d'échec, une créature acquiert l'état Effrayé jusqu'au début de votre prochain tour.</content>
   <content contentuid="h6bf206d3ga5dag2afag19eegf2c35e7a534e" version="1">Vous avez toujours Marque du chasseur préparé. Vous pouvez le lancer sans dépenser d'emplacement de sort un nombre de fois égal à la valeur indiquée dans la colonne Ennemi juré du tableau des Caractéristiques du Rôdeur. Vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
   <content contentuid="h0707320dgdc67g5261gca84g8c7ba39b2add" version="1">Vous pouvez lancer Marque du chasseur sans dépenser d'emplacement de sort deux fois au 1er niveau, trois fois au 5e niveau et quatre fois au 9e niveau.</content>
   <content contentuid="h41856fd8g557fg1204g89c3gd79299a20aba" version="1">Courroux du Sauvage</content>
   <content contentuid="h5b50bb5cg8fd5g63ccgdf38gc338449b5822" version="1">Vous puisez votre pouvoir dans les horreurs étranges et anciennes de la terre, vous faisant pousser des excroissances contre nature, comme des bois ensanglantés ou des crocs putrides, ou faisant s'allonger ou se tordre votre ombre autour de vous. En tant qu'Action bonus, vous pouvez dépenser une utilisation d'Ennemi juré pour vous transformer en une forme macabre, gagnant les avantages suivants pendant 1 minute ou jusqu'à ce que vous ayez l'état Neutralisé, mouriez ou mettiez fin à la transformation (aucune action requise).</content>
   <content contentuid="hf1d97e50g4266g20d2gfa31gc28b01a57f91" version="1">Rétribution rôdeuse</content>
-  <content contentuid="hd4469619g376dg9d74gbfb4gb103475e4356" version="1">Immédiatement après qu'une créature que vous pouvez voir à 5 pieds ou moins de vous vous inflige des dégâts ou inflige des dégâts à l'un de vos alliés, vous pouvez effectuer une Attaque d'opportunité contre cette créature.</content>
+  <content contentuid="hd4469619g376dg9d74gbfb4gb103475e4356" version="1">Immédiatement après qu'une créature que vous pouvez voir à 1,50 mètre ou moins de vous vous inflige des dégâts ou inflige des dégâts à l'un de vos alliés, vous pouvez effectuer une Attaque d'opportunité contre cette créature.</content>
   <content contentuid="hcb469b5ag81e6gc10dgf121g03e0273e12e0" version="1">Aura inquiétante</content>
-  <content contentuid="hfe6b221fg701bg9db4gdb32ga44f7bac6573" version="1">Lorsque vous vous transformez et au début de chacun de vos tours suivants, chaque créature de votre choix dans une Émanation de 10 pieds prenant sa source en vous effectue un jet de sauvegarde de Sagesse contre votre DD de sort. En cas d'échec, une créature acquiert l'état Effrayé jusqu'au début de votre prochain tour.</content>
+  <content contentuid="hfe6b221fg701bg9db4gdb32ga44f7bac6573" version="1">Lorsque vous vous transformez et au début de chacun de vos tours suivants, chaque créature de votre choix dans une Émanation de 3 mètres prenant sa source en vous effectue un jet de sauvegarde de Sagesse contre votre DD de sort. En cas d'échec, une créature acquiert l'état Effrayé jusqu'au début de votre prochain tour.</content>
   <content contentuid="hccc59875g41d7g8efag4ac7gd30ae86a609f" version="1">Puissance affamée</content>
   <content contentuid="h5d295166ga39bg4056gc6afg3170dfffabae" version="1">Vous récupérez un nombre de Points de vie égal à 1d10 plus votre modificateur de Sagesse.</content>
   <content contentuid="h69a7fb39g6a1dg8cc5g6b7egf436399cf817" version="1">Aura menaçante</content>
   <content contentuid="h2dd6c79cg9334g06a2g3d43geab02d13b382" version="1">Lorsqu'une créature échoue à son jet de sauvegarde contre l'Aura inquiétante, elle ne peut pas non plus récupérer des Points de vie ni prendre de Réactions jusqu'au début de votre prochain tour.</content>
-  <content contentuid="hf16702a8g0c7fgdd18g3ea0g64f4822587ba" version="1">Lorsque vous lancez un tour de magie de Sorcier-Lié, ajoutez votre &lt;LSTag Tooltip="Charisma"&gt;Charisme&lt;/LSTag&gt; &lt;LSTag Tooltip="AbilityModifier"&gt;Modificateur&lt;/LSTag&gt; aux dégâts qu'il inflige, sauf s'il est négatif.</content>
+  <content contentuid="hf16702a8g0c7fgdd18g3ea0g64f4822587ba" version="1">Lorsque vous lancez un sort mineur d'Occultiste, ajoutez votre &lt;LSTag Tooltip="Charisma"&gt;Charisme&lt;/LSTag&gt; &lt;LSTag Tooltip="AbilityModifier"&gt;Modificateur&lt;/LSTag&gt; aux dégâts qu'il inflige, sauf s'il est négatif.</content>
   <content contentuid="h82eeb0d5g97f8gb543g1fccgc1ddce66a5b2" version="2">Patron Mort-vivant</content>
   <content contentuid="h8fe28200g46b7g051cga5b0ga6bd5b6a5b73" version="1">Vous avez conclu un pacte avec une créature qui défie le cycle de la vie et de la mort : un puissant liche, un vampire ou une autre entité de la mort-vivance. Ayant autrefois été mortels, ces anciens patrons connaissent de première main les voies de l'ambition et les routes au-delà des portes de la mort. Ils partagent avidement ces connaissances profanes et d'autres secrets avec ceux qui exécutent leur volonté parmi les vivants.</content>
   <content contentuid="hf3e7b3e5gd803gdb85g050dg99a565121fbd" version="1">Niveau 3 : Forme de terreur</content>
@@ -4241,12 +4330,12 @@ Aura inquiétante. Lorsque vous vous transformez et au début de chacun de vos t
 
 Avatar terrifiant. Une fois par tour, lorsque vous touchez une créature avec un jet d'attaque, vous pouvez la forcer à effectuer un jet de sauvegarde de Sagesse contre votre DD de sort. En cas d'échec, la cible acquiert l'état Effrayé jusqu'à la fin de votre prochain tour.</content>
   <content contentuid="hcd558b81gae7eg26dag6eaegf0f7e3dd0197" version="1">Niveau 3 : Sorts du Mort-vivant</content>
-  <content contentuid="h72a8bf1agc8fbgec94g5bd1g5c0893342c80" version="1">La magie de votre patron vous assure d'avoir toujours certains sorts prêts ; lorsque vous atteignez un niveau de Sorcier-Lié spécifié dans le tableau des sorts du Mort-vivant, vous avez désormais toujours les sorts listés préparés.</content>
+  <content contentuid="h72a8bf1agc8fbgec94g5bd1g5c0893342c80" version="1">La magie de votre patron vous assure d'avoir toujours certains sorts prêts ; lorsque vous atteignez un niveau d'Occultiste spécifié dans le tableau des sorts du Mort-vivant, vous avez désormais toujours les sorts listés préparés. Au 3e niveau, vous apprenez Imprécation, Cécité, Force fantasmagorique et Rayon empoisonné. Au 5e niveau, vous apprenez Communication avec les morts et Animation des morts. Au 7e niveau, vous apprenez Invisibilité suprême et Assassin imaginaire. Au 9e niveau, vous apprenez Danse macabre et Brume mortelle.</content>
   <content contentuid="h423f4d8eg647cg79b9g302bg9ad97549087a" version="2">Au 3e niveau, vous apprenez Fléau, Cécité, Force fantasmagorique et Rayon de maladie. Au 5e niveau, vous apprenez Parler avec les morts et Animation des morts. Au 7e niveau, vous apprenez Invisibilité supérieure et Assassin fantasmagorique. Au 9e niveau, vous apprenez Danse macabre et Nuage mortel.</content>
   <content contentuid="h51d8435ag421eg4abdg2702ga3868c2dab5c" version="1">Niveau 6 : Touché par la tombe</content>
   <content contentuid="h9978d0deg7d77g5755g43fbg0caf50e3b407" version="2">Les pouvoirs de votre patron ont un effet profond sur votre corps et votre magie, vous accordant les avantages suivants.
 
-Nécrose arcanique. Les dégâts Nécrotiques de vos attaques, sorts de Sorcier-Lié et capacités de Sorcier-Lié ignorent la Résistance aux dégâts Nécrotiques.
+Nécrose arcanique. Les dégâts Nécrotiques de vos attaques, sorts d'Occultiste et capacités d'Occultiste ignorent la Résistance aux dégâts Nécrotiques.
 
 Nécrose redoutable. Les sorts que vous lancez et les attaques que vous effectuez ignorent la &lt;LSTag Tooltip="Resistant"&gt;Résistance&lt;/LSTag&gt; aux dégâts Nécrotiques. De plus, lorsque vous infligez des dégâts Nécrotiques avec un sort, vous ne pouvez pas obtenir un [1].
 
@@ -4256,7 +4345,7 @@ Endurance morte-vivante. Vous n'avez pas besoin de dormir, et la magie ne peut p
 
 Résilience nécrotique. Vous avez l'Immunité aux dégâts Nécrotiques.</content>
   <content contentuid="hcaaac561g47fbgc64dga290gc1f58fa033fa" version="1">Déluge astral</content>
-  <content contentuid="h08797ed7gc753g8f41gd903g4ec54ed567d1" version="1">Vous canalisez de l'énergie depuis la Mer astrale pour déchaîner un torrent de magie depuis vous dans un Cône de 30 pieds. Chaque créature dans le Cône doit réussir un jet de sauvegarde de Dextérité ou subir des dégâts Radieux. La cible ne peut voir qu'à 15 pieds d'elle-même, et elle a l'état Aveuglé pour tout ce qui est au-delà de cette distance jusqu'à la fin de votre prochain tour.</content>
+  <content contentuid="h08797ed7gc753g8f41gd903g4ec54ed567d1" version="1">Vous canalisez de l'énergie depuis la Mer astrale pour déchaîner un torrent de magie depuis vous dans un Cône de 9 mètres. Chaque créature dans le Cône doit réussir un jet de sauvegarde de Dextérité ou subir des dégâts Radiants. La cible ne peut voir qu'à 4,50 mètres d'elle-même, et elle a l'état Aveuglé pour tout ce qui est au-delà de cette distance jusqu'à la fin de votre prochain tour.</content>
   <content contentuid="h7b203ccagf3bbgbc50ge697g2f7d6dd55d71" version="1">Classes utilisables : Ensorceleur, Magicien</content>
   <content contentuid="h5cc2b487g9e1cg67f3gff45gb8bebf140d50" version="1">Classes utilisables : Ensorceleur, Magicien</content>
   <content contentuid="h81b6ff86g5390gac9bg1d77ga53e64111601" version="1">Classes utilisables : Ensorceleur, Magicien</content>
@@ -4264,29 +4353,29 @@ Résilience nécrotique. Vous avez l'Immunité aux dégâts Nécrotiques.</conte
   <content contentuid="hc5d990c5g4bc9g584ag42c3g14e89f46c133" version="1">Classes utilisables : Druide, Ensorceleur, Magicien</content>
   <content contentuid="hea71fda5ge282g59e5g6655g9ddd810de96b" version="1">Classes utilisables : Druide, Ensorceleur</content>
   <content contentuid="h9a00c633g9e59gdb51g8d17g33a090a4b718" version="1">Classes utilisables : Barde, Ensorceleur, Magicien</content>
-  <content contentuid="h3bfc9f9egcbcfgb28fg8505ga053e8195000" version="1">Classes utilisables : Druide, Ensorceleur, Sorcier-Lié, Magicien</content>
-  <content contentuid="hdc575017g0d8dgb342gd41bg10a869827f81" version="1">Classes utilisables : Ensorceleur, Sorcier-Lié, Magicien</content>
+  <content contentuid="h3bfc9f9egcbcfgb28fg8505ga053e8195000" version="1">Classes utilisables : Druide, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="hdc575017g0d8dgb342gd41bg10a869827f81" version="1">Classes utilisables : Ensorceleur, Occultiste, Magicien</content>
   <content contentuid="hb9aeb007g1897g208eg83f7g7edbb0f8ef8c" version="1">Classes utilisables : Ensorceleur, Magicien</content>
   <content contentuid="h112db883g654cga8e4ga30cg28987b743aac" version="1">Classes utilisables : Barde, Druide, Ensorceleur, Magicien</content>
   <content contentuid="h00d06463gd5ceg24d8gecefgfe155fa64a8a" version="1">Classes utilisables : Druide, Magicien</content>
   <content contentuid="h36b518acg95c4ge183g4e63gd3392cb3da45" version="1">Classes utilisables : Druide, Magicien</content>
   <content contentuid="h0be24935g2030g85b3gc306g2bb41fc4e3ae" version="1">Classes utilisables : Barde, Ensorceleur, Magicien</content>
-  <content contentuid="h5b9af6b6g0fb9g76bfge6acg31f03b6be9ab" version="1">Classes utilisables : Barde, Ensorceleur, Sorcier-Lié, Magicien</content>
+  <content contentuid="h5b9af6b6g0fb9g76bfge6acg31f03b6be9ab" version="1">Classes utilisables : Barde, Ensorceleur, Occultiste, Magicien</content>
   <content contentuid="h081d2ca7g938fg7b8cgabc2g3ebfd3f20918" version="2">Classes utilisables : Barde, Clerc, Druide, Magicien</content>
   <content contentuid="h9ce29b2fg9512g42fcg0bb3g0130eac87437" version="1">Classes utilisables : Druide, Ensorceleur, Magicien</content>
-  <content contentuid="hb5449aaeg0cdag7016g618ag5818eb654495" version="1">Classes utilisables : Artificier, Ensorceleur, Sorcier-Lié, Magicien</content>
+  <content contentuid="hb5449aaeg0cdag7016g618ag5818eb654495" version="1">Classes utilisables : Artificier, Ensorceleur, Occultiste, Magicien</content>
   <content contentuid="h8ce9a23egb8a0gb9d7gd45fga0d286bbc402" version="1">Classes utilisables : Ensorceleur, Magicien</content>
-  <content contentuid="hc21389d1g0818gfd8cg1028g98e4b6dfab5f" version="1">Classes utilisables : Ensorceleur, Sorcier-Lié, Magicien</content>
+  <content contentuid="hc21389d1g0818gfd8cg1028g98e4b6dfab5f" version="1">Classes utilisables : Ensorceleur, Occultiste, Magicien</content>
   <content contentuid="h99da7e22g12afgd783gdbf2gc858ed098a7c" version="1">Classes utilisables : Ensorceleur, Magicien</content>
   <content contentuid="ha12ea06dg5003g6e60gc979g1f90ad6c1484" version="1">Classes utilisables : Artificier, Barde, Clerc, Magicien</content>
   <content contentuid="h53ebe725g777bg732bgd58fg65c4f7d7f4a5" version="1">Classes utilisables : Artificier, Ensorceleur, Magicien</content>
-  <content contentuid="hb1711043gacb3g9782g2cf8g32a2ec0ff2ea" version="1">Classes utilisables : Barde, Ensorceleur, Sorcier-Lié, Magicien</content>
-  <content contentuid="hdd2cf90fg0261g02b3gae25gfb176a817222" version="1">Classes utilisables : Barde, Ensorceleur, Sorcier-Lié, Magicien</content>
+  <content contentuid="hb1711043gacb3g9782g2cf8g32a2ec0ff2ea" version="1">Classes utilisables : Barde, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="hdd2cf90fg0261g02b3gae25gfb176a817222" version="1">Classes utilisables : Barde, Ensorceleur, Occultiste, Magicien</content>
   <content contentuid="h62899232g86b6gcbbag7509g512371a04a09" version="1">Classes utilisables : Druide, Ensorceleur, Magicien</content>
   <content contentuid="h92ddaa49ge22bg88d7gdd71g0018b45092c4" version="1">Classes utilisables : Barde, Ensorceleur, Magicien</content>
   <content contentuid="h7d350fc2gaf25g08f0g58f4g2246514bfbb4" version="1">Classes utilisables : Barde, Magicien</content>
   <content contentuid="he09832a9g1034gf61eg906bg73be5b1aa940" version="1">Classes utilisables : Barde, Magicien</content>
-  <content contentuid="h871fa494g4b4eg1958g9389g7d0935b4ff7b" version="1">Classes utilisables : Barde, Clerc, Druide, Sorcier-Lié, Magicien</content>
+  <content contentuid="h871fa494g4b4eg1958g9389g7d0935b4ff7b" version="1">Classes utilisables : Barde, Clerc, Druide, Occultiste, Magicien</content>
   <content contentuid="h631b429cg3757gfc36gdba0ga51c780084b6" version="1">Classes utilisables : Barde, Druide, Ensorceleur, Magicien</content>
   <content contentuid="hf991584cg399dge2a2g8552gf07ff0b4b8d3" version="1">Classes utilisables : Artificier, Clerc, Druide, Rôdeur, Ensorceleur, Magicien</content>
   <content contentuid="h8b5be3bcge99dg7031gbde6g1d904a4e7ab7" version="1">Classes utilisables : Artificier, Magicien</content>
@@ -4295,26 +4384,26 @@ Résilience nécrotique. Vous avez l'Immunité aux dégâts Nécrotiques.</conte
   <content contentuid="h094ae749g82a5g27f5g5963g3c4b4de8ae2a" version="1">Classes utilisables : Barde, Ensorceleur, Magicien</content>
   <content contentuid="h96da94d7gf3f8g932bgd0d2g8c8fecea83ea" version="1">Classes utilisables : Barde, Ensorceleur, Magicien</content>
   <content contentuid="hcb7bb507ge7f5g0a9egc740gd2e42ec643dd" version="1">Classes utilisables : Artificier, Druide, Rôdeur, Ensorceleur, Magicien</content>
-  <content contentuid="h490fc0dege26fg9f86gebe5ge9fe1504744d" version="1">Classes utilisables : Ensorceleur, Sorcier-Lié, Magicien</content>
-  <content contentuid="h405a2a4dgacbdgeb6bg4dcfg074c58afd9b7" version="1">Classes utilisables : Barde, Ensorceleur, Sorcier-Lié, Magicien</content>
+  <content contentuid="h490fc0dege26fg9f86gebe5ge9fe1504744d" version="1">Classes utilisables : Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h405a2a4dgacbdgeb6bg4dcfg074c58afd9b7" version="1">Classes utilisables : Barde, Ensorceleur, Occultiste, Magicien</content>
   <content contentuid="h498bbe50g966fg2071g8171gfed451e31514" version="1">Classes utilisables : Ensorceleur, Magicien</content>
   <content contentuid="h265185b6gb7e4gbe1dgf258g5b026be55064" version="1">Classes utilisables : Druide, Ensorceleur, Magicien</content>
   <content contentuid="hfd8df497g28c9g3b75gc242gfa87f646de28" version="1">Classes utilisables : Magicien</content>
   <content contentuid="h76da8d92g272dgb35ag7f49g0604c8aceb3f" version="1">Classes utilisables : Artificier, Druide, Ensorceleur, Magicien</content>
   <content contentuid="h43586658g7269g4ac9g84f4g92239e7e5113" version="1">Classes utilisables : Druide, Ensorceleur, Magicien</content>
-  <content contentuid="h82fcd113g91bcg7a32g7db2g7a9bb77bc1a9" version="1">Classes utilisables : Barde, Ensorceleur, Sorcier-Lié, Magicien</content>
+  <content contentuid="h82fcd113g91bcg7a32g7db2g7a9bb77bc1a9" version="1">Classes utilisables : Barde, Ensorceleur, Occultiste, Magicien</content>
   <content contentuid="h0d09994cgb932g4c8bg28b6g6a5d21972441" version="1">Classes utilisables : Ensorceleur, Magicien</content>
   <content contentuid="h41e92c9cgd1e2gd267g02c4geb8bae5ebc9c" version="1">Classes utilisables : Clerc, Druide, Ensorceleur, Magicien</content>
   <content contentuid="h1e3fa5f7g9907g40dag9d6ag90042eff8573" version="2">Patron Lame maudite</content>
-  <content contentuid="h76260c1cg2fd0ga2b1gf453g7108d2706083" version="1">Vous avez conclu un pacte avec une arme magique sentiente et les forces maudites contenues dans sa lame. Une telle arme pourrait être l'épée au côté d'un Sorcier-Lié, ou il pourrait s'agir d'une arme magique infâme conservée ailleurs, projetant son pouvoir à travers le multivers pour faire avancer ses plans rusés. À ceux qui sont prêts à suivre ses caprices, ces patrons insondables accordent le pouvoir d'infliger des malédictions malignes, de porter des coups punitifs et de renforcer leurs porteurs.</content>
+  <content contentuid="h76260c1cg2fd0ga2b1gf453g7108d2706083" version="1">Vous avez conclu un pacte avec une arme magique sentiente et les forces maudites contenues dans sa lame. Une telle arme pourrait être l'épée au côté d'un Occultiste, ou il pourrait s'agir d'une arme magique infâme conservée ailleurs, projetant son pouvoir à travers le multivers pour faire avancer ses plans rusés. À ceux qui sont prêts à suivre ses caprices, ces patrons insondables accordent le pouvoir d'infliger des malédictions malignes, de porter des coups punitifs et de renforcer leurs porteurs.</content>
   <content contentuid="h41b0a1dbg7c44g6848gbf1ag34105de9296b" version="2">Patron Archefée</content>
-  <content contentuid="h5e78186dgabebg2b99g11acg070fef938db4" version="2">Votre pacte puise dans le pouvoir du Féeroyaume. Lorsque vous choisissez cette sous-classe, vous pourriez conclure un accord avec une archefée, comme le Prince du Givre ; la Reine de l'Air et des Ténèbres, souveraine de la Cour du Crépuscule ; Titania de la Cour d'Été ; ou une ancienne sorcière. Ou vous pourriez invoquer un spectre de Fées, tissant un réseau de faveurs et de dettes. Qui qu'ils soient, votre patron est souvent insondable et capricieux.</content>
+  <content contentuid="h5e78186dgabebg2b99g11acg070fef938db4" version="2">Votre pacte puise dans le pouvoir de la Féérie sauvage. Lorsque vous choisissez cette sous-classe, vous pourriez conclure un accord avec une archefée, comme le Prince du Givre ; la Reine de l'Air et des Ténèbres, souveraine de la Cour du Crépuscule ; Titania de la Cour d'Été ; ou une ancienne sorcière. Ou vous pourriez invoquer un spectre de Fées, tissant un réseau de faveurs et de dettes. Qui qu'ils soient, votre patron est souvent insondable et capricieux.</content>
   <content contentuid="hd55742dag24b8g9010g614cg8ff311ddd61a" version="1">Patron Fiélon</content>
   <content contentuid="h52d5cbc0g4e75gc1bfgaf8egc799b8481188" version="1">Vous avez engagé votre âme aux Enfers ou à l'Abysse en échange d'un arsenal mortel d'arcanies démoniaques.</content>
   <content contentuid="ha989ddfeg14aege15egc09fgf298fc8f086e" version="1">Patron Grand Ancien</content>
   <content contentuid="h3504f51eg1ac0gd563g881eg515b53b1f37b" version="1">Lorsque vous choisissez cette sous-classe, vous pourriez vous lier à un être indicible du Lointain Royaume ou à un dieu ancien — un être comme Tharizdun, le Dieu enchaîné ; Zargon, le Revenant ; Hadar, la Faim des ténèbres ; ou le Grand Cthulhu. Ou vous pourriez invoquer plusieurs entités sans vous lier à une seule. Les motivations de ces êtres sont incompréhensibles, et le Grand Ancien pourrait être indifférent à votre existence. Mais les secrets que vous avez appris vous permettent néanmoins d'en tirer une magie étrange.</content>
   <content contentuid="h68dcfb27g52ddg20aag7977g147e317f34ce" version="1">Niveau 3 : Sorts de la Lame maudite</content>
-  <content contentuid="h4336900ag6e5egc73bgadb8g0a8300eeb536" version="1">La magie de votre patron vous assure d'avoir toujours certains sorts préparés. Lorsque vous atteignez un niveau de Sorcier-Lié spécifié dans le tableau des sorts de la Lame maudite, vous avez désormais toujours les sorts listés préparés.</content>
+  <content contentuid="h4336900ag6e5egc73bgadb8g0a8300eeb536" version="1">La magie de votre patron vous assure d'avoir toujours certains sorts préparés. Lorsque vous atteignez un niveau d'Occultiste spécifié dans le tableau des sorts de la Lame maudite, vous avez désormais toujours les sorts listés préparés. Au 3e niveau, vous apprenez Vigueur arcanique, Maléfice, Arme magique, Bouclier et Châtiment courroucé. Au 5e niveau, vous apprenez Malédiction et Hérissement de projectiles. Au 7e niveau, vous apprenez Liberté de mouvement et Châtiment débilitant. Au 9e niveau, vous apprenez Frappe des vents d'acier.</content>
   <content contentuid="h6b8ec4b1g6350g0a0ag1d7dgc74d66ad8dd7" version="1">Au 3e niveau, vous apprenez Vigueur arcanique, Maléfice, Arme magique, Bouclier, Châtiment courroucé. Au 5e niveau, vous apprenez Malédiction et Déluge. Au 7e niveau, vous apprenez Liberté de mouvement, Châtiment déconcertant. Au 9e niveau, vous apprenez Frappe du vent d'acier.</content>
   <content contentuid="hfa17cac1gac88g9d72gf29eg0946ab8c0bb4" version="1">Niveau 3 : Manifestation de la Lame maudite</content>
   <content contentuid="ha92a78f3ge96agd47egb8ddg6ad716d3cc56" version="3">Malédiction de la Lame maudite. Vous pouvez lancer Maléfice sans dépenser d'emplacement de sort un nombre de fois égal à votre modificateur de Charisme (minimum une fois), et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long. Lorsque vous lancez Maléfice, une arme spectrale ressemblant à votre patron orbite autour de la cible maudite.
@@ -4416,33 +4505,33 @@ Les goliaths ont des caractéristiques physiques qui rappellent les géants dans
   <content contentuid="hcf571c87ge866geaedge93eg4b1d41f25793" version="1">Goliath</content>
   <content contentuid="h53df4a2egf34cge0cegdbaeg961cb646fadd" version="1">Les goliaths sont des descendants lointains des géants et cherchent à atteindre des sommets dépassant ceux de leurs ancêtres.</content>
   <content contentuid="hce152759gc1e1g418cgcf1agfab6759d882e" version="1">Ascendance géante : Géant des nuages</content>
-  <content contentuid="had6cf5adg8eb1gc683g7f11gab246e2b6b44" version="2">Escapade des nuages (Géant des nuages). En tant qu'Action bonus, vous vous téléportez magiquement jusqu'à 30 pieds vers un espace inoccupé que vous pouvez voir.</content>
+  <content contentuid="had6cf5adg8eb1gc683g7f11gab246e2b6b44" version="2">Escapade des nuages (Géant des nuages). En tant qu'Action bonus, vous vous téléportez magiquement jusqu'à 9 mètres vers un espace inoccupé que vous pouvez voir.</content>
   <content contentuid="h297e6dcbgbedbg0037ga402g524f90049893" version="1">Ascendance géante : Géant du feu</content>
   <content contentuid="he807aa9age4ccga253g9743gd1a253159665" version="1">Brûlure du feu (Géant du feu). Lorsque vous touchez une cible avec un jet d'attaque et lui infligez des dégâts, vous pouvez également lui infliger 1d10 dégâts de Feu.</content>
   <content contentuid="h51b85e6cg91c9g2e69ga921ga3e9856e5b2c" version="1">Ascendance géante : Géant du givre</content>
-  <content contentuid="h6f446eaeg8ec6g19c7g34a6gf2ed7fde9501" version="1">Froid du givre (Géant du givre). Lorsque vous touchez une cible avec un jet d'attaque et lui infligez des dégâts, vous pouvez également lui infliger 1d6 dégâts de Froid et réduire sa Vitesse de 10 pieds jusqu'au début de votre prochain tour.</content>
+  <content contentuid="h6f446eaeg8ec6g19c7g34a6gf2ed7fde9501" version="1">Froid du givre (Géant du givre). Lorsque vous touchez une cible avec un jet d'attaque et lui infligez des dégâts, vous pouvez également lui infliger 1d6 dégâts de Froid et réduire sa Vitesse de 3 mètres jusqu'au début de votre prochain tour.</content>
   <content contentuid="h1ac94e1cge830g5902g72eag69029753a94b" version="1">Ascendance géante : Géant des collines</content>
   <content contentuid="hb2925e5dgb422g689cgfe37g45413ec054f1" version="1">Chute des collines (Géant des collines). Lorsque vous touchez une créature de taille Grande ou inférieure avec un jet d'attaque et lui infligez des dégâts, vous pouvez lui infliger l'état À terre.</content>
   <content contentuid="h93939658gac4fgd417g1ad0gb5ba75bb2ea6" version="1">Ascendance géante : Géant de pierre</content>
   <content contentuid="h09a0bd7fg8439g3ebbg63abg78025f642aab" version="1">Endurance de pierre (Géant de pierre). Lorsque vous subissez des dégâts, vous pouvez utiliser votre Réaction pour lancer 1d12. Ajoutez votre modificateur de Constitution au résultat et réduisez les dégâts de ce total.</content>
   <content contentuid="h9cd64908gcb06gfdd5g1d19g351cc167fcfc" version="1">Ascendance géante : Géant des tempêtes</content>
-  <content contentuid="h58289e87g34a5g2ffdg308dge576a637a4d7" version="1">Tonnerre des tempêtes (Géant des tempêtes). Lorsque vous subissez des dégâts d'une créature à 60 pieds ou moins de vous, vous pouvez utiliser votre Réaction pour lui infliger 1d8 dégâts de Tonnerre.</content>
+  <content contentuid="h58289e87g34a5g2ffdg308dge576a637a4d7" version="1">Tonnerre des tempêtes (Géant des tempêtes). Lorsque vous subissez des dégâts d'une créature à 18 mètres ou moins de vous, vous pouvez utiliser votre Réaction pour lui infliger 1d8 dégâts de Tonnerre.</content>
   <content contentuid="h30624b26g7d8bgc040g2e6dgfef7836f5019" version="1">Ascendance géante</content>
   <content contentuid="hbfc7d66dgd649g2d81g9f50ga79cce5da957" version="1">Vous êtes un descendant de Géants. Choisissez l'un des avantages suivants — une grâce surnaturelle de votre ascendance ; vous pouvez utiliser l'avantage choisi un nombre de fois égal à votre bonus de maîtrise, et vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long :</content>
   <content contentuid="h7c22fcc1g0e9ag6fd2g21d9g5c933a3fdc0d" version="1">Constitution robuste</content>
   <content contentuid="h0173efabg1383ge3d4g48f1g947ac6978c5b" version="2">Vous avez l'Avantage à tout test de caractéristique que vous effectuez pour mettre fin à l'état Entravé. Votre capacité de charge est augmentée d'un quart.</content>
   <content contentuid="h7fa26bbcgfc27g49d1g9176g83491cbaf4bf" version="2">Humaine</content>
   <content contentuid="h87059730gb37aga16ag3703gbaaea8527528" version="1">Résistance céleste</content>
-  <content contentuid="h5f178becg3db2geb81g5414g5c6e0287715f" version="1">Vous avez la Résistance aux dégâts Nécrotiques et aux dégâts Radieux.</content>
+  <content contentuid="h5f178becg3db2geb81g5414g5c6e0287715f" version="1">Vous avez la Résistance aux dégâts Nécrotiques et aux dégâts Radiants.</content>
   <content contentuid="h28d61c0bg65ddgf141gf093g53b6a58f6196" version="1">Mains guérisseuses</content>
   <content contentuid="h41691e6fg7ecbgcaa8ga939gf512c0bc7016" version="1">En tant qu'action Magique, vous touchez une créature et lancez un nombre de d4 égal à votre bonus de maîtrise. La créature récupère un nombre de Points de vie égal au total obtenu. Une fois que vous avez utilisé ce trait, vous ne pouvez pas l'utiliser à nouveau jusqu'à ce que vous terminiez un Repos long.</content>
   <content contentuid="h4545e270g8facg12e9geda5gd28be0c71012" version="1">Porteur de lumière</content>
-  <content contentuid="h1e2aaf16gdbc2g54c6g171cgeae9eb0ce5c5" version="1">Vous connaissez le tour de magie Lumière.</content>
+  <content contentuid="h1e2aaf16gdbc2g54c6g171cgeae9eb0ce5c5" version="1">Vous connaissez le sort mineur Lumière.</content>
   <content contentuid="hc5a84737g0024g47c9g1052gdf0e4350d3ec" version="1">Ailes célestes. Deux ailes spectrales jaillissent temporairement de votre dos. Jusqu'à la fin de la transformation, vous avez une Vitesse de vol égale à votre Vitesse.
 
-Radiance intérieure. Une lumière ardente rayonne temporairement de vos yeux et de votre bouche. Pendant la durée, vous émettez une Lumière vive dans un rayon de 10 pieds et une Lumière faible sur 10 pieds supplémentaires, et à la fin de chacun de vos tours, chaque créature à 10 pieds ou moins de vous subit des dégâts Radieux égaux à votre bonus de maîtrise.
+Radiance intérieure. Une lumière ardente rayonne temporairement de vos yeux et de votre bouche. Pendant la durée, vous émettez une Lumière vive dans un rayon de 3 mètres et une Lumière faible sur 3 mètres supplémentaires, et à la fin de chacun de vos tours, chaque créature à 3 mètres ou moins de vous subit des dégâts Radiants égaux à votre bonus de maîtrise.
 
-Linceul nécrotique. Vos yeux deviennent brièvement des puits d'obscurité, et des ailes sans vol jaillissent temporairement de votre dos. Les créatures autres que vos alliés à 10 pieds ou moins de vous doivent réussir un jet de sauvegarde de Charisme (DD 8 plus votre modificateur de Charisme et bonus de maîtrise) ou acquérir l'état Effrayé jusqu'à la fin de votre prochain tour.</content>
+Linceul nécrotique. Vos yeux deviennent brièvement des puits d'obscurité, et des ailes sans vol jaillissent temporairement de votre dos. Les créatures autres que vos alliés à 3 mètres ou moins de vous doivent réussir un jet de sauvegarde de Charisme (DD 8 plus votre modificateur de Charisme et bonus de maîtrise) ou acquérir l'état Effrayé jusqu'à la fin de votre prochain tour.</content>
   <content contentuid="h1441708fgd061g4a56g61b7gb8e8733cc36d" version="1">Aasimar</content>
   <content contentuid="h17794a45gbffdg8b0dg0332g414e8cee0aa7" version="1">Les aasimars (prononcé AH-si-mar) sont des mortels qui portent en eux une étincelle des Plans supérieurs. Qu'ils soient descendants d'un être angélique ou imprégnés de pouvoir céleste, ils peuvent attiser cette étincelle pour apporter lumière, guérison et fureur céleste.
 
@@ -4486,7 +4575,7 @@ Les kalashtar ne peuvent pas communiquer directement avec leurs esprits quori. A
 Si vous touchez une créature avec cette arme, cette créature a le Désavantage à son prochain jet d'attaque avant le début de votre prochain tour.</content>
   <content contentuid="h3339cd6bg6f73ge757g76cdg991057f97dde" version="2">Maîtrise d'arme : Ralentir
 
-Si vous touchez une créature avec cette arme et lui infligez des dégâts, vous pouvez réduire sa Vitesse de 10 pieds jusqu'au début de votre prochain tour.</content>
+Si vous touchez une créature avec cette arme et lui infligez des dégâts, vous pouvez réduire sa Vitesse de 3 mètres jusqu'au début de votre prochain tour.</content>
   <content contentuid="h10007b53gb4bcgbac3g9089g6d911c3cc5d4" version="1">Maîtrise d'arme : Déstabiliser
 
 Si vous touchez une créature avec cette arme et lui infligez des dégâts, vous avez l'Avantage à votre prochain jet d'attaque contre cette créature avant la fin de votre prochain tour.</content>
@@ -4496,7 +4585,7 @@ Si vous touchez une créature avec cette arme et lui infligez des dégâts, vous
   <content contentuid="had2ab3bfgf4fbga6e6gecbdgd688b4b2e4e0" version="2">Tranchant : Coup critique amélioré</content>
   <content contentuid="hb9a7c09eg9f65g5801gb3e4gb060b99c7378" version="1">Lorsque vous infligez un Coup critique qui inflige des dégâts Tranchants à une créature, elle a le Désavantage aux jets d'attaque jusqu'au début de votre prochain tour.</content>
   <content contentuid="hf17a7619g3977g6814g32fbgf85330abba85" version="2">Tranchant : Couper les jarrets</content>
-  <content contentuid="hff8f8621g9bc7gd484g306bg3d323ffef343" version="2">Lorsque vous touchez une créature avec une attaque qui inflige des dégâts Tranchants, vous pouvez réduire la Vitesse de cette créature de 10 pieds jusqu'au début de votre prochain tour.</content>
+  <content contentuid="hff8f8621g9bc7gd484g306bg3d323ffef343" version="2">Lorsque vous touchez une créature avec une attaque qui inflige des dégâts Tranchants, vous pouvez réduire la Vitesse de cette créature de 3 mètres jusqu'au début de votre prochain tour.</content>
   <content contentuid="h3f40a0a2gba17g34abgbc3ag09290e63a9f3" version="1">Écrasant : Coup critique amélioré</content>
   <content contentuid="hb0b2260fg01d4gf52agf9f4g93f90248b7e1" version="1">Lorsque vous infligez un Coup critique qui inflige des dégâts Contondants à une créature, les jets d'attaque contre cette créature ont l'Avantage jusqu'au début de votre prochain tour.</content>
   <content contentuid="he395d87dg4873gcaafg7185g880684e4c5bd" version="1">Perforant : Coup critique amélioré</content>
@@ -4504,31 +4593,33 @@ Si vous touchez une créature avec cette arme et lui infligez des dégâts, vous
   <content contentuid="h80d2cf8bgc729g9a24gbc58gb659d3b9da3a" version="1">Esprit</content>
   <content contentuid="h8a6990cbg9b40g71f3gb9cfg5c82ea25fcf2" version="1">Le Domaine de l'Esprit célèbre le pouvoir de l'esprit mortel, canalisant l'énergie psychique pour protéger les fidèles et frapper vos ennemis. Bien que cela soit le plus souvent associé à la Voie de la Lumière ou à la Voie riedrane de l'Inspiration, les adeptes des daelkyr peuvent également maîtriser ce pouvoir. Les visions de Xoriat peuvent conduire un prêtre à la folie, mais elles peuvent aussi révéler des secrets mortels de l'esprit.</content>
   <content contentuid="h72fe5c98g4eeagbdcfg176cg9e7d2200729b" version="1">Niveau 3 : Sorts du domaine de l'Esprit</content>
-  <content contentuid="hd98d7d87g77cegbc88gd214g64ac7bacec24" version="1">Votre connexion à ce domaine divin vous assure d'avoir toujours certains sorts prêts. Lorsque vous atteignez un niveau de Clerc spécifié dans le tableau des sorts du domaine de l'Esprit, vous avez désormais toujours les sorts listés préparés.</content>
-  <content contentuid="h793cd839gb6abg5b14g2409gcd0bd8f9ce42" version="1">Au 3e niveau, ils apprennent Injonction, Détection des pensées, Chuchotements dissonants et Pointe mentale ; au 5e niveau, Contresort et Terreur ; au 7e niveau, Confusion et Assassin fantasmagorique ; et au 9e niveau, Statique synaptique et Télékinésie.</content>
+  <content contentuid="hd98d7d87g77cegbc88gd214g64ac7bacec24" version="1">Votre connexion à ce domaine divin vous assure d'avoir toujours certains sorts prêts. Lorsque vous atteignez un niveau de Clerc spécifié dans le tableau des sorts du domaine de l'Esprit, vous avez désormais toujours les sorts listés préparés. Au 3e niveau, ils apprennent Injonction, Détection des pensées, Murmures dissonants et Épine mentale ; au 5e niveau, Contresort et Terreur ; au 7e niveau, Confusion et Assassin imaginaire ; et au 9e niveau, Perturbations synaptiques et Télékinésie.</content>
+  <content contentuid="h793cd839gb6abg5b14g2409gcd0bd8f9ce42" version="1">Au 3e niveau, ils apprennent Injonction, Détection des pensées, Chuchotements dissonants et Pointe mentale ; au 5e niveau, Contresort et Terreur ; au 7e niveau, Confusion et Assassin fantasmagorique ; et au 9e niveau, Perturbations synaptiques et Télékinésie.</content>
   <content contentuid="h8f6de0c2g375fgd164gdd46g3b76457a3d70" version="1">Niveau 3 : Rétroaction psychique</content>
-  <content contentuid="h5360cb80gee7ag0e61g2927g4eace8e2c5e6" version="2">Lorsqu'une créature que vous pouvez voir à 30 pieds ou moins de vous réussit un jet de sauvegarde, vous pouvez utiliser votre Réaction et dépenser une utilisation de votre Conduit divin pour imposer le Désavantage au jet de sauvegarde, s'introduisant dans son esprit avant qu'elle réussisse ou échoue.</content>
+  <content contentuid="h5360cb80gee7ag0e61g2927g4eace8e2c5e6" version="2">Lorsqu'une créature que vous pouvez voir à 9 mètres ou moins de vous réussit un jet de sauvegarde, vous pouvez utiliser votre Réaction et dépenser une utilisation de votre Conduit divin pour imposer le Désavantage au jet de sauvegarde, s'introduisant dans son esprit avant qu'elle réussisse ou échoue.</content>
   <content contentuid="h65dab31ag9d8cg8927g3507g782f6b5249c9" version="1">Niveau 3 : Force psychique</content>
-  <content contentuid="h637fd45bg14ebg37d7g4fd0g0b738fa63f79" version="3">Vous apprenez à frapper vos ennemis avec un pouvoir mental. Lorsque vous lancez un sort de Clerc qui inflige des dégâts Radieux ou Psychiques, chaque cible de ce sort subit des dégâts Psychiques supplémentaires égaux à votre modificateur de Charisme.</content>
+  <content contentuid="h637fd45bg14ebg37d7g4fd0g0b738fa63f79" version="3">Vous apprenez à frapper vos ennemis avec un pouvoir mental. Lorsque vous lancez un sort de Clerc qui inflige des dégâts Radiants ou Psychiques, chaque cible de ce sort subit des dégâts Psychiques supplémentaires égaux à votre modificateur de Charisme.</content>
   <content contentuid="h66a70d44ge6f0ga710g9f15ge39c0aaa98f6" version="1">Niveau 6 : Ancre de gestalt</content>
-  <content contentuid="ha688aa5dgc9bege050gd0f4gd8a5d10c7791" version="1">Votre pouvoir mental augmente, vous permettant de projeter un sentiment de calme dans une Émanation de 10 pieds prenant sa source en vous. La projection est inactive si vous avez l'état Neutralisé.
+  <content contentuid="ha688aa5dgc9bege050gd0f4gd8a5d10c7791" version="1">Votre pouvoir mental augmente, vous permettant de projeter un sentiment de calme dans une Émanation de 3 mètres prenant sa source en vous. La projection est inactive si vous avez l'état Neutralisé.
 
 Vous et vos alliés dans la projection gagnez un bonus de +2 aux jets de sauvegarde d'Intelligence, de Sagesse et de Charisme.
 
 Si un autre Clerc du domaine de l'Esprit est présent, une créature ne peut bénéficier que d'une seule Ancre de gestalt à la fois.</content>
   <content contentuid="hc9a2be39gbdf5g35d5g580age250f4630342" version="1">Rétroaction psychique</content>
-  <content contentuid="hd056c493g818eg1d13g8842g31b9217e79e6" version="2">Lorsqu'une créature que vous pouvez voir à 30 pieds ou moins de vous réussit un jet de sauvegarde, vous pouvez utiliser votre Réaction et dépenser une utilisation de votre Conduit divin pour imposer le Désavantage au jet de sauvegarde, s'introduisant dans son esprit avant qu'elle réussisse ou échoue.</content>
+  <content contentuid="hd056c493g818eg1d13g8842g31b9217e79e6" version="2">Lorsqu'une créature que vous pouvez voir à 9 mètres ou moins de vous réussit un jet de sauvegarde, vous pouvez utiliser votre Réaction et dépenser une utilisation de votre Conduit divin pour imposer le Désavantage au jet de sauvegarde, s'introduisant dans son esprit avant qu'elle réussisse ou échoue.</content>
   <content contentuid="hf5d4f6f7g7924g8f6fg9ab0g9dfcbf96b1f0" version="1">Ancre de gestalt</content>
-  <content contentuid="h949175afg7b78g0963gee66g437f1ebddb65" version="1">Votre pouvoir mental augmente, vous permettant de projeter un sentiment de calme dans une Émanation de 10 pieds prenant sa source en vous. La projection est inactive si vous avez l'état Neutralisé.</content>
+  <content contentuid="h949175afg7b78g0963gee66g437f1ebddb65" version="1">Votre pouvoir mental augmente, vous permettant de projeter un sentiment de calme dans une Émanation de 3 mètres prenant sa source en vous. La projection est inactive si vous avez l'état Neutralisé.
+
+Vous et vos alliés dans la projection gagnez un bonus de +2 aux jets de sauvegarde d'Intelligence, de Sagesse et de Charisme.</content>
   <content contentuid="h5523ff58gc19agf695g2c18g98109b1b9045" version="1">Ancre de gestalt</content>
   <content contentuid="h63ae3ebcg6ca5g662cga9ebg81bcaf35125f" version="1">Gagnez un bonus de +2 aux jets de sauvegarde d'Intelligence, de Sagesse et de Charisme.</content>
   <content contentuid="h50b49a89g7327gee14gb91dg12153f8b0fd5" version="1">Subissez un malus de -5 à l'Initiative.</content>
-  <content contentuid="h89fdc87bg9104g7a67g82f9gea36ba2329e9" version="1">Frappe occulte</content>
-  <content contentuid="hfcd09315g6bf2g29efgc581g90a0a0b160fa" version="1">Frappe occulte lors d'un Coup critique</content>
-  <content contentuid="h0cd27988g7bc2g4ac0g6bafg09eb92cd684f" version="1">Frappe occulte lors d'un Coup critique</content>
-  <content contentuid="h2e15736fg5bd6g3f4dg0fc4g819006dce402" version="1">Frappe occulte</content>
-  <content contentuid="h5bda03eag283cgfcf7ga7d9g208fb40a60f2" version="1">Frappe occulte</content>
-  <content contentuid="h16b86fe8gc17cgeb8cg6b91g3ff530eba5fc" version="1">Frappe occulte lors d'un Coup critique</content>
+  <content contentuid="h89fdc87bg9104g7a67g82f9gea36ba2329e9" version="2">Châtiment occulte (Corps à corps)</content>
+  <content contentuid="hfcd09315g6bf2g29efgc581g90a0a0b160fa" version="2">Châtiment occulte sur Coup critique (Corps à corps)</content>
+  <content contentuid="h0cd27988g7bc2g4ac0g6bafg09eb92cd684f" version="2">Châtiment occulte sur Coup critique (Corps à corps)</content>
+  <content contentuid="h2e15736fg5bd6g3f4dg0fc4g819006dce402" version="2">Châtiment occulte (Corps à corps)</content>
+  <content contentuid="h5bda03eag283cgfcf7ga7d9g208fb40a60f2" version="2">Châtiment occulte (Corps à corps)</content>
+  <content contentuid="h16b86fe8gc17cgeb8cg6b91g3ff530eba5fc" version="2">Châtiment occulte sur Coup critique (Corps à corps)</content>
   <content contentuid="h8530202fg28b6g772egd8f7gc108c5f8cded" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie de pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 par niveau de l'emplacement de sort, et vous pouvez infliger l'état À terre à la cible si elle est de taille Immense ou inférieure.</content>
   <content contentuid="hf7ca621bg1f12ga4d3g3047g634d03c15efe" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie de pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 par niveau de l'emplacement de sort, et vous pouvez infliger l'état À terre à la cible si elle est de taille Immense ou inférieure.</content>
   <content contentuid="h479f3229gb556gd7b7g73bcgb4311aa0da92" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie de pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 par niveau de l'emplacement de sort, et vous pouvez infliger l'état À terre à la cible si elle est de taille Immense ou inférieure.</content>
@@ -4537,7 +4628,7 @@ Si un autre Clerc du domaine de l'Esprit est présent, une créature ne peut bé
   <content contentuid="h1498d59bg1126gb9c5gd9b1ga55c4cbb3816" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie de pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 par niveau de l'emplacement de sort, et vous pouvez infliger l'état À terre à la cible si elle est de taille Immense ou inférieure.</content>
   <content contentuid="h91a9a031gbb78g3004g2f6cg6dcdb8f2cea3" version="1">Vous pouvez utiliser le Combat à deux armes même si vos armes ne sont pas &lt;LSTag Tooltip="Light"&gt;Légères&lt;/LSTag&gt;. Vous ne pouvez pas manier deux armes &lt;LSTag Tooltip="TwoHanded"&gt;À deux mains&lt;/LSTag&gt; simultanément.&lt;br&gt;&lt;br&gt;Lorsque vous effectuez l'action Attaquer à votre tour et attaquez avec une arme de mêlée, vous pouvez effectuer une Attaque de la main secondaire en tant qu'Action bonus plus tard dans le même tour. Si vous avez maîtrisé la propriété Entaille et avez une arme Entaille équipée dans la main secondaire, vous pouvez effectuer jusqu'à deux Attaques de la main secondaire par tour.</content>
   <content contentuid="h7f4aa580ga87dg16dcgfbe8g89f017ded271" version="1">Niveau 3 : Sorts d'Ombre</content>
-  <content contentuid="h822a72b8g17f5g73a6gd5f7g245ac996eb94" version="1">Lorsque vous atteignez un niveau d'Ensorceleur spécifié dans le tableau des sorts d'Ombre, vous avez désormais toujours les sorts listés préparés.</content>
+  <content contentuid="h822a72b8g17f5g73a6gd5f7g245ac996eb94" version="1">Lorsque vous atteignez un niveau d'Ensorceleur spécifié dans le tableau des sorts d'Ombre, vous avez désormais toujours les sorts listés préparés. Les ensorceleurs de la Magie des ombres gagnent des sorts supplémentaires à certains niveaux : Imprécation, Ténèbres, Blessure et Passage sans trace au 3e niveau ; Faim d'Hadar et Terreur au 5e niveau ; Invisibilité suprême et Assassin imaginaire au 7e niveau ; et Contagion et Brume mortelle au 9e niveau.</content>
   <content contentuid="hce90f19eg2ee2g0ff4g4c21g7ebf85d46c9d" version="1">Les ensorceleurs de Magie des ombres gagnent des sorts supplémentaires à certains niveaux : Malédiction, Ténèbres, Infliger des blessures et Passage sans trace au 3e niveau ; Faim de Hadar et Terreur au 5e niveau ; Invisibilité suprême et Assassin fantasmagorique au 7e niveau ; et Contagion et Nuée de mort au 9e niveau.</content>
   <content contentuid="h312226b3g88ffg25afg2137g749c468fee54" version="1">Niveau 3 : Yeux des ténèbres</content>
   <content contentuid="ha1f41cf1g38dagde18ga234gcff8d509b5e3" version="1">Niveau 3 : Force de la tombe</content>
@@ -4545,21 +4636,21 @@ Si un autre Clerc du domaine de l'Esprit est présent, une créature ne peut bé
   <content contentuid="hae8c9a5cgf06dg6b71gb093ge2e25716f7d2" version="1">Votre magie innée provient des forces les plus nébuleuses et insondables du Féroombre ou d'autres régions de ténèbres surnaturelles. Vous pourriez retracer votre lignage jusqu'à une entité d'un tel lieu, ou peut-être avez-vous été exposé à l'énergie sinistre d'un dragon des ombres et transformé par elle. Votre magie ombrelle vous permet de commander les ténèbres, la mort-vivance et le malheur.</content>
   <content contentuid="h442cd917g6095gef57g713bg55e902c18ad3" version="1">Sorcellerie de magie sauvage</content>
   <content contentuid="h18ed8a2cgfbfbgc16ag59c2gdbdf16bfd5ca" version="1">Votre magie innée provient des forces du chaos qui sous-tendent l'ordre de la création. Vous ou un ancêtre avez peut-être été exposé à la magie brute, peut-être à travers un portail planaire menant au Limbe ou aux Plans élémentaires. Peut-être avez-vous été béni par un être féerique ou marqué par un démon. Ou votre magie pourrait être une anomalie sans cause apparente. Quelle que soit sa source, cette magie bouillonne en vous, attendant toute occasion de se libérer.</content>
-  <content contentuid="hb5c8a2c2gcb05g89ceg701dg519dda931a2d" version="1">Un rayon argenté de pâle lumière brille dans un Cylindre de 5 pieds de rayon et de 40 pieds de hauteur centré sur un point à portée. Jusqu'à la fin du sort, la Lumière faible remplit le Cylindre, et vous pouvez effectuer une action Magique lors des tours suivants pour déplacer le Cylindre jusqu'à 60 pieds.
+  <content contentuid="hb5c8a2c2gcb05g89ceg701dg519dda931a2d" version="1">Un rayon argenté de pâle lumière brille dans un Cylindre de 1,50 mètre de rayon et de 12 mètres de hauteur centré sur un point à portée. Jusqu'à la fin du sort, la Lumière faible remplit le Cylindre, et vous pouvez effectuer une action Magique lors des tours suivants pour déplacer le Cylindre jusqu'à 18 mètres.
 
-Lorsque le Cylindre apparaît, chaque créature qu'il contient effectue un jet de sauvegarde de Constitution. En cas d'échec, une créature subit des dégâts Radieux. En cas de réussite, une créature ne subit que la moitié des dégâts. Une créature effectue également ce jet de sauvegarde lorsque la zone du sort se déplace dans son espace et lorsqu'elle termine son tour à cet endroit. Une créature n'effectue ce jet de sauvegarde qu'une seule fois par tour.</content>
-  <content contentuid="hc24592adg7667g3703g77f3g28bd0167f967" version="1">Un rayon argenté de pâle lumière brille dans un Cylindre de 5 pieds de rayon et de 40 pieds de hauteur centré sur un point à portée. Jusqu'à la fin du sort, la Lumière faible remplit le Cylindre, et vous pouvez effectuer une action Magique lors des tours suivants pour déplacer le Cylindre jusqu'à 60 pieds.
+Lorsque le Cylindre apparaît, chaque créature qu'il contient effectue un jet de sauvegarde de Constitution. En cas d'échec, une créature subit des dégâts Radiants. En cas de réussite, une créature ne subit que la moitié des dégâts. Une créature effectue également ce jet de sauvegarde lorsque la zone du sort se déplace dans son espace et lorsqu'elle termine son tour à cet endroit. Une créature n'effectue ce jet de sauvegarde qu'une seule fois par tour.</content>
+  <content contentuid="hc24592adg7667g3703g77f3g28bd0167f967" version="1">Un rayon argenté de pâle lumière brille dans un Cylindre de 1,50 mètre de rayon et de 12 mètres de hauteur centré sur un point à portée. Jusqu'à la fin du sort, la Lumière faible remplit le Cylindre, et vous pouvez effectuer une action Magique lors des tours suivants pour déplacer le Cylindre jusqu'à 18 mètres.
 
-Lorsque le Cylindre apparaît, chaque créature qu'il contient effectue un jet de sauvegarde de Constitution. En cas d'échec, une créature subit des dégâts Radieux. En cas de réussite, une créature ne subit que la moitié des dégâts. Une créature effectue également ce jet de sauvegarde lorsque la zone du sort se déplace dans son espace et lorsqu'elle termine son tour à cet endroit. Une créature n'effectue ce jet de sauvegarde qu'une seule fois par tour.</content>
-  <content contentuid="h2a605fbbg9e30g5d2fg99cfge3895f1bc658" version="1">Un rayon argenté de pâle lumière brille dans un Cylindre de 5 pieds de rayon et de 40 pieds de hauteur centré sur un point à portée. Jusqu'à la fin du sort, la Lumière faible remplit le Cylindre, et vous pouvez effectuer une action Magique lors des tours suivants pour déplacer le Cylindre jusqu'à 60 pieds.
+Lorsque le Cylindre apparaît, chaque créature qu'il contient effectue un jet de sauvegarde de Constitution. En cas d'échec, une créature subit des dégâts Radiants. En cas de réussite, une créature ne subit que la moitié des dégâts. Une créature effectue également ce jet de sauvegarde lorsque la zone du sort se déplace dans son espace et lorsqu'elle termine son tour à cet endroit. Une créature n'effectue ce jet de sauvegarde qu'une seule fois par tour.</content>
+  <content contentuid="h2a605fbbg9e30g5d2fg99cfge3895f1bc658" version="1">Un rayon argenté de pâle lumière brille dans un Cylindre de 1,50 mètre de rayon et de 12 mètres de hauteur centré sur un point à portée. Jusqu'à la fin du sort, la Lumière faible remplit le Cylindre, et vous pouvez effectuer une action Magique lors des tours suivants pour déplacer le Cylindre jusqu'à 18 mètres.
 
-Lorsque le Cylindre apparaît, chaque créature qu'il contient effectue un jet de sauvegarde de Constitution. En cas d'échec, une créature subit des dégâts Radieux. En cas de réussite, une créature ne subit que la moitié des dégâts. Une créature effectue également ce jet de sauvegarde lorsque la zone du sort se déplace dans son espace et lorsqu'elle termine son tour à cet endroit. Une créature n'effectue ce jet de sauvegarde qu'une seule fois par tour.</content>
-  <content contentuid="h3d8e9323g4462gb81dg88e1g83c02f1a2c2b" version="1">Un rayon argenté de pâle lumière brille dans un Cylindre de 5 pieds de rayon et de 40 pieds de hauteur centré sur un point à portée. Jusqu'à la fin du sort, la Lumière faible remplit le Cylindre, et vous pouvez effectuer une action Magique lors des tours suivants pour déplacer le Cylindre jusqu'à 60 pieds.
+Lorsque le Cylindre apparaît, chaque créature qu'il contient effectue un jet de sauvegarde de Constitution. En cas d'échec, une créature subit des dégâts Radiants. En cas de réussite, une créature ne subit que la moitié des dégâts. Une créature effectue également ce jet de sauvegarde lorsque la zone du sort se déplace dans son espace et lorsqu'elle termine son tour à cet endroit. Une créature n'effectue ce jet de sauvegarde qu'une seule fois par tour.</content>
+  <content contentuid="h3d8e9323g4462gb81dg88e1g83c02f1a2c2b" version="1">Un rayon argenté de pâle lumière brille dans un Cylindre de 1,50 mètre de rayon et de 12 mètres de hauteur centré sur un point à portée. Jusqu'à la fin du sort, la Lumière faible remplit le Cylindre, et vous pouvez effectuer une action Magique lors des tours suivants pour déplacer le Cylindre jusqu'à 18 mètres.
 
-Lorsque le Cylindre apparaît, chaque créature qu'il contient effectue un jet de sauvegarde de Constitution. En cas d'échec, une créature subit des dégâts Radieux. En cas de réussite, une créature ne subit que la moitié des dégâts. Une créature effectue également ce jet de sauvegarde lorsque la zone du sort se déplace dans son espace et lorsqu'elle termine son tour à cet endroit. Une créature n'effectue ce jet de sauvegarde qu'une seule fois par tour.</content>
-  <content contentuid="heee3ac7dg3b5cg3d93geb1dgae3f70c163c3" version="1">Un rayon argenté de pâle lumière brille dans un Cylindre de 5 pieds de rayon et de 40 pieds de hauteur centré sur un point à portée. Jusqu'à la fin du sort, la Lumière faible remplit le Cylindre, et vous pouvez effectuer une action Magique lors des tours suivants pour déplacer le Cylindre jusqu'à 60 pieds.
+Lorsque le Cylindre apparaît, chaque créature qu'il contient effectue un jet de sauvegarde de Constitution. En cas d'échec, une créature subit des dégâts Radiants. En cas de réussite, une créature ne subit que la moitié des dégâts. Une créature effectue également ce jet de sauvegarde lorsque la zone du sort se déplace dans son espace et lorsqu'elle termine son tour à cet endroit. Une créature n'effectue ce jet de sauvegarde qu'une seule fois par tour.</content>
+  <content contentuid="heee3ac7dg3b5cg3d93geb1dgae3f70c163c3" version="1">Un rayon argenté de pâle lumière brille dans un Cylindre de 1,50 mètre de rayon et de 12 mètres de hauteur centré sur un point à portée. Jusqu'à la fin du sort, la Lumière faible remplit le Cylindre, et vous pouvez effectuer une action Magique lors des tours suivants pour déplacer le Cylindre jusqu'à 18 mètres.
 
-Lorsque le Cylindre apparaît, chaque créature qu'il contient effectue un jet de sauvegarde de Constitution. En cas d'échec, une créature subit des dégâts Radieux. En cas de réussite, une créature ne subit que la moitié des dégâts. Une créature effectue également ce jet de sauvegarde lorsque la zone du sort se déplace dans son espace et lorsqu'elle termine son tour à cet endroit. Une créature n'effectue ce jet de sauvegarde qu'une seule fois par tour.</content>
+Lorsque le Cylindre apparaît, chaque créature qu'il contient effectue un jet de sauvegarde de Constitution. En cas d'échec, une créature subit des dégâts Radiants. En cas de réussite, une créature ne subit que la moitié des dégâts. Une créature effectue également ce jet de sauvegarde lorsque la zone du sort se déplace dans son espace et lorsqu'elle termine son tour à cet endroit. Une créature n'effectue ce jet de sauvegarde qu'une seule fois par tour.</content>
   <content contentuid="h2effdbc6g3649ga065g631ag652379eb3394" version="1">Déplacez le rayon de clair de lune jusqu'à [1].</content>
   <content contentuid="h743085a1g10dfg57d1g29eagd8357d3c8d91" version="1">Déplacez le rayon de clair de lune jusqu'à [1].</content>
   <content contentuid="h86e6e70dg96a1gf0b3g1ac9g183926c4fc52" version="1">Déplacez le rayon de clair de lune jusqu'à [1].</content>
@@ -4571,17 +4662,19 @@ Lorsque le Cylindre apparaît, chaque créature qu'il contient effectue un jet d
   <content contentuid="h46e9e82fg3994g14dageffdg4ecef2102490" version="1">Des dagues tourbillonnantes remplissent l'air. Toute personne qui termine son tour à l'intérieur du tourbillon subit [1].</content>
   <content contentuid="he983b2f2gd458g80bdg28d9g76d209dcf6d6" version="1">Des dagues tourbillonnantes remplissent l'air. Toute personne qui termine son tour à l'intérieur du tourbillon subit [1].</content>
   <content contentuid="h8c43a796gf6abg9b17ga6e7g640846c1d925" version="1">Frappe de bouclier (Bousculade)</content>
-  <content contentuid="he6b03eaeg69d3geb4cgfcafg07e44f75a6d9" version="1">Si vous attaquez une créature à 5 pieds ou moins de vous dans le cadre de l'action Attaquer et touchez avec une arme de mêlée, vous pouvez immédiatement frapper la cible avec votre Bouclier s'il est équipé, forçant la cible à effectuer un jet de sauvegarde de Force (DD 8 plus votre modificateur de Force et bonus de maîtrise). En cas d'échec, vous poussez la cible à 5 pieds de vous ou lui infligez l'état À terre (votre choix). Vous ne pouvez utiliser cet avantage qu'une seule fois à chacun de vos tours.</content>
+  <content contentuid="he6b03eaeg69d3geb4cgfcafg07e44f75a6d9" version="1">Si vous attaquez une créature à 1,50 mètre ou moins de vous dans le cadre de l'action Attaquer et touchez avec une arme de mêlée, vous pouvez immédiatement frapper la cible avec votre Bouclier s'il est équipé, forçant la cible à effectuer un jet de sauvegarde de Force (DD 8 plus votre modificateur de Force et bonus de maîtrise). En cas d'échec, vous poussez la cible à 1,50 mètre de vous ou lui infligez l'état À terre (votre choix). Vous ne pouvez utiliser cet avantage qu'une seule fois à chacun de vos tours.</content>
   <content contentuid="he6c26bfag496eg4545g66e5g0166e2cb0452" version="1">Frappe de bouclier (À terre)</content>
   <content contentuid="h86dd84e2ge406g25feg8fbag707fbd12baf0" version="1">Règle : Parchemins de sort</content>
-  <content contentuid="hb0c05d37g1b53g2cb2g912fg504559979b3f" version="2">Un parchemin de sort ne peut être utilisé que si le sort inscrit sur le parchemin figure sur la liste de sorts de l'une de vos classes ou sous-classes.
+  <content contentuid="hb0c05d37g1b53g2cb2g912fg504559979b3f" version="3">Un parchemin de sort ne peut être utilisé que si le sort inscrit sur le parchemin figure sur la liste de sorts de l'une de vos classes ou sous-classes.
 
-De plus, votre niveau d'emplacement de sort le plus élevé doit être au moins d'un niveau inférieur au niveau du sort inscrit sur le parchemin. Pour déterminer les niveaux d'emplacement de sort d'un personnage multiclassé, seuls les niveaux dans les classes et sous-classes qui ont le sort sur leur liste de sorts sont comptés.</content>
+De plus, votre niveau d'emplacement de sort le plus élevé doit être au moins d'un niveau inférieur au niveau du sort inscrit sur le parchemin. Pour déterminer les niveaux d'emplacement de sort d'un personnage multiclassé, seuls les niveaux dans les classes et sous-classes qui ont le sort sur leur liste de sorts sont comptés.
+
+Les parchemins de Retour à la vie sont toujours exempts de cette restriction et peuvent être utilisés par n'importe quel personnage.</content>
   <content contentuid="h2a38021bge7c4g0eedgdbf5g331c3221892d" version="1">Par exemple, un Parchemin de Mur de feu (sort de 4e niveau) nécessite un accès aux emplacements de sort de 3e niveau. Un personnage pourrait satisfaire cette exigence avec 5 niveaux de Magicien, ou avec une combinaison telle que 4 niveaux de Magicien et 3 niveaux de Filou arcanique. Cependant, un personnage avec 4 niveaux de Clerc et 3 niveaux de Filou arcanique ne serait pas qualifié, car Mur de feu n'apparaît pas sur la liste de sorts du Clerc.</content>
   <content contentuid="h94c617f1g467ag18f3gf740gb5a9fc763e88" version="1">Duelliste défensif</content>
   <content contentuid="hb74c3fd9ga6a8g8c4bg0373g427c3edf70f7" version="4">Sauter en bas</content>
   <content contentuid="hd44fd6ddg1098gdbf5g10d4g8ca7b30d62bc" version="4">Sauter en haut</content>
-  <content contentuid="h73da64f6ga623g5c60g31edg8434e7996703" version="1">Sautez jusqu'à 30 pieds en dépensant 10 pieds de déplacement.</content>
+  <content contentuid="h73da64f6ga623g5c60g31edg8434e7996703" version="1">Sautez jusqu'à 9 mètres en dépensant 3 mètres de déplacement.</content>
   <content contentuid="hcc124e06g703dga91ag38b5g45f683e89b78" version="1">Frappe guidée (Allié)</content>
   <content contentuid="h7f5b837cg0df3g8c6eg1f50ga527560cf9e6" version="1">Tant que cette aura dure, vous pouvez lancer &lt;LSTag Type="Spell" Tooltip="Target_AuraOfVitality_Activate"&gt;Restaurer la vitalité&lt;/LSTag&gt; pour vous soigner ou soigner vos alliés proches.</content>
   <content contentuid="h476d4d67g76e8g6262gd36egb27efe1c901e" version="1">Tant que cette aura dure, vous pouvez lancer &lt;LSTag Type="Spell" Tooltip="Target_AuraOfVitality_Activate"&gt;Restaurer la vitalité&lt;/LSTag&gt; pour vous soigner ou soigner vos alliés proches.</content>
@@ -4614,22 +4707,22 @@ Chaque fois que vous lancez un sort d'Abjuration avec un emplacement de sort, le
   <content contentuid="h21e9c371g94d2g99bbgc117g1f69a24cfd8a" version="1">Recharger le bouclier arcanique</content>
   <content contentuid="h441c9c45ge8e7g3d2cg79e6g8a57eab6e20d" version="1">Vous pouvez dépenser un emplacement de sort, et le bouclier récupère un nombre de Points de vie égal à deux fois le niveau de l'emplacement de sort dépensé.</content>
   <content contentuid="h19c5b950gb887g4a56g312cga3c9a0b8839a" version="1">Niveau 6 : Bouclier projeté</content>
-  <content contentuid="h173a0fccg668ag5a93gc996gfe83b0867a07" version="1">Lorsqu'une créature que vous pouvez voir à 30 pieds ou moins de vous subit des dégâts, vous pouvez utiliser votre Réaction pour que votre Bouclier arcanique absorbe ces dégâts.</content>
-  <content contentuid="hf1f2ce33g9f28ga79dg8ad9g713bd9d1afd1" version="1">Lorsqu'une créature que vous pouvez voir à 30 pieds ou moins de vous subit des dégâts, vous pouvez utiliser votre Réaction pour que votre Bouclier arcanique absorbe ces dégâts.</content>
+  <content contentuid="h173a0fccg668ag5a93gc996gfe83b0867a07" version="1">Lorsqu'une créature que vous pouvez voir à 9 mètres ou moins de vous subit des dégâts, vous pouvez utiliser votre Réaction pour que votre Bouclier arcanique absorbe ces dégâts.</content>
+  <content contentuid="hf1f2ce33g9f28ga79dg8ad9g713bd9d1afd1" version="1">Lorsqu'une créature que vous pouvez voir à 9 mètres ou moins de vous subit des dégâts, vous pouvez utiliser votre Réaction pour que votre Bouclier arcanique absorbe ces dégâts.</content>
   <content contentuid="h288cd5f8gfde5gf844g35b4g78176c8d8034" version="1">Niveau 10 : Abjuration améliorée</content>
   <content contentuid="h9d3fbbaegc6b1gf48egd8c4gef06e95785f3" version="1">Chaque fois que vous prenez un &lt;LSTag Tooltip="ShortRest"&gt;Repos court&lt;/LSTag&gt;, votre &lt;LSTag Type="Passive" Tooltip="ArcaneWard"&gt;Bouclier arcanique&lt;/LSTag&gt; est entièrement restauré.</content>
   <content contentuid="h4b6ab214gd4f9gba28g0fb5gc087fbca986d" version="1">Dévastateur : Attaque à mains nues</content>
   <content contentuid="hf9be0a35gce33ga419g1a57gcc67560214a9" version="1">Saut en longueur</content>
-  <content contentuid="ha04791c7ge8d9ge47cg41f1ga366abc70f0a" version="1">Pendant la durée, une fois à chacun des tours de la cible, elle peut dépenser 10 pieds de déplacement pour sauter jusqu'à 30 pieds. De plus, la distance de saut maximale de la cible est triplée.</content>
-  <content contentuid="haa0cb759gbb2fg6e12g0a4bgd7393063d2c3" version="1">Pendant la durée, une fois à chacun des tours de la cible, elle peut dépenser 10 pieds de déplacement pour sauter jusqu'à 30 pieds. De plus, la distance de saut maximale de la cible est triplée.</content>
-  <content contentuid="h4b50165cg7c3dg0c06g4d6cgbbeb1860e49c" version="1">Touchez une créature consentante. Pendant la durée, une fois à chacun des tours de la cible, elle peut dépenser 10 pieds de déplacement pour sauter jusqu'à 30 pieds. De plus, la distance de saut maximale de la cible est triplée.</content>
-  <content contentuid="h2c906325gf33ag8c1cgb681g54b7ac099738" version="1">Touchez une créature consentante. Pendant la durée, une fois à chacun des tours de la cible, elle peut dépenser 10 pieds de déplacement pour sauter jusqu'à 30 pieds. De plus, la distance de saut maximale de la cible est triplée.</content>
-  <content contentuid="h35f37f72g15a5g5604gdb78g977b94b87709" version="1">Touchez une créature consentante. Pendant la durée, une fois à chacun des tours de la cible, elle peut dépenser 10 pieds de déplacement pour sauter jusqu'à 30 pieds. De plus, la distance de saut maximale de la cible est triplée.</content>
-  <content contentuid="ha63bbbd5g91e2g8333gb91ag7753f4337e19" version="1">Touchez une créature consentante. Pendant la durée, une fois à chacun des tours de la cible, elle peut dépenser 10 pieds de déplacement pour sauter jusqu'à 30 pieds. De plus, la distance de saut maximale de la cible est triplée.</content>
-  <content contentuid="h57ee6921g4a34g9c18gedfbg01c62484a2ed" version="1">Touchez une créature consentante. Pendant la durée, une fois à chacun des tours de la cible, elle peut dépenser 10 pieds de déplacement pour sauter jusqu'à 30 pieds. De plus, la distance de saut maximale de la cible est triplée.</content>
-  <content contentuid="ha30a8814gd13dg168cgb242g878fd141f459" version="1">Touchez une créature consentante. Pendant la durée, une fois à chacun des tours de la cible, elle peut dépenser 10 pieds de déplacement pour sauter jusqu'à 30 pieds. De plus, la distance de saut maximale de la cible est triplée.</content>
+  <content contentuid="ha04791c7ge8d9ge47cg41f1ga366abc70f0a" version="1">Pendant la durée, une fois à chacun des tours de la cible, elle peut dépenser 3 mètres de déplacement pour sauter jusqu'à 9 mètres. De plus, la distance de saut maximale de la cible est triplée.</content>
+  <content contentuid="haa0cb759gbb2fg6e12g0a4bgd7393063d2c3" version="1">Pendant la durée, une fois à chacun des tours de la cible, elle peut dépenser 3 mètres de déplacement pour sauter jusqu'à 9 mètres. De plus, la distance de saut maximale de la cible est triplée.</content>
+  <content contentuid="h4b50165cg7c3dg0c06g4d6cgbbeb1860e49c" version="1">Touchez une créature consentante. Pendant la durée, une fois à chacun des tours de la cible, elle peut dépenser 3 mètres de déplacement pour sauter jusqu'à 9 mètres. De plus, la distance de saut maximale de la cible est triplée.</content>
+  <content contentuid="h2c906325gf33ag8c1cgb681g54b7ac099738" version="1">Touchez une créature consentante. Pendant la durée, une fois à chacun des tours de la cible, elle peut dépenser 3 mètres de déplacement pour sauter jusqu'à 9 mètres. De plus, la distance de saut maximale de la cible est triplée.</content>
+  <content contentuid="h35f37f72g15a5g5604gdb78g977b94b87709" version="1">Touchez une créature consentante. Pendant la durée, une fois à chacun des tours de la cible, elle peut dépenser 3 mètres de déplacement pour sauter jusqu'à 9 mètres. De plus, la distance de saut maximale de la cible est triplée.</content>
+  <content contentuid="ha63bbbd5g91e2g8333gb91ag7753f4337e19" version="1">Touchez une créature consentante. Pendant la durée, une fois à chacun des tours de la cible, elle peut dépenser 3 mètres de déplacement pour sauter jusqu'à 9 mètres. De plus, la distance de saut maximale de la cible est triplée.</content>
+  <content contentuid="h57ee6921g4a34g9c18gedfbg01c62484a2ed" version="1">Touchez une créature consentante. Pendant la durée, une fois à chacun des tours de la cible, elle peut dépenser 3 mètres de déplacement pour sauter jusqu'à 9 mètres. De plus, la distance de saut maximale de la cible est triplée.</content>
+  <content contentuid="ha30a8814gd13dg168cgb242g878fd141f459" version="1">Touchez une créature consentante. Pendant la durée, une fois à chacun des tours de la cible, elle peut dépenser 3 mètres de déplacement pour sauter jusqu'à 9 mètres. De plus, la distance de saut maximale de la cible est triplée.</content>
   <content contentuid="h7978f94bg37bbgd94fg0344g897bfa2c2b06" version="1">Sautez vers l'emplacement sélectionné, en consommant un déplacement égal à la distance sautée.</content>
-  <content contentuid="hfa470112gc789g976ag5dcdgab4fa45eb69b" version="1">Bondissez jusqu'à 30 pieds, en consommant 10 pieds de déplacement.</content>
+  <content contentuid="hfa470112gc789g976ag5dcdgab4fa45eb69b" version="1">Bondissez jusqu'à 9 mètres, en consommant 3 mètres de déplacement.</content>
   <content contentuid="hd667caedgdc28gdefdg4285gcd7ef4a63a22" version="1">Saut du Vent bondissant</content>
   <content contentuid="he4305daaga010gf583gff81gcaf63ebe3f32" version="1">Bondissez jusqu'à deux fois votre distance de saut normale. Ce saut consomme un déplacement égal à la moitié de la distance parcourue.</content>
   <content contentuid="h7f5a2c22g1d31g7893g11c5gbb065055abeb" version="1">Lien de protection</content>
@@ -4637,4 +4730,1171 @@ Chaque fois que vous lancez un sort d'Abjuration avec un emplacement de sort, le
   <content contentuid="hba127cc1ga142gbe30g42a0gefcf3b5c831e" version="2">Des boucliers arcaniques vous protègent contre la magie pendant la durée. Vous avez l'Avantage aux jets de sauvegarde contre les sorts et les effets magiques. De plus, vous avez la Résistance aux dégâts infligés par les sorts.</content>
   <content contentuid="hb659d87bg7ae8g6489g2b3ege4e114b8699e" version="1">Évasion d'Elminster</content>
   <content contentuid="h9f0fa794gdfc2ge2f8gcf06g046d97ef0b1d" version="1">Des boucliers arcaniques vous protègent contre la magie pendant la durée. Vous avez l'Avantage aux jets de sauvegarde contre les sorts et les effets magiques. De plus, vous avez la Résistance aux dégâts infligés par les sorts.</content>
+  <content contentuid="h39139aafg7efag9037g4297g47b92c38caf8" version="1">Niveau 3 : Faucheuse</content>
+  <content contentuid="hef1552acg9a55g7c16ge056g056772bcc3ec" version="1">Embrasement du Feu des sorts</content>
+  <content contentuid="hcfd88999g4267g263ag85aag89c1108ee65c" version="2">Vous déchaînez une explosion de feu éclatant. Effectuez une attaque de sort à distance contre une cible à portée. En cas de touche, la cible subit des dégâts Radiants.</content>
+  <content contentuid="hf91f3fe6gf176g015fg2e8bg8d7e113fb2e5" version="1">Tempête du Feu des sorts</content>
+  <content contentuid="hc68e827eg501cgbab0ga48egb7055d764e5b" version="3">Vous invoquez un pilier de Feu des sorts dans un Cylindre de 6 mètres de rayon et 6 mètres de hauteur centré sur un point à portée. La zone du Cylindre est éclairée d'une Lumière vive, et chaque créature qui s'y trouve lorsqu'il apparaît effectue un jet de sauvegarde de Constitution, subissant des dégâts Radiants en cas d'échec, ou la moitié de ces dégâts en cas de réussite. Une créature effectue également ce jet de sauvegarde lorsqu'elle entre dans la zone du sort pour la première fois lors d'un tour ou qu'elle y termine son tour. Une créature n'effectue ce jet de sauvegarde qu'une fois par tour.
+
+De plus, chaque fois qu'une créature dans le Cylindre lance un sort, cette créature effectue un jet de sauvegarde de Constitution. En cas d'échec, le sort se dissipe sans effet, et l'action, l'Action bonus ou la Réaction utilisée pour le lancer est perdue.
+
+Lorsque vous lancez ce sort, vous pouvez désigner des créatures qui ne seront pas affectées.</content>
+  <content contentuid="h563db1bag0ff4gf88bgaa5dg36f6eab08bb4" version="1">Tempête du Feu des sorts</content>
+  <content contentuid="hd62f5a63g6062g55cfg4eb3g09082565784c" version="1">Chaque fois qu'une créature dans le Cylindre lance un sort, cette créature effectue un jet de sauvegarde de Constitution. En cas d'échec, le sort se dissipe sans effet, et l'action, l'Action bonus ou la Réaction utilisée pour le lancer est perdue.</content>
+  <content contentuid="hf91e618bg7cfcg3668g95bbg4b7e8eb659d9" version="2">Tempête du Feu des sorts : Perturbation des sorts</content>
+  <content contentuid="h150cb7degdc6bg252agb2cag7b6c5033e87d" version="1">Chaque fois qu'une créature dans le Cylindre lance un sort, cette créature effectue un jet de sauvegarde de Constitution. En cas d'échec, le sort se dissipe sans effet, et l'action, l'Action bonus ou la Réaction utilisée pour le lancer est perdue.</content>
+  <content contentuid="h2d7fc4afgebcbg804ag8764g1902de76e587" version="1">Tempête du Feu des sorts : Dégâts Radiants</content>
+  <content contentuid="h5acbb969gf7e6g885egf07ag2ca3bb42d3a7" version="1">Sursaut d'effroi</content>
+  <content contentuid="h834e8d02gd8f9g2e05ge709gc3ecb8d0d3da" version="1">Vous déformez votre visage pour effrayer une créature que vous pouvez voir à portée. La créature doit réussir un jet de sauvegarde de Sagesse ou avoir la condition Effrayé jusqu'au début de votre prochain tour.</content>
+  <content contentuid="hbca64bf4ga835g10c5gba60g0c68950c7135" version="1">Mot sacré</content>
+  <content contentuid="h8caea2f7gd7feg90a5gc318g2cfb95c6f90b" version="1">Vous murmurez une parole divine dans un souffle, en veillant à ne pas parler trop fort, car un tel pouvoir céleste n'est pas destiné aux indignes. Effectuez une attaque de sort à distance contre une cible à portée. En cas de touche, la cible subit des dégâts Radiants. Si la cible est une Créature féérique, un Fiélon ou un Mort-vivant, sa Vitesse est réduite de 3 mètres et elle ne peut pas effectuer de Réactions jusqu'à la fin de son prochain tour.</content>
+  <content contentuid="h2a918193g01a1gcd83gf729g2e88e3223327" version="1">Mot sacré</content>
+  <content contentuid="h4fb83fe3g593ag7f0cg6424g2a7ebbb50df8" version="1">Si la cible est une Créature féérique, un Fiélon ou un Mort-vivant, sa Vitesse est réduite de 3 mètres et elle ne peut pas effectuer de Réactions jusqu'à la fin de son prochain tour.</content>
+  <content contentuid="he2351ff1gc2fegeb0ag256cg5f2fee7ff699" version="1">Trait de ténèbres</content>
+  <content contentuid="h50f91c1cgccffgefd8g17f1g12dfc280157d" version="1">Vous prononcez une rapide invocation pour créer un nimbe noir autour de votre main, puis lancez trois rayons de ténèbres sur une ou plusieurs cibles à portée. Les rayons peuvent être répartis entre les cibles comme vous le souhaitez. Effectuez une attaque de sort à distance pour chaque cible (et non pour chaque rayon) ; chaque rayon qui touche inflige 1d10 dégâts de Froid. Une cible touchée par un ou plusieurs rayons doit réussir un jet de sauvegarde de Constitution ou ne pas pouvoir effectuer de Réactions jusqu'au début de son prochain tour.</content>
+  <content contentuid="h1e313479g10bdg79f6gcd1eg8ea0fd340038" version="1">Trait de ténèbres</content>
+  <content contentuid="h64c3d662g403agbd6dgc831g665675b5f32a" version="1">Ne peut pas effectuer de Réactions</content>
+  <content contentuid="h47e9e8edg7b15gb388g44c7ge5b71376dbe8" version="1">Armure de mort</content>
+  <content contentuid="h9bba05a0ga2fag0a19gfc1egb6a0b1880e7a" version="1">Pendant la durée, une aura d'un noir d'encre entoure une créature que vous touchez. La cible a l'Avantage aux jets de sauvegarde contre la mort, et une fois par tour, lorsqu'une créature à 1,50 mètre ou moins de la cible la touche avec un jet d'attaque de corps à corps, l'attaquant subit 2d4 dégâts Nécrotiques.</content>
+  <content contentuid="hb2037ed3g9376ge28egdf30gb396e5836806" version="1">Armure de mort</content>
+  <content contentuid="h9c70dde9ga77cgb33fgf511g497c918b7702" version="1">Pendant la durée, une aura d'un noir d'encre entoure une créature que vous touchez. La cible a l'Avantage aux jets de sauvegarde contre la mort, et une fois par tour, lorsqu'une créature à 1,50 mètre ou moins de la cible la touche avec un jet d'attaque de corps à corps, l'attaquant subit 2d4 dégâts Nécrotiques.</content>
+  <content contentuid="h0e05ff53ge761gd35cg2778g68647c918731" version="1">Armure de mort</content>
+  <content contentuid="hd20da03ag764eg50f6g5b4dga5c0e396f838" version="1">Pendant la durée, une aura d'un noir d'encre entoure une créature que vous touchez. La cible a l'Avantage aux jets de sauvegarde contre la mort, et une fois par tour, lorsqu'une créature à 1,50 mètre ou moins de la cible la touche avec un jet d'attaque de corps à corps, l'attaquant subit 2d4 dégâts Nécrotiques.</content>
+  <content contentuid="h8f9cfbbcgaa6dgc17bg2d8fg66589650eeb4" version="1">Répulsion</content>
+  <content contentuid="h42d34c6cg2c2dg6152g7c9dg22ed3a5cedc7" version="1">Vous projetez une force magique désorientante vers une créature à portée. La cible effectue un jet de sauvegarde de Constitution. En cas d'échec, la cible subit des dégâts de Force, sa Vitesse est réduite de moitié jusqu'au début de votre prochain tour, et lors de son prochain tour, elle ne peut effectuer qu'une action ou une Action bonus (mais pas les deux). En cas de réussite, la cible subit seulement la moitié des dégâts.</content>
+  <content contentuid="h739e0b6ag9070g3f0cg30cdg185c98e6150c" version="1">Répulsion</content>
+  <content contentuid="he30340c8gee67gea26g42dfg7428ad2ffc24" version="1">La &lt;LSTag Tooltip="MovementSpeed"&gt;vitesse de déplacement&lt;/LSTag&gt; de l'entité affectée est réduite de moitié.&lt;br&gt;&lt;br&gt;L'entité ne peut effectuer qu'une action ou une action bonus.</content>
+  <content contentuid="haac8d098g36f5gfad0g0c19g710686be3050" version="1">Flambée d'Aganazzar</content>
+  <content contentuid="h05279eecg66b6g48b2gd7bbg31b8b9364190" version="1">Une ligne de flammes rugissantes de 9 mètres de long et 1,50 mètre de large émane de vous dans la direction de votre choix. Chaque créature dans la ligne doit effectuer un jet de sauvegarde de Dextérité. Une créature subit des dégâts de Feu en cas d'échec, ou la moitié de ces dégâts en cas de réussite.</content>
+  <content contentuid="hd072401cgab74ga74bgb28egccb3e4a6554d" version="1">Linceul d'ombre</content>
+  <content contentuid="h23041527g684fg9b54gfd8bgbc94bca6aa62" version="1">Vous vous drapez d'ombre, ce qui vous donne l'Avantage aux tests de Dextérité (Discrétion) contre les créatures qui se fient à la vue.</content>
+  <content contentuid="hc9492c94g19bfg3230gbfc3g6cf10c6d02e5" version="1">Linceul d'ombre</content>
+  <content contentuid="h8dbcd1e2ga506gd79fg540bgdeebf6743060" version="1">Vous vous drapez d'ombre, ce qui vous donne l'Avantage aux tests de Dextérité (Discrétion) contre les créatures qui se fient à la vue.</content>
+  <content contentuid="h954ddf9fg7f78ge82dg57c0gb1a304bf4d54" version="1">Rune de feu</content>
+  <content contentuid="h8756f6c6ga536g0a7agc01agf500547496f2" version="1">Vous touchez une arme de corps à corps et y placez un effet magique, créant une rune visible gravée dans l'arme. Les attaques effectuées avec l'arme enchantée infligent 1d8 dégâts de Feu supplémentaires en cas de touche.</content>
+  <content contentuid="h7db07aaegcba0g874eg8391ge8926782e7f8" version="1">Rune de feu</content>
+  <content contentuid="h241ed709g7588g2cc5g9cd2gbc1ec16c5753" version="1">Les attaques effectuées avec l'arme enchantée infligent 1d8 dégâts de Feu supplémentaires en cas de touche.</content>
+  <content contentuid="h06dbb138g6afagfebbg9a03gd5d229bb475e" version="1">Déflagration étourdissante</content>
+  <content contentuid="h36e08fceg5a47gf889gc415g5a67ba284ba1" version="1">Une onde de force jaillit de vos paumes et cible une créature à portée. La cible effectue un jet de sauvegarde de Constitution. En cas d'échec, la créature subit 2d6 dégâts de Force et a la condition Étourdi jusqu'à la fin de son prochain tour. En cas de réussite, la créature subit seulement les dégâts.</content>
+  <content contentuid="h1d86fe95gbfdbg4380gabf5g485af2f71992" version="1">Niveau 3 : Sorts du Domaine de l'Ombre</content>
+  <content contentuid="h7b73f5fagb632g4dd6gbb1bg52e10cb075ff" version="1">Votre connexion à ce domaine divin vous assure d'avoir toujours certains sorts prêts. Lorsque vous atteignez un niveau de Clerc spécifié dans le tableau des sorts du domaine de l'Ombre, vous avez désormais toujours les sorts listés préparés. Le Domaine de l'Ombre accorde les sorts suivants à mesure que vous gagnez des niveaux de Clerc : Imprécation, Simulacre de vie, Cécité et Ténèbres au 3e niveau ; Clignotement et Terreur au 5e niveau ; Tentacules noirs et Invisibilité suprême au 7e niveau ; et Cône de froid et Songe au 9e niveau.</content>
+  <content contentuid="hb05d9f4bgc914g4d44g95b9ga646b28fd85b" version="1">Le Domaine de l'Ombre accorde les sorts suivants à mesure que vous gagnez des niveaux de Clerc : Imprécation, Simulacre de vie, Cécité et Ténèbres au 3e niveau ; Clignotement et Terreur au 5e niveau ; Tentacules noirs et Invisibilité suprême au 7e niveau ; et Cône de froid et Songe au 9e niveau.</content>
+  <content contentuid="h1064bb85gee8cg09fbge5ebg6e90aa761e30" version="1">Domaine de l'Ombre</content>
+  <content contentuid="h904f48b3g5c0bg6e25g75bcg2b014d46c23f" version="1">Domaine de l'Ombre</content>
+  <content contentuid="h034102c0gf054g2c35ga023g5f4e2e8fbffd" version="1">Le Domaine de l'Ombre embrasse les ténèbres qui entourent toutes choses et manipule le gris transitoire qui sépare la lumière de l'obscurité. Les clercs du Domaine de l'Ombre suivent une voie subtile, changeant fréquemment d'allégeance et préférant agir sans être vus.</content>
+  <content contentuid="h52d0bda6g4b49g2a89gf69bg489e840efe5a" version="1">Niveau 3 : Couvert de la nuit</content>
+  <content contentuid="h5aa5a2a8gba10g31e1gabfeg038d2569ac84" version="1">Vous gagnez la maîtrise de la compétence Discrétion et la vision dans le noir. De plus, vous pouvez utiliser une action bonus pour vous cacher.</content>
+  <content contentuid="hb2f444e4g0325g881ag13bcgf25bad34406e" version="1">Niveau 3 : Extension d'ombre</content>
+  <content contentuid="h69f399c6g8e60g3971g78a2gebd2397144ff" version="1">Vous pouvez manipuler votre propre ombre pour étendre votre allonge. Lorsque vous lancez un sort de clerc avec une portée de contact, votre ombre peut transmettre le sort comme si vous l'aviez lancé. Votre cible doit être à 4,50 mètres ou moins de vous, et vous devez pouvoir la voir. Vous pouvez utiliser cette fonctionnalité même si vous vous trouvez dans une zone où vous ne projetez pas d'ombre.</content>
+  <content contentuid="hb5ac88b0ga681g79ebg1b09g63b221dbec59" version="1">Niveau 3 : Étreinte d'ombre</content>
+  <content contentuid="hbcbd58e8g49cfg974bg8aabgdc71760d819a" version="1">Vous pouvez utiliser votre Conduit divin pour retourner l'ombre d'une créature contre elle. En tant qu'action, choisissez une créature que vous pouvez voir à 9 mètres ou moins de vous. Elle est Entravée par sa propre ombre jusqu'à la fin de votre prochain tour. Vous pouvez utiliser cette fonctionnalité même si la cible se trouve dans une zone où elle ne projette pas d'ombre.</content>
+  <content contentuid="hc2dd73deg615cg8bd1g4aeagcf05e9e5d0ff" version="1">Niveau 6 : Disparition dans les ténèbres</content>
+  <content contentuid="hc80832b3gccecg3c55ge08fgc2a067adc4af" version="1">En tant qu'action bonus, vous pouvez devenir invisible par magie pendant 1 minute. Vous pouvez utiliser cette fonctionnalité un nombre de fois égal à votre modificateur de Sagesse (minimum une fois). Vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
+  <content contentuid="hda876b8bgf832g00b4g56d9g44e1bd90c465" version="1">Se cacher</content>
+  <content contentuid="h2748c4afgb7c1g935dg46f9g95303ee42d02" version="1">Étreinte d'ombre</content>
+  <content contentuid="h40671bc4g4e10g2c2egd92cg6a9ae5dc8595" version="1">Étreinte d'ombre</content>
+  <content contentuid="h7630efebgc128g1a88g3056g3cd8dbd6ce14" version="1">Vous pouvez utiliser votre Conduit divin pour retourner l'ombre d'une créature contre elle. En tant qu'action, choisissez une créature que vous pouvez voir à 9 mètres ou moins de vous. Elle est Entravée par sa propre ombre jusqu'à la fin de votre prochain tour. Vous pouvez utiliser cette fonctionnalité même si la cible se trouve dans une zone où elle ne projette pas d'ombre.</content>
+  <content contentuid="h1d580cb5gc915g8f13g3f12g57d46d07e991" version="2">Disparition dans les ténèbres</content>
+  <content contentuid="h0e8b7698gbb37g834bge366g5db24efbb56c" version="1">En tant qu'action bonus, vous pouvez devenir invisible par magie pendant 1 minute.</content>
+  <content contentuid="h7eca827eg60a1g2e15ga615g5750ad9f5621" version="1">Disparition dans les ténèbres</content>
+  <content contentuid="h075cad75ge0b8g8089g7a0bge757b2193df5" version="1">Niveau 10 : Intervention divine</content>
+  <content contentuid="h8dfac8b3gdd9aga779ga229g8159a97e610e" version="2">Lorsque vous faites appel à votre divinité pour une Intervention divine, votre dieu vous répond en restaurant une partie de votre pouvoir divin. Vous récupérez immédiatement un emplacement de sort de niveau 5.</content>
+  <content contentuid="hb220d543g0de9ga76cg8f82gc0f939ce0a89" version="1">Illumination protectrice améliorée</content>
+  <content contentuid="he222d284gfebfg2d88g1574g14e9d5ea7c35" version="1">Gagnez des Points de vie temporaires égaux à 2d6 + le modificateur de Sagesse du Clerc.</content>
+  <content contentuid="h717d6a55gf9a8g7d5eg5430gc31fbe95ad80" version="1">Collège des Esprits</content>
+  <content contentuid="h6923d229ga101g2539g1a0fg9771146b44a4" version="1">Les Bardes du Collège des Esprits invoquent des esprits légendaires pour changer le monde. Mais de telles entités sont capricieuses, et ce qu'un Barde convoque n'est pas toujours entièrement sous son contrôle.</content>
+  <content contentuid="h1ebd2503g6d9eg64e4g7876gf81e5169c3d1" version="1">Niveau 3 : Canalisateur</content>
+  <content contentuid="haf76903dg7bbdg5e64g7f90g970b37ad3960" version="1">Murmures des esprits. Vous connaissez le sort mineur Assistance. Il a une portée de 18 mètres lorsque vous le lancez.</content>
+  <content contentuid="h86ac4829gb9e1g65b8gf4b3g9e412c0d7a5e" version="1">Murmures des esprits</content>
+  <content contentuid="hf142ccaeg2d4cg6976g4ac2g7597d90fed0d" version="1">Niveau 3 : Esprits de l'au-delà</content>
+  <content contentuid="hadba9481g03c7gb0e4g2fc9gf098670ca5a9" version="2">Vous pouvez invoquer les esprits des morts pour vous renforcer, vous et vos alliés. Lorsque vous prenez une Action bonus pour donner un dé d'Inspiration bardique à une créature, vous pouvez faire appel aux pouvoirs d'un esprit aléatoire. Pour déterminer l'esprit que vous canalisez, lancez le dé d'Inspiration bardique et consultez la table Esprits de l'au-delà. L'esprit reste canalisé jusqu'à ce que vous le libériez ou que vous terminiez un Repos long.
+
+Canalisation contrôlée. En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Inspiration bardique et canaliser un esprit spécifique. Lorsque vous le faites, choisissez l'esprit dans la table Esprits de l'au-delà au lieu de lancer le dé. Le numéro correspondant à l'esprit choisi doit être inférieur ou égal au plus haut numéro de votre dé d'Inspiration bardique ; par exemple, si votre dé d'Inspiration bardique est un d8, vous pouvez choisir de canaliser n'importe quel esprit jusqu'à l'Ombre (incluse).
+
+Libérer un esprit. En tant qu'action Magique, vous pouvez libérer l'un de vos esprits canalisés. Choisissez une créature que vous pouvez voir à 9 mètres ou moins de vous comme cible de l'esprit. L'esprit prend alors effet ; si l'effet d'un esprit nécessite un jet de sauvegarde, le DD est égal à votre DD de sauvegarde de sort de Barde. Cette action vous permet d'utiliser réellement l'esprit.</content>
+  <content contentuid="hc94fe18bg4a60g7150g9266g8db53b913dac" version="1">Esprits de l'au-delà</content>
+  <content contentuid="h3b40a7b0g581fga77bg3d22g30944ffbaf78" version="1">Esprits de l'au-delà : Bien-aimé</content>
+  <content contentuid="hf382e28aged60gce44g754cg188b504d016d" version="1">Esprits de l'au-delà : Tireur d'élite</content>
+  <content contentuid="h6ea82181ga4bcg90c8g0b02gd8675e5b6aa4" version="1">Esprits de l'au-delà : Vengeur</content>
+  <content contentuid="h39df96a1g0bb3g137cg23aeg512d3de172d2" version="1">Esprits de l'au-delà : Renégat</content>
+  <content contentuid="h00cf74a8g6e1bgfba1g86f5gbc8aca92fe8c" version="1">Esprits de l'au-delà : Diseur de bonne aventure</content>
+  <content contentuid="he2f5e421g3789g0097gdfe7gab3e93f549a1" version="1">Esprits de l'au-delà : Voyageur</content>
+  <content contentuid="h6458540ag501ag8624gecf2g2f8f24c77656" version="1">Esprits de l'au-delà : Farceur</content>
+  <content contentuid="h8b0f281eg7854g1a32gf59fge016a5551f0b" version="1">Esprits de l'au-delà : Ombre</content>
+  <content contentuid="h1b99642bgb883g462cg638fg192cfcf25647" version="1">Esprits de l'au-delà : Incendiaire</content>
+  <content contentuid="h9329b80cg3c57g3510gedb5gde3327d9570b" version="1">Esprits de l'au-delà : Couard</content>
+  <content contentuid="hb5b80dd1g369bg905ag47a7g28e7465806d8" version="1">Vous pouvez invoquer les esprits des morts pour vous renforcer, vous et vos alliés. Lorsque vous prenez une Action bonus pour donner un dé d'Inspiration bardique à une créature, vous pouvez faire appel aux pouvoirs d'un esprit aléatoire. Pour déterminer l'esprit que vous canalisez, lancez le dé d'Inspiration bardique et consultez la table Esprits de l'au-delà. L'esprit reste canalisé jusqu'à ce que vous le libériez ou que vous terminiez un Repos long.</content>
+  <content contentuid="hc7d9adccgd21cg6730g04c3g3a1c38c6c5a9" version="2">Bien-aimé. La cible récupère un nombre de Points de vie égal à un jet de votre dé d'Inspiration bardique plus votre modificateur de Charisme.</content>
+  <content contentuid="h5b47bba7gdab8g8410ga59dgef9c6100ab29" version="2">Tireur d'élite. La cible subit des dégâts de Force égaux à un jet de votre dé d'Inspiration bardique plus votre modificateur de Charisme.</content>
+  <content contentuid="he73898ceg2342gac1agce15gffad564f5c59" version="2">Vengeur. Jusqu'à la fin de votre prochain tour, toute créature qui touche la cible avec un jet d'attaque de corps à corps subit des dégâts de Force égaux à un jet de votre dé d'Inspiration bardique.</content>
+  <content contentuid="h7d06d7d0g728fgd57ag44f5g66f05c613163" version="3">Renégat. Jusqu'à la fin de son tour, la cible peut utiliser sa Réaction pour se téléporter jusqu'à 9 mètres vers un espace inoccupé qu'elle peut voir.</content>
+  <content contentuid="h61deeb2fg018dgeadegdab2g65d4b9e1683a" version="2">Diseur de bonne aventure. La cible a l'Avantage aux Tests de D20 jusqu'au début de votre prochain tour.</content>
+  <content contentuid="h2bd86b9fg5a4bg7828gd29cg98815c2ef7d3" version="2">Voyageur. La cible gagne des Points de vie temporaires égaux à un jet de votre dé d'Inspiration bardique plus votre niveau de Barde. Tant que la cible a ces Points de vie temporaires, sa Vitesse augmente de 3 mètres.</content>
+  <content contentuid="h53224a2ag2d24g306bg844dge14be06ef6b9" version="2">Farceur. La cible effectue un jet de sauvegarde de Sagesse. En cas d'échec, la cible subit des dégâts Psychiques égaux à deux jets de votre dé d'Inspiration bardique et a la condition Charmé jusqu'au début de votre prochain tour. En cas de réussite, la cible subit seulement la moitié des dégâts.</content>
+  <content contentuid="hcb079ee5g1c25gbdc5gf618gc2aef3acfd28" version="2">Ombre. La cible a la condition Invisible jusqu'à la fin de son prochain tour ou jusqu'à ce qu'elle effectue un jet d'attaque, inflige des dégâts ou lance un sort. Lorsque l'invisibilité prend fin, chaque créature dans une Émanation de 1,50 mètre prenant sa source dans la cible doit réussir un jet de sauvegarde de Constitution ou subir des dégâts Nécrotiques égaux à deux jets de votre dé d'Inspiration bardique.</content>
+  <content contentuid="ha71f769bge1a3g46dfg432fga8899602df6a" version="2">Incendiaire. La cible effectue un jet de sauvegarde de Dextérité, subissant des dégâts de Feu égaux à quatre jets de votre dé d'Inspiration bardique en cas d'échec, ou la moitié de ces dégâts en cas de réussite.</content>
+  <content contentuid="h373150f8gf513g0146g7190ge9494becea23" version="2">Couard. La cible et chaque créature de votre choix dans une Émanation de 9 mètres prenant sa source dans la cible doivent réussir un jet de sauvegarde de Sagesse ou avoir la condition Effrayé jusqu'au début de votre prochain tour. Tant qu'une créature est Effrayée, sa Vitesse est réduite de moitié (arrondi à l'inférieur), et elle peut effectuer soit une action, soit une Action bonus, mais pas les deux.</content>
+  <content contentuid="hffce3b1cg9e68gb50cgbc7eg803cec074d21" version="1">Canalisation contrôlée</content>
+  <content contentuid="h945acb09g1397g1556g11b6g3c002e37946c" version="1">Canalisation contrôlée : Bien-aimé</content>
+  <content contentuid="hd8ba8bf9gec5fgc971g6414g155bd042f134" version="1">Canalisation contrôlée : Tireur d'élite</content>
+  <content contentuid="h98f45553g103ag5816g3970ga4819b6d6cb6" version="1">Canalisation contrôlée : Vengeur</content>
+  <content contentuid="h39687befg6a05g7279gb83dg79a1db3002ce" version="1">Canalisation contrôlée : Renégat</content>
+  <content contentuid="h62bc4434g28bdg98c9gcbb8ga8015d78cb4e" version="1">Canalisation contrôlée : Diseur de bonne aventure</content>
+  <content contentuid="h29dfe375g8154gf8bcg453cgfa9a2614e7fb" version="1">Canalisation contrôlée : Voyageur</content>
+  <content contentuid="h45a38cb9gec4fg8cfdge87eg66614158ce7d" version="1">Canalisation contrôlée : Farceur</content>
+  <content contentuid="he31164f3gc7eeg457ag9c53ge89b52235660" version="1">Canalisation contrôlée : Ombre</content>
+  <content contentuid="hc2dbe1c0gf4a2g7ed0g532agdde0fc25cd5d" version="1">Canalisation contrôlée : Incendiaire</content>
+  <content contentuid="hff226ec3g9b2dg45b2g19dfg56c02c4af940" version="1">Canalisation contrôlée : Couard</content>
+  <content contentuid="hd0b1b087g7e7fg7cf3gdc0fg4b7196bb961f" version="1">En tant qu'Action bonus, vous pouvez dépenser une utilisation de votre Inspiration bardique et canaliser un esprit spécifique. Lorsque vous le faites, choisissez l'esprit dans la table Esprits de l'au-delà au lieu de lancer le dé. Le numéro correspondant à l'esprit choisi doit être inférieur ou égal au plus haut numéro de votre dé d'Inspiration bardique ; par exemple, si votre dé d'Inspiration bardique est un d8, vous pouvez choisir de canaliser n'importe quel esprit jusqu'à l'Ombre (incluse).</content>
+  <content contentuid="h23b11d5dg4140gd4e3g0710ge0e1bf4a740e" version="1">Libérer un esprit</content>
+  <content contentuid="h99fc91bfg4ca1g9784g96bege336a9f9cf88" version="1">En tant qu'action Magique, vous pouvez libérer l'un de vos esprits canalisés. Choisissez une créature que vous pouvez voir à 9 mètres ou moins de vous comme cible de l'esprit. L'esprit prend alors effet ; si l'effet d'un esprit nécessite un jet de sauvegarde, le DD est égal à votre DD de sauvegarde de sort de Barde. Cette action vous permet d'utiliser réellement l'esprit.</content>
+  <content contentuid="h809e5f68g6c1fg087fg4ebbgd6a42f20a3f2" version="1">La cible récupère un nombre de Points de vie égal à un jet de votre dé d'Inspiration bardique plus votre modificateur de Charisme.</content>
+  <content contentuid="ha93da29dg5863g46a5gb636gdc16581b4520" version="1">La cible subit des dégâts de Force égaux à un jet de votre dé d'Inspiration bardique plus votre modificateur de Charisme.</content>
+  <content contentuid="h97319f1bgef21gc6f0g305bg9cc81c5b14c1" version="1">Jusqu'à la fin de votre prochain tour, toute créature qui touche la cible avec un jet d'attaque de corps à corps subit des dégâts de Force égaux à un jet de votre dé d'Inspiration bardique.</content>
+  <content contentuid="h6b7ca201g1238g4bbdg17feg37877398fd9e" version="2">Jusqu'à la fin de son tour, la cible peut utiliser sa Réaction pour se téléporter jusqu'à 9 mètres vers un espace inoccupé qu'elle peut voir.</content>
+  <content contentuid="hf34a9c9bga45bgc852g5af5g53f40d5fc0f3" version="1">La cible a l'Avantage aux Tests de D20 jusqu'au début de votre prochain tour.</content>
+  <content contentuid="h3c143767g21a8g66bcg6a21gf96dcfb36b88" version="1">La cible gagne des Points de vie temporaires égaux à un jet de votre dé d'Inspiration bardique plus votre niveau de Barde. Tant que la cible a ces Points de vie temporaires, sa Vitesse augmente de 3 mètres.</content>
+  <content contentuid="h8bd54844g8c51g684dg0147ga45b20304d23" version="1">La cible effectue un jet de sauvegarde de Sagesse. En cas d'échec, la cible subit des dégâts Psychiques égaux à deux jets de votre dé d'Inspiration bardique et a la condition Charmé jusqu'au début de votre prochain tour. En cas de réussite, la cible subit seulement la moitié des dégâts.</content>
+  <content contentuid="h1558545egaf7dg1079g8177g9f6871b6f525" version="1">La cible a la condition Invisible jusqu'à la fin de son prochain tour ou jusqu'à ce qu'elle effectue un jet d'attaque, inflige des dégâts ou lance un sort. Lorsque l'invisibilité prend fin, chaque créature dans une Émanation de 1,50 mètre prenant sa source dans la cible doit réussir un jet de sauvegarde de Constitution ou subir des dégâts Nécrotiques égaux à deux jets de votre dé d'Inspiration bardique.</content>
+  <content contentuid="hec346c79gf7e0ga44egbc79gbe72af6c9ba3" version="1">La cible effectue un jet de sauvegarde de Dextérité, subissant des dégâts de Feu égaux à quatre jets de votre dé d'Inspiration bardique en cas d'échec, ou la moitié de ces dégâts en cas de réussite.</content>
+  <content contentuid="h173fc315gc0d2g81edgd93dg3ddf2abd9626" version="1">La cible et chaque créature de votre choix dans une Émanation de 9 mètres prenant sa source dans la cible doivent réussir un jet de sauvegarde de Sagesse ou avoir la condition Effrayé jusqu'au début de votre prochain tour. Tant qu'une créature est Effrayée, sa Vitesse est réduite de moitié (arrondi à l'inférieur), et elle peut effectuer soit une action, soit une Action bonus, mais pas les deux.</content>
+  <content contentuid="h7f175533g6214gdd3dg85abgf900f49f70ea" version="1">Libérer un esprit : Bien-aimé</content>
+  <content contentuid="h2d7ed16fgf4dag658eg9a3bg2d0403eee929" version="1">Libérer un esprit : Tireur d'élite</content>
+  <content contentuid="he8db4d75g3788gb865gfae8g1e29680df8a8" version="1">Libérer un esprit : Vengeur</content>
+  <content contentuid="h038053e1gcfecgf7dbgde6fg58230daeb450" version="1">Libérer un esprit : Renégat</content>
+  <content contentuid="h77672afbg5619g3b1ag237eg9443a77c6090" version="1">Libérer un esprit : Diseur de bonne aventure</content>
+  <content contentuid="h9275efcdg5392ga44cg149cg1a62add6cf2a" version="1">Libérer un esprit : Voyageur</content>
+  <content contentuid="hea1ddd9cg5190g336fgf671gcf66a2291763" version="1">Libérer un esprit : Farceur</content>
+  <content contentuid="he46fe671gb7f8g016egffdfgebfe371c4328" version="1">Libérer un esprit : Ombre</content>
+  <content contentuid="h61d2bdf7g6628g46ddg50d4gb76f3723bdac" version="1">Libérer un esprit : Incendiaire</content>
+  <content contentuid="hf6a2b168g2d98g1bf5g837cg2fceb2ab048d" version="1">Libérer un esprit : Couard</content>
+  <content contentuid="h6d81a250g3cfag76eeg8fe0ga9763c05b980" version="1">Niveau 6 : Canalisation renforcée</content>
+  <content contentuid="h2cf47fc4g37cfg4d26ga580g3908890371fb" version="1">Votre capacité à canaliser les esprits s'améliore. Vous gagnez les bénéfices suivants.
+
+Pouvoir de l'au-delà. Une fois par tour, lorsque vous lancez un sort de Barde avec un emplacement de sort qui inflige des dégâts ou restaure des Points de vie, lancez 1d6. Ajoutez le résultat obtenu à l'un des jets de dégâts du sort ou au total des Points de vie qu'il restaure.
+
+Manifestation spirituelle. Vous avez toujours le sort Esprits gardiens préparé. De plus, vous gagnez un emplacement de sort de niveau 3 qui ne peut être utilisé que pour lancer Esprits gardiens. Vous récupérez cet emplacement de sort lorsque vous terminez un Repos long.</content>
+  <content contentuid="h7502ba87ga4a8g6ef1gd41dgad0795b74d7a" version="1">Vengeur</content>
+  <content contentuid="hef65c52fg7f7dgb2b3g1627g79d21c2f19bf" version="1">Toute créature qui touche la cible avec un jet d'attaque de corps à corps subit des dégâts de Force</content>
+  <content contentuid="h85cb392fg0a2fg3859g7db8g8b0c9e7dfe2e" version="1">Vengeur</content>
+  <content contentuid="ha2864a37g9128g6f44gcbf7gd841c7dd1ee3" version="1">Renégat</content>
+  <content contentuid="hfaa297fcgd10eg8d87g5895g1856bdac31ee" version="1">Jusqu'à la fin de son tour, la cible peut utiliser sa Réaction pour se téléporter jusqu'à 9 mètres vers un espace inoccupé qu'elle peut voir.</content>
+  <content contentuid="hbff33399g3821g55a5g1421g5be8f35d3981" version="1">Renégat</content>
+  <content contentuid="h496851c8g04fdg00a4g089dg29319b878d02" version="1">Se téléporte jusqu'à 9 mètres vers un espace inoccupé qu'elle peut voir.</content>
+  <content contentuid="had7c3cbeg7e83gce08g901aga518994d49f8" version="1">Diseur de bonne aventure</content>
+  <content contentuid="haf74a863gaa87g31eag1f55g095c055c056c" version="1">A l'Avantage aux Tests de D20.</content>
+  <content contentuid="h575cf64dg1928g3ab1g38b2gac008a149822" version="1">Voyageur</content>
+  <content contentuid="h9186b28dg0766gc68bg29a8ga4ca99c2272e" version="1">Gagne des Points de vie temporaires. Tant qu'elle a ces Points de vie temporaires, sa Vitesse augmente de 3 mètres.</content>
+  <content contentuid="h35ce1531gbf74g63ebgb93dge033e33d1130" version="1">Ombre</content>
+  <content contentuid="hf545430ag2493gc858g08d3g0bef38197077" version="1">A la condition Invisible. Lorsque l'invisibilité prend fin, chaque créature dans une Émanation de 1,50 mètre prenant sa source dans le personnage doit réussir un jet de sauvegarde de Constitution ou subir des dégâts Nécrotiques égaux à deux jets de votre dé d'Inspiration bardique.</content>
+  <content contentuid="h4f8f14ccgd5a6gc212g98ebg59206e3227ef" version="1">Couard</content>
+  <content contentuid="hc04acb85gbc27gf6ecga81eg712f62387e98" version="1">Sa Vitesse est réduite de moitié (arrondi à l'inférieur), et elle peut effectuer soit une action, soit une Action bonus, mais pas les deux.</content>
+  <content contentuid="h48078124g7f94gbb02g1bbeg8729dfed349b" version="1">Lame de radiance</content>
+  <content contentuid="hb5daba8dgda0agdf43g3675gc6035aefebbd" version="1">Les Lames de radiance, aussi appelées Acier-Saints, comptent parmi les ordres les plus meurtriers de l'Église. Pour devenir une lame, il faut être un fervent adepte de la foi, car seuls ceux qui sont prêts à mourir pour la cause sont jugés dignes. Les membres potentiels sont formés dans les murs de l'Église, faisant du clergé leur nouvelle famille et abandonnant les liens familiaux qu'ils entretenaient autrefois. Leur ferveur zélée leur confère une puissance inégalée sur le champ de bataille : ils manient des armes massives comme s'il s'agissait de jouets, infusent leurs lames d'énergie divine et brisent leurs ennemis un par un.
+
+Les Lames de radiance accomplissent un éventail incroyablement varié de missions. Les membres les plus brutaux règlent les affaires les plus sordides avec une précision létale, tandis que ceux d'un tempérament plus empathique protègent leurs semblables. Malgré leurs différences, tous partagent un même objectif : protéger l'Église et ses membres, quel qu'en soit le prix.</content>
+  <content contentuid="h964e4272gf52dgfcbcgc84eg674db33423b6" version="1">Niveau 3 : Champion sanctifié</content>
+  <content contentuid="h1449cbcfg1e78g7153g5e0dg53362829c1a3" version="1">Votre entraînement intensif porte ses fruits. Vous gagnez la maîtrise des armes de guerre et l'entraînement aux armures intermédiaires.
+
+Chaque fois que vous terminez un Repos court, vous pouvez accomplir un rituel sur une arme de corps à corps que vous maîtrisez et qui inflige des dégâts Perforants ou Tranchants, la sanctifiant. Elle devient votre lame sanctifiée, et vous ne pouvez avoir qu'une seule lame de ce type à la fois. La lame gagne la propriété Finesse pour vous, et les attaques effectuées avec elle contre les Aberrations, les Fiélons et les Morts-vivants ignorent la Résistance aux dégâts.</content>
+  <content contentuid="hd4c5ce4dgcb1bg633fg9549gc049d53401cf" version="1">Lame sanctifiée</content>
+  <content contentuid="hb8fdcfc4ga498g2b1cg07dfg1712e7560d44" version="1">Chaque fois que vous terminez un Repos court, vous pouvez accomplir un rituel sur une arme de corps à corps que vous maîtrisez et qui inflige des dégâts Perforants ou Tranchants, la sanctifiant. Elle devient votre lame sanctifiée, et vous ne pouvez avoir qu'une seule lame de ce type à la fois. La lame gagne la propriété Finesse pour vous, et les attaques effectuées avec elle contre les Aberrations, les Fiélons et les Morts-vivants ignorent la Résistance aux dégâts.</content>
+  <content contentuid="h690e847bge185g8948g88e3g81fa0004b7a4" version="1">Lame sanctifiée</content>
+  <content contentuid="h76a22005g0fd5g7e8bgedc0g71ee16b02cd7" version="1">La lame gagne la propriété Finesse pour vous, et les attaques effectuées avec elle contre les Aberrations, les Fiélons et les Morts-vivants ignorent la Résistance aux dégâts.</content>
+  <content contentuid="h7a334947g9694gb548gb4e4g4bfde199cc8d" version="1">Niveau 3 : Bénédictions divines</content>
+  <content contentuid="h0f7b9f58g4722gc431g724fgbbd26f346b33" version="1">Votre dévotion se manifeste sous forme de puissance vertueuse. Vous avez une réserve de Points divins égale à 1 plus votre modificateur de Sagesse (minimum de 1). Vous récupérez tous les Points divins dépensés lorsque vous terminez un Repos court ou long.
+
+De plus, chaque fois que vous tuez une Aberration, une Bête sauvage, un Fiélon ou un Mort-vivant de FP 1/2 ou plus avec votre lame sanctifiée, vous récupérez 1 Point divin dépensé.</content>
+  <content contentuid="h61182600gdefdg90cdg3670gd4d17060e741" version="2">Niveau 3 : Armure du fidèle</content>
+  <content contentuid="h87a8aa38gfa6eg9164g4acbgf38e8e39787f" version="1">En tant que Réaction lorsqu'une créature vous prend pour cible d'une attaque, vous pouvez dépenser 1 Point divin pour la forcer à effectuer un jet de sauvegarde de Sagesse. En cas d'échec, l'attaquant doit choisir une nouvelle cible, sans quoi l'attaque n'a aucun effet, et il ne peut plus vous prendre pour cible jusqu'au début de votre prochain tour. Cette fonctionnalité ne vous protège pas des zones d'effet.</content>
+  <content contentuid="h4786c94egf555g6fe0g55b0g55cb3a928893" version="2">Niveau 3 : Inspiration divine</content>
+  <content contentuid="h5d3f13dbgaaafgc317g4fb1ga68568021092" version="1">Lorsque vous effectuez un test d'Intelligence (Histoire ou Religion) ou de Sagesse (Perspicacité), vous gagnez un bonus au jet égal à votre modificateur de Sagesse.</content>
+  <content contentuid="h797675dag18a1ge22agbb1bgb5b01c18fd4d" version="2">Niveau 3 : Pourfendre les blasphémateurs</content>
+  <content contentuid="h5b6f609dg9e15g8c7cg33f8gbe509d75e00e" version="1">Après avoir pris l'action Attaquer avec votre lame sanctifiée, vous pouvez prendre une Action bonus et dépenser 1 Point divin pour effectuer une attaque supplémentaire avec elle, en gagnant un bonus au jet d'attaque égal à votre modificateur de Sagesse (minimum 1).</content>
+  <content contentuid="h7aef76d5g0c5egb8cfg0085g9e626ecff011" version="1">Pourfendre les blasphémateurs</content>
+  <content contentuid="h12a804eegfe14gb540gf10eg7e12569c4945" version="1">Vous pouvez prendre une Action bonus et dépenser 1 Point divin pour effectuer une attaque supplémentaire avec elle, en gagnant un bonus au jet d'attaque égal à votre modificateur de Sagesse (minimum 1).</content>
+  <content contentuid="he6e0389bg4b53gc6f7gd3fdg822f50ed705b" version="1">Armure du fidèle</content>
+  <content contentuid="h93f49c42g8f4fg3ae3g035dg2463963e3dd9" version="1">En tant que Réaction lorsqu'une créature vous prend pour cible d'une attaque, vous pouvez dépenser 1 Point divin pour la forcer à effectuer un jet de sauvegarde de Sagesse. En cas d'échec, l'attaquant doit choisir une nouvelle cible, sans quoi l'attaque n'a aucun effet, et il ne peut plus vous prendre pour cible jusqu'au début de votre prochain tour. Cette fonctionnalité ne vous protège pas des zones d'effet.</content>
+  <content contentuid="h6f23bbc7ga5a4gcc3dgd44eg45b750c2f618" version="1">Armure du fidèle</content>
+  <content contentuid="hd8d03d73gad13g0cd8g4a62g3287c6ec2cad" version="1">Pourfendre les blasphémateurs</content>
+  <content contentuid="he42b6d25ga54ag95feg90bbge79fe3812ac0" version="1">Point divin</content>
+  <content contentuid="h36a07310gf671gd6d5g26c3ge6250fa1718d" version="1">Niveau 9 : Chaînes du jugement</content>
+  <content contentuid="h05726c6egfdc1g7e6fgb135gb031d3bba7f8" version="1">Lorsque vous touchez une créature avec votre lame sanctifiée, vous pouvez dépenser 1 Point divin pour la lier dans des chaînes sacrées. La cible doit réussir un jet de sauvegarde de Force ou subir des dégâts Radiants égaux à votre modificateur de Sagesse et avoir la condition Entravé jusqu'à la fin de votre prochain tour.</content>
+  <content contentuid="hda7d8a17g6668ga3a6g1781g963016c95096" version="1">Niveau 9 : Représailles divines</content>
+  <content contentuid="hb1f27e8cg3c25g45d2gfff0gf52a143b7438" version="1">En tant que Réaction lorsqu'une créature vous inflige des dégâts avec une attaque de corps à corps, vous pouvez dépenser 1 Point divin pour effectuer une attaque de corps à corps contre elle. Vous gagnez un bonus au jet de dégâts égal à votre modificateur de Sagesse.</content>
+  <content contentuid="h4991ec40g26c7gc891g8995g3c46491be240" version="1">Niveau 9 : Lames jaillissantes</content>
+  <content contentuid="hda73ee14g5c7dg9f17g063dg92a87621426e" version="2">Vous pouvez dépenser 2 Points divins pour faire pleuvoir des lames radieuses en une Ligne de 13,50 mètres de long et 1,50 mètre de large. Chaque créature dans la Ligne doit effectuer un jet de sauvegarde de Dextérité, subissant des dégâts Radiants égaux à vos dégâts d'Attaque sournoise en cas d'échec, ou la moitié de ces dégâts en cas de réussite.</content>
+  <content contentuid="h53541f0cg04a1g112bge21dg808b86467f1d" version="1">Chaînes du jugement</content>
+  <content contentuid="hb5aeae53g0a47g6c52g8ed3gf1c8722ca565" version="1">Lorsque vous touchez une créature avec votre lame sanctifiée, vous pouvez dépenser 1 Point divin pour la lier dans des chaînes sacrées. La cible doit réussir un jet de sauvegarde de Force ou subir des dégâts Radiants égaux à votre modificateur de Sagesse et avoir la condition Entravé jusqu'à la fin de votre prochain tour.</content>
+  <content contentuid="haab525c5g6408g1302gb797gcc6ec923a940" version="1">Représailles divines</content>
+  <content contentuid="hdb2b4b09g8d02ge0d3g8eeagd0b7b294e1c2" version="1">En tant que Réaction lorsqu'une créature vous inflige des dégâts avec une attaque de corps à corps, vous pouvez dépenser 1 Point divin pour effectuer une attaque de corps à corps contre elle. Vous gagnez un bonus au jet de dégâts égal à votre modificateur de Sagesse.</content>
+  <content contentuid="ha43fceeeg4ad3g069bgbbf5g78b41ca67687" version="1">Lames jaillissantes</content>
+  <content contentuid="h6a7e8dbfg5edcgcfebgef9bgb58dbe804543" version="1">Vous pouvez dépenser 2 Points divins pour faire pleuvoir des lames radieuses en une Ligne de 13,50 mètres de long et 1,50 mètre de large. Chaque créature dans la Ligne doit effectuer un jet de sauvegarde de Dextérité, subissant des dégâts Radiants égaux à vos dégâts d'Attaque sournoise en cas d'échec, ou la moitié de ces dégâts en cas de réussite.</content>
+  <content contentuid="hf3cc24d4g40efg76d7g744fgfdf00c511218" version="1">Voie du Fracturé</content>
+  <content contentuid="he8be7bbbg7ac3ge2fegb60egac3d86538826" version="1">Les Barbares se définissent par leur rage, qu'ils canalisent pour déchaîner une destruction brève mais dévastatrice. Rares sont ceux qui ont le courage — ou l'imprudence — d'étudier les techniques psychologiques ésotériques qui séparent leur rage du reste de leur psyché, divisant leur identité en deux parties : l'ego et le ça. Lorsque leur ego est aux commandes, les Fracturés — c'est ainsi qu'on nomme ces Barbares — font preuve d'une maîtrise de soi et d'une ruse qui dépassent celles de la plupart des autres Barbares. Lorsqu'ils laissent leur ça prendre le contrôle, leur visage devient monstrueux et leur corps enfle sous la puissance d'une rage devenue physiquement manifeste.</content>
+  <content contentuid="h8130ff94gaab7gaff6gf12bgac599c7bd03e" version="1">Niveau 3 : Visage de rage</content>
+  <content contentuid="h1f2a95a9gb577g787bgb156g888616ccad6a" version="1">Niveau 3 : Masque de civilité</content>
+  <content contentuid="h9bf00f77g7323g0f09g943dg0f62ae2d5816" version="1">Niveau 6 : Cerveau et muscles</content>
+  <content contentuid="hcb5a649cg1519gbd23g0221g4d0efabd2166" version="1">Niveau 10 : Ruse et brutalité</content>
+  <content contentuid="h19bace45g8db7g181dgc420ge0fc17190c49" version="2">Lorsque vous activez votre Rage, votre visage se déforme et votre corps enfle. Les créatures qui n'ont pas été témoins de votre transformation, maintenant ou par le passé, ne vous reconnaissent pas. De plus, tant que votre Rage est active, vous gagnez les bénéfices suivants :
+
+Vous pouvez lancer 1d8 à la place des dégâts normaux de votre Attaque à mains nues.
+
+Lorsque vous touchez une créature avec une Attaque à mains nues, vous pouvez la repousser de 3 mètres ou la forcer à effectuer un jet de sauvegarde de Constitution (DD 8 plus votre modificateur de Force et votre Bonus de maîtrise). En cas d'échec, la créature a la condition À terre.
+
+Lorsque vous effectuez une Attaque à mains nues, votre portée est accrue de 1,50 mètre par rapport à la normale.</content>
+  <content contentuid="hb18ef098g90c9g4ad7gaf03g5aee30c02615" version="1">Vous avez la maîtrise de l'une des compétences suivantes de votre choix : Arcanes, Histoire, Investigation, Médecine, Nature, Persuasion ou Religion</content>
+  <content contentuid="hb0b38705ga312g7e31g9767g722d245f3d33" version="1">Tant que votre Rage n'est pas active, vous avez la Résistance aux dégâts Psychiques. Tant que votre Rage est active, vous avez la Résistance à tous les types de dégâts sauf les dégâts de Force et Psychiques.</content>
+  <content contentuid="hcdd6b1c9gc361g1c98gc596g4eefab4fdf0f" version="1">Tant que votre Rage n'est pas active, vous pouvez prendre l'action Se désengager ou Aider en tant qu'Action bonus. Tant que votre Rage est active, vos jets d'attaque avec des Attaques à mains nues peuvent infliger un Coup critique sur un résultat de 19 ou 20 sur le d20.</content>
+  <content contentuid="h954836cfg0b63g6106g5d15g224a3463e27e" version="1">Visage de rage : Poussée</content>
+  <content contentuid="h2c508ab1g6e88g9fc6g8d98gf93c24fc5e1a" version="1">Lorsque vous activez votre Rage, lorsque vous touchez une créature avec une Attaque à mains nues, vous pouvez la repousser de 3 mètres.</content>
+  <content contentuid="h534ed7cdg1c82g686bg5c11g853eb4fc79da" version="1">Visage de rage : À terre</content>
+  <content contentuid="h9ab20eb3gc598g3449gb504g354483f2972b" version="1">Lorsque vous activez votre Rage, lorsque vous touchez une créature avec une Attaque à mains nues, vous pouvez la forcer à effectuer un jet de sauvegarde de Constitution (DD 8 plus votre modificateur de Force et votre Bonus de maîtrise). En cas d'échec, la créature a la condition À terre.</content>
+  <content contentuid="hf0667bf6g77dagda24g515cg27017347e947" version="1">Voie du Berserker</content>
+  <content contentuid="h054c34e8gf7acg1ce5g9297g2f198a57cc90" version="2">Les Barbares qui suivent la Voie du Berserker dirigent leur Rage principalement vers la violence. Leur voie est celle d'une fureur sans entraves, et ils se délectent du chaos de la bataille lorsqu'ils laissent leur Rage s'emparer d'eux et les renforcer.</content>
+  <content contentuid="hfe2d7a7cg1f66g7b4cg4485g45ffc2e4f8ca" version="1">Voie du Cœur sauvage</content>
+  <content contentuid="h0a89d75bg6efag48a6gf526g8742bbe1176f" version="2">Les Barbares qui suivent la Voie du Cœur sauvage se considèrent comme apparentés aux animaux. Ces Barbares apprennent des moyens magiques de communiquer avec les animaux, et leur Rage renforce leur lien avec eux en les emplissant d'une puissance surnaturelle.</content>
+  <content contentuid="h20c62466g58aegc458g775bg12619ff97e87" version="1">Voie du Géant</content>
+  <content contentuid="haa843db4g20ebg9021gacedg3f8ada559a41" version="2">Les Barbares qui suivent la Voie du Géant puisent leur force dans les mêmes forces primordiales que les géants. Lorsqu'ils entrent en rage, ces barbares débordent de puissance élémentaire et grandissent en taille, adoptant des formes qui évoquent la gloire des géants. Certains barbares ressemblent à des versions surdimensionnées d'eux-mêmes, avec parfois une lueur d'énergie élémentaire dans les yeux et autour de leurs armes. D'autres se transforment plus radicalement, prenant l'apparence d'un véritable géant ou une forme proche d'un Élémentaire, nimbés de feu, de givre ou de foudre.</content>
+  <content contentuid="h64ffc9d5ga96fg168bg296eg9642cbd7f4b0" version="1">Voie de la Magie sauvage</content>
+  <content contentuid="h08c08b52g956bgcf55gaba1gfea165770305" version="2">De nombreux endroits du multivers regorgent de beauté, d'émotions intenses et de magie débridée ; la Féérie sauvage, les Plans supérieurs et d'autres royaumes de pouvoir surnaturel irradient de telles forces et peuvent profondément influencer les gens. Êtres de sentiments profonds, les barbares sont particulièrement sensibles à ces influences sauvages, certains étant transformés par cette magie. Ces barbares imprégnés de magie suivent la Voie de la Magie sauvage. Les barbares elfes, tieffelins, aasimars et génasis recherchent souvent cette voie, avides de manifester la magie d'un autre monde de leurs ancêtres.</content>
+  <content contentuid="h9c95882dg83f6g1bbdg05f2geae221b89b7a" version="1">Simulacre de vie</content>
+  <content contentuid="h22179fdag3286gcd27g7facg8e73f5c76e01" version="3">Vous gagnez 2d4 + [1] &lt;LSTag Tooltip="TemporaryHitPoints"&gt;points de vie temporaires&lt;/LSTag&gt;.</content>
+  <content contentuid="hd981160eg2361g96c5g14b2g6faa8b2cc888" version="1">Invocation : Simulacre de vie</content>
+  <content contentuid="h7706db7cg7c7dgf09bg4d14gc9faed17fc8b" version="1">Simulacre de vie</content>
+  <content contentuid="h64a85505gb9ccg347eg37efg4472a54e2380" version="1">A gagné 2d4+[1] &lt;LSTag Tooltip="TemporaryHitPoints"&gt;points de vie temporaires&lt;/LSTag&gt;.</content>
+  <content contentuid="h7db1a592ge710g4c16g2014gbe064274b274" version="1">Raz-de-marée</content>
+  <content contentuid="ha9c3ab13g3fb0g8a2eg5ee1gfbd234126c3d" version="1">Vous invoquez une vague d'eau qui s'abat sur une zone à portée. La zone peut mesurer jusqu'à 9 mètres de long, 3 mètres de large et 3 mètres de haut. Chaque créature dans cette zone doit effectuer un jet de sauvegarde de Dextérité. En cas d'échec, une créature subit 4d8 dégâts Contondants et est jetée À terre. En cas de réussite, une créature subit la moitié de ces dégâts et n'est pas jetée À terre</content>
+  <content contentuid="hec10168bged4egc312g169dgd40b9b631b23" version="1">Infusion de sang de troll</content>
+  <content contentuid="h2a98d2a4g6136gc14eg1cb9g3739feecfebf" version="1">Une créature que vous touchez est magiquement imprégnée des propriétés régénératrices du sang de troll. Pendant la durée du sort, la cible récupère 5 Points de vie au début de chacun de ses tours si elle a au moins 1 Point de vie, et réussit automatiquement ses jets de sauvegarde contre la mort.</content>
+  <content contentuid="hce516d21g26c1g26cfg3512gdec3165acc58" version="1">Infusion de sang de troll</content>
+  <content contentuid="hebd09d64gbff3g6d56gd342gcb0e1169f115" version="1">Une créature que vous touchez est magiquement imprégnée des propriétés régénératrices du sang de troll. Pendant la durée du sort, la cible récupère 5 Points de vie au début de chacun de ses tours si elle a au moins 1 Point de vie, et réussit automatiquement ses jets de sauvegarde contre la mort.</content>
+  <content contentuid="h8b08b170g8caagfb3fg29fcg67cbdcce5976" version="1">Frappe du Vide</content>
+  <content contentuid="h5cfaf826gcbcdg6716gd3c9gb82508ad025d" version="1">Par une courte phrase en langage du Vide, vous rassemblez des ténèbres grouillantes autour de votre main. Lorsque vous lancez le sort, puis par une action lors des tours suivants, vous pouvez décocher un trait de ténèbres sur une cible à portée. Effectuez une attaque de sort à distance. Si votre cible se trouve dans une Lumière faible ou dans les ténèbres, vous avez l'Avantage au jet. En cas de touche, la cible subit des dégâts Nécrotiques et est Effrayée par vous jusqu'au début de votre prochain tour.</content>
+  <content contentuid="hfa2950d9g0184g255ag6ff3gfe24dbf54ebc" version="1">Frappe du Vide</content>
+  <content contentuid="h69e1f672gc48fg3f52g323bg3be6611e1538" version="1">Nuée de corbeaux</content>
+  <content contentuid="ha5f5579fg9ce6ge4abg474ag9e80c16acfae" version="1">Vous invoquez et déchaînez une nuée de corbeaux meurtriers. Chaque créature de votre choix dans un Cône de 9 mètres prenant sa source en vous effectue un jet de sauvegarde de Dextérité. En cas d'échec, la cible subit 5d6 dégâts de Force et a la condition Aveuglé. En cas de réussite, elle subit seulement la moitié des dégâts. Une créature Aveuglée répète le jet de sauvegarde à la fin de chacun de ses tours, mettant fin à l'effet sur elle-même en cas de réussite.</content>
+  <content contentuid="h9652267bgde21g4799ga95ag6f6fadec6806" version="1">Murmures funestes</content>
+  <content contentuid="h5ed5413eg93c7gb24cg21d8g7901b49c4c83" version="1">Vous entonnez un chant funèbre murmuré, magiquement accompagné par les hurlements d'esprits et d'autres présages sinistres. Pendant la durée, une aura irradie de vous dans une Émanation de 9 mètres. Lorsque vous créez l'aura et au début de chacun de vos tours tant qu'elle persiste, vous pouvez choisir une créature à l'intérieur pour effectuer un jet de sauvegarde de Constitution. En cas d'échec, la créature subit 3d8 dégâts Nécrotiques.</content>
+  <content contentuid="h49cf69a9g3850ga86fg9854g543c73e1e561" version="1">Murmures funestes</content>
+  <content contentuid="hea3f9087gcfa4gad7eg1453gcafb3a204579" version="1">Pendant la durée, vous pouvez choisir une créature à l'intérieur pour effectuer un jet de sauvegarde de Constitution. En cas d'échec, la créature subit 3d8 dégâts Nécrotiques.</content>
+  <content contentuid="h95738422ged47g3260g1b9dg2cefcd3f0146" version="1">Orbe incandescent</content>
+  <content contentuid="hdf6371dcga18fg87bcgbe0dgf6e2f7928012" version="1">Vous créez et lancez un orbe d'énergie pulsante sur une créature à portée. Effectuez une attaque de sort à distance contre la cible. En cas de touche, la cible subit des dégâts Radiants. Que l'attaque touche ou non, l'orbe explose ensuite dans un éclair de lumière. La cible et chaque créature à 3 mètres ou moins d'elle effectuent un jet de sauvegarde de Constitution. En cas d'échec, une créature a la condition Aveuglé jusqu'à la fin de son prochain tour.</content>
+  <content contentuid="h144827a5g121ag0953g6918gbec2aad13de2" version="1">Orbe incandescent</content>
+  <content contentuid="hdfa4f375gf615g4ca4g83d9g72b194e8669b" version="1">Parchemin de Linceul d'ombre</content>
+  <content contentuid="h4787af58gb589g4278gafcfg39dfbb20933e" version="1">Parchemin de Cravache de l'Enfer</content>
+  <content contentuid="h7efb8458g9df5g41d1ga0afgd2d654771719" version="1">Parchemin d'Embrasement du Feu des sorts</content>
+  <content contentuid="hfcc54a67g386cg4555g8d89ga075abf80f71" version="1">Parchemin de Répulsion</content>
+  <content contentuid="h45d48dd0g0261g469ag929agaf26bcfb4b9a" version="1">Parchemin de Flambée d'Aganazzar</content>
+  <content contentuid="h4335d661g724ag4efag8e44g360b73743cb6" version="1">Parchemin de Trait de ténèbres</content>
+  <content contentuid="h6dc74b36g19fdg40fcgbff7gab2417f68395" version="1">Parchemin de Déflagration étourdissante</content>
+  <content contentuid="h2d0f0f01ga2cfg4ad5ga369g91672fb5295f" version="1">Parchemin d'Armure de mort</content>
+  <content contentuid="hfb9ed428ga689g44f4g81abg6451884c102e" version="1">Parchemin d'Évasion d'Elminster</content>
+  <content contentuid="h6192e9b5g8977g429cgb010g38af763aba20" version="1">Parchemin d'Invoquer une monture</content>
+  <content contentuid="h7c81072bgf346g4f27gb4d8gd92165d9db13" version="1">Parchemin de Rune de feu</content>
+  <content contentuid="h25cabd18g0f77g4c9bgb4b4g2683c7d2a2ac" version="1">Parchemin d'Épine mentale</content>
+  <content contentuid="hb51bf2b7g75aeg47ebg9ff7ge3b84584466e" version="1">Parchemin d'Orbe incandescent</content>
+  <content contentuid="h2a8c9d1dg05adg4418ga0fag5df33139674e" version="1">Parchemin de Nuée de boules de neige de Snilloc</content>
+  <content contentuid="h2956727dgcedeg4aebga14eg9e67a637bebe" version="1">Parchemin de Convocation de bête</content>
+  <content contentuid="h2802f412g5c46g4e5bgae24g35918b4e76d7" version="1">Parchemin de Fouet mental de Tasha</content>
+  <content contentuid="h804a9ebcg4a39g42b8ga542g639267b37959" version="1">Parchemin de Déluge astral</content>
+  <content contentuid="h1630aef7gc936g4946ga0a9gbf70c40a2178" version="1">Classes utilisables : Barde, Ensorceleur, Magicien</content>
+  <content contentuid="hd655beafg57e3g4552g9d37g67a7049e1e27" version="1">Parchemin de Murmures funestes</content>
+  <content contentuid="h367a9c18g6d87g4efdg8728gc9fd15827a4e" version="1">Classes utilisables : Barde, Occultiste</content>
+  <content contentuid="h9e0c03abgc377g42a3gb347g290fe5e06c2c" version="1">Parchemin de Convocation de fée</content>
+  <content contentuid="h4f00c785g7fadg44b7g98a0g85e5a5fe8f05" version="1">Classes utilisables : Druide, Rôdeur, Occultiste, Magicien</content>
+  <content contentuid="h1fb7c701gc871g4362g96bdg0f65d80431cb" version="1">Parchemin de Raz-de-marée</content>
+  <content contentuid="h746d4594g6849g43f2g8c6bg6c3abf36abce" version="1">Classes utilisables : Druide, Ensorceleur, Magicien</content>
+  <content contentuid="ha44c3b97g2d76g4729ga6f6g3cc7b6bec780" version="1">Parchemin d'Infusion de sang de troll</content>
+  <content contentuid="h4379be35gd68dg43b1gb25cg5cdcb15c5b69" version="1">Classes utilisables : Barde, Clerc, Druide, Occultiste</content>
+  <content contentuid="hbeec8e75gd58fg4960gba58ga21977fc95e3" version="1">Parchemin de Frappe du Vide</content>
+  <content contentuid="h9bcb5012g2665g4b8dgba67gbca63653cdca" version="1">Classes utilisables : Magicien</content>
+  <content contentuid="h91520a7bg4f44g4ed1g8018g075671f1d306" version="1">Parchemin de Source de clair de lune</content>
+  <content contentuid="hcbbdc17dgccb4g448fgb973gdab488542e7d" version="1">Classes utilisables : Barde, Druide</content>
+  <content contentuid="h185fff26gbcedg4e66g92fbg3f2bdd2a122c" version="1">Parchemin de Nuée de corbeaux</content>
+  <content contentuid="h6888009egf712g4161gaaedgabdba5f5df67" version="1">Classes utilisables : Druide, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="hba6165b1gb19eg4191g9bbdg8789273b4fe5" version="1">Parchemin de Tempête du Feu des sorts</content>
+  <content contentuid="hd6ae92cdg60f9g47afg988fg10b392c19463" version="1">Classes utilisables : Ensorceleur, Magicien</content>
+  <content contentuid="hf651f6cag4ca9g4fd5g83e7g9abff23ad945" version="1">Parchemin de Sphère de vitriol</content>
+  <content contentuid="hcfa316e6g8c9ag4b2bg96f8g2b057b958772" version="1">Classes utilisables : Ensorceleur, Magicien</content>
+  <content contentuid="h87b9abdbg15d6g4106g87f2g377b6bf7332f" version="1">Parchemin de Frappe des vents d'acier</content>
+  <content contentuid="h9b163dcdgf8c4g4da3ga132g95dbd23e830a" version="1">Classes utilisables : Magicien</content>
+  <content contentuid="hb1592619g4e2cg45c4ga433g8a0f0cae796b" version="1">Parchemin de Perturbations synaptiques</content>
+  <content contentuid="h6b8c9b31g95bbg4d4cga9a0gf66e4d6187f5" version="1">Classes utilisables : Barde, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h679a5d3cgea36g8caagcfd7gebbdee910cc1" version="1">Expert de la charge : Attaque à mains nues</content>
+  <content contentuid="h39e3d3b1gb37fgc87bg75c2g7b659b7eb280" version="1">Vous infligez davantage de dégâts en chargeant et en percutant le premier ennemi sur votre route.</content>
+  <content contentuid="h22201c0cgc0a5g5477gc910gd1dbcb28c892" version="1">Témérité (À mains nues)</content>
+  <content contentuid="h72f074a8gc35ag1dacg638cgaa77b73e11be" version="1">Témérité</content>
+  <content contentuid="hc91dc46cg504cg46c4g8871ga592835d0949" version="1">Pic de magie sauvage</content>
+  <content contentuid="he691a90cga2c9gccd3g42a4gd122e5addb8d" version="1">Pic de magie sauvage : 1</content>
+  <content contentuid="he04135b5gb4bdg7ef6g903dg79f721e678d7" version="1">Pic de magie sauvage : 2</content>
+  <content contentuid="h10ce0f8dgb205g8791g48d8g83dd4502eef1" version="1">Pic de magie sauvage : 3</content>
+  <content contentuid="h2baa5138g7f32g4883g9735g5325c9522d0e" version="1">Pic de magie sauvage : 4</content>
+  <content contentuid="h82e56d85gc785g489bgbb4ege0a19b8fe6e8" version="1">Pic de magie sauvage : 5</content>
+  <content contentuid="hd99aa48bga5c6g4ac6gb5cage54144031c95" version="1">Pic de magie sauvage : 6</content>
+  <content contentuid="hb2c173fcg575eg44e5ga59fg3b3cefefcad0" version="1">Pic de magie sauvage : 7</content>
+  <content contentuid="h43186f3ag40cbg4598g9a4fgcaff41f1976f" version="1">Pic de magie sauvage : 8</content>
+  <content contentuid="h5d4307efgbca8g4bbdg8d68g77396f91dcb9" version="1">Pic de magie sauvage : 9</content>
+  <content contentuid="h7989306eg4a2dg41adg9f68g038e56a38dad" version="1">Pic de magie sauvage : 10</content>
+  <content contentuid="hc5f19176gf96eg470dgb33dgd67abaa7ef20" version="1">Pic de magie sauvage : 11</content>
+  <content contentuid="h911b9430gdc16g44d3gb551gb1d0463be002" version="1">Pic de magie sauvage : 12</content>
+  <content contentuid="ha9e0e6d0g1774g431fgb80eg59e4a462a0ed" version="1">Pic de magie sauvage : 13</content>
+  <content contentuid="he9b3d4adgade9g4171g9518ge5f02d5df140" version="1">Pic de magie sauvage : 14</content>
+  <content contentuid="hef5f9ba9ge238g4f07gb2bdg869482cb3a8c" version="1">Pic de magie sauvage : 15</content>
+  <content contentuid="hcb3d62c8g153bg4a8dg9a4cgb00f7c9db4f2" version="1">Pic de magie sauvage : 16</content>
+  <content contentuid="hf596b76dga032g4cffga465g4ab733f22b4c" version="1">Pic de magie sauvage : 17</content>
+  <content contentuid="hc69d4034gbf69g49bag86e6g0f0109d305e8" version="1">Pic de magie sauvage : 18</content>
+  <content contentuid="h6b3566acg7d62g4275gbf28g66e172b9b38b" version="1">Pic de magie sauvage : 19</content>
+  <content contentuid="h7cd14cabg1201g4091gad64g60a75120337e" version="1">Pic de magie sauvage : 20</content>
+  <content contentuid="h3c40e1begc18eg451cga2b3gbccce7bb85c8" version="1">Pic de magie sauvage : 21</content>
+  <content contentuid="hac7bc041g88b1g49b0g934fg4a162a2be7ea" version="1">Pic de magie sauvage : 22</content>
+  <content contentuid="hc0ae25cbgae79g465bga74bgbce4c3bf1b28" version="1">Pic de magie sauvage : 23</content>
+  <content contentuid="ha31ba8a2g7b28g47e1g88feg5c4d8b8acf1e" version="1">Pic de magie sauvage : 24</content>
+  <content contentuid="h3c13d23dg756eg4a7dg8293gfcfe0f23e611" version="1">Pic de magie sauvage : 25</content>
+  <content contentuid="hab20c329g2757g440ega8d4g0e07e1303f35" version="1">Pic de magie sauvage : 26</content>
+  <content contentuid="h0a3e0bc7g9d38g4f2ag812egf444a1b03395" version="1">Pic de magie sauvage : 27</content>
+  <content contentuid="h022cdb32g5389g4281g8338g549638563766" version="1">Pic de magie sauvage : 28</content>
+  <content contentuid="h55f51a0eg75feg4865gba6eg358bc477f4cb" version="1">Pic de magie sauvage : 29</content>
+  <content contentuid="h9fc0c99dg8bebg4f4bg8606g042d17e256aa" version="1">Pic de magie sauvage : 30</content>
+  <content contentuid="h052bacebge45bg4843g90e7gc3002671ed4b" version="1">Pic de magie sauvage : 31</content>
+  <content contentuid="h6f9db5d8ge9a4g429ag92f9gc84c9d208323" version="1">Pic de magie sauvage : 32</content>
+  <content contentuid="hd3c5709fgac28g4adfgb8a9g1b4393bc45ea" version="1">Pic de magie sauvage : 33</content>
+  <content contentuid="h0c7bb697g4b7bg43eaga162g2b8ec4389c79" version="1">Pic de magie sauvage : 34</content>
+  <content contentuid="hc9c3ef43gf870g4d46g832egbaf67bb256f5" version="1">Pic de magie sauvage : 35</content>
+  <content contentuid="h9d4224aag171bg45bag888cgcb612da36ff8" version="1">Pic de magie sauvage : 36</content>
+  <content contentuid="h59a19f11gb4ebg4683gb4c8g44b0655734b7" version="1">Pic de magie sauvage : 37</content>
+  <content contentuid="h6908a343g2018g469fgaa1dg4492fe75fbb8" version="1">Pic de magie sauvage : 38</content>
+  <content contentuid="hd62d554fg19cfg4c34g8d6bge1845e2b065c" version="1">Pic de magie sauvage : 39</content>
+  <content contentuid="hd3d38b6agc9c6g48f4g9a75gc00340680aba" version="1">Pic de magie sauvage : 40</content>
+  <content contentuid="h4c26e43bge586g467fg9205g5daf5b9a4dbe" version="1">Pic de magie sauvage : 41</content>
+  <content contentuid="hdd5386dege144g459egbdd0ga5e0df1e9e7d" version="1">Pic de magie sauvage : 42</content>
+  <content contentuid="hd13f1a02g4d0eg4adcg9198g5ddf49d06f92" version="1">Pic de magie sauvage : 43</content>
+  <content contentuid="h580fc2adg9a07g4b84g8406g66cee3940b7f" version="1">Pic de magie sauvage : 44</content>
+  <content contentuid="h850eef46g150cg454aga814g4c76c60acb15" version="1">Pic de magie sauvage : 45</content>
+  <content contentuid="h755d721egdf7cg475cg8c42gc376bbb6af2b" version="1">Pic de magie sauvage : 46</content>
+  <content contentuid="h4b65a709gdc2bg47d7g8c34g18da49aec014" version="1">Pic de magie sauvage : 47</content>
+  <content contentuid="h0422cb7bg7ba7g4b12g8bffg832d3bc36b7e" version="1">Pic de magie sauvage : 48</content>
+  <content contentuid="hdcf69baagf86cg4b41gaee6g0b110d02152c" version="1">Pic de magie sauvage : 49</content>
+  <content contentuid="h30d3eca1gf899g4339g8bc3g1cadc1d6e030" version="1">Pic de magie sauvage : 50</content>
+  <content contentuid="h3110d474g5ad0g4df4ga9efgb02b82a97fb5" version="1">Pic de magie sauvage : 51</content>
+  <content contentuid="he2107db4g1664g4f79gaacag1758b38f0a31" version="1">Pic de magie sauvage : 52</content>
+  <content contentuid="h24b89bb4gd8a9g42fcg820ag8320befe42b1" version="1">Pic de magie sauvage : 53</content>
+  <content contentuid="h9fcf1bb4gf901g4946gba77g007cdfcaa15c" version="1">Pic de magie sauvage : 54</content>
+  <content contentuid="hfdc643bcg3babg4131g9f4bg7dc9a8fc01c4" version="1">Pic de magie sauvage : 55</content>
+  <content contentuid="h3054d95fg8194g4844gbdfagd9ad964d120b" version="1">Pic de magie sauvage : 56</content>
+  <content contentuid="h60eaa46fgd017g4e53g8073g2530d1144555" version="1">Pic de magie sauvage : 57</content>
+  <content contentuid="h6b941fc2g8579g447cga808g27c98979390d" version="1">Pic de magie sauvage : 58</content>
+  <content contentuid="h8917383aga333g4ce8gb10fgf93ff004fb63" version="1">Pic de magie sauvage : 59</content>
+  <content contentuid="h19c1706eg886ag45b2gbceag7c9e8e6bb694" version="1">Pic de magie sauvage : 60</content>
+  <content contentuid="h088d47bfg6808g4533gaec0g5f56a095eab4" version="1">Pic de magie sauvage : 61</content>
+  <content contentuid="h2dfdc35fg3778g4a55g8ba8g0f758f18172a" version="1">Pic de magie sauvage : 62</content>
+  <content contentuid="h3fb43e6age8adg44f4gb372g446fa2f664b6" version="1">Pic de magie sauvage : 63</content>
+  <content contentuid="hf1a0cf79ge96eg46c5gb1e4g4fa9d9a9a4c8" version="1">Pic de magie sauvage : 64</content>
+  <content contentuid="h27cacff3g5518g47bagb42cg08a2ddc140bb" version="1">Pic de magie sauvage : 65</content>
+  <content contentuid="hf4a5969bg59b6g4954gb93fg7b4dbd82afaa" version="1">Pic de magie sauvage : 66</content>
+  <content contentuid="he56a7e5cg4d03g4d50g9c2dg1252906fa219" version="1">Pic de magie sauvage : 67</content>
+  <content contentuid="h763e4709g1f92g48cbgb1d6g76d8586f4f88" version="1">Pic de magie sauvage : 68</content>
+  <content contentuid="h774ea108gebb7g4530g96c4g4a4f8530d16d" version="1">Pic de magie sauvage : 69</content>
+  <content contentuid="h231ffa22gb10cg4e1fg9b11ge342e47b0044" version="1">Pic de magie sauvage : 70</content>
+  <content contentuid="h0c5690acg57b8g4376gbdc4gcb93e5e3eadd" version="1">Pic de magie sauvage : 71</content>
+  <content contentuid="hddb6fbd2g82ecg4cf8g80e6gad8d81e7b943" version="1">Pic de magie sauvage : 72</content>
+  <content contentuid="hd9840361g2bfbg4fe6gbe25g0cc1bb0baac6" version="1">Pic de magie sauvage : 73</content>
+  <content contentuid="h195ec5b4g16e2g4a92gb299g3fa4f039a31e" version="1">Pic de magie sauvage : 74</content>
+  <content contentuid="h9ad47560g92d4g4bf2gb79agf087593164f4" version="1">Pic de magie sauvage : 75</content>
+  <content contentuid="hd8713bdfg0f37g400fga9b9gf1051666d904" version="1">Pic de magie sauvage : 76</content>
+  <content contentuid="h7986d55ag4b99g4f18g8a49g23926f7099d8" version="1">Pic de magie sauvage : 77</content>
+  <content contentuid="h9ced7473g352fg4a27g8da6g9e6fc2ad30f3" version="1">Pic de magie sauvage : 78</content>
+  <content contentuid="h1431c900g7a9ag4dcbg829fg9beb05facf3c" version="1">Pic de magie sauvage : 79</content>
+  <content contentuid="h6612f5d3g8924g4373g8b56g3d9c0cb4fde9" version="1">Pic de magie sauvage : 80</content>
+  <content contentuid="h8b90d907gae26g4ed0gacd8g69cdee3b3374" version="1">Pic de magie sauvage : 81</content>
+  <content contentuid="hb2629a69ge692g4c6dg85b4gdc37f77b4751" version="1">Pic de magie sauvage : 82</content>
+  <content contentuid="h17cda355g1776g4ba1g8e43g05b27e350d5e" version="1">Pic de magie sauvage : 83</content>
+  <content contentuid="hc4507d45gc0bag4bccgb9d8g1a953014319e" version="1">Pic de magie sauvage : 84</content>
+  <content contentuid="h408e7605g1f99g4029g8d7fgec9e3816065b" version="1">Pic de magie sauvage : 85</content>
+  <content contentuid="hc498aa93g38fcg4e64gb4e0ge93e9c0d17ae" version="1">Pic de magie sauvage : 86</content>
+  <content contentuid="he813f8cfg0064g46c4gab4fg7e21ee6f3817" version="1">Pic de magie sauvage : 87</content>
+  <content contentuid="hf2f2a7f2g321fg4fbeg8738gef1fefaba29d" version="1">Pic de magie sauvage : 88</content>
+  <content contentuid="h12c9762dg5f8cg40f6gb17cg935c848f6abd" version="1">Pic de magie sauvage : 89</content>
+  <content contentuid="h1820df21g521eg4257gb040g0cf6524fa4ea" version="1">Pic de magie sauvage : 90</content>
+  <content contentuid="h7cabb53egaec5g4bb6gadbag8ca15a4190c3" version="1">Pic de magie sauvage : 91</content>
+  <content contentuid="heef0635bg9befg4c3eg81dag89f471f87834" version="1">Pic de magie sauvage : 92</content>
+  <content contentuid="h7e7cd1efg5673g41f8gbd84g7d0637e90a92" version="1">Pic de magie sauvage : 93</content>
+  <content contentuid="hf2bee80bg0a49g4a08ga752ga03dd23892bb" version="1">Pic de magie sauvage : 94</content>
+  <content contentuid="h95705cfdg90fcg413agae54g5181ab30dab7" version="1">Pic de magie sauvage : 95</content>
+  <content contentuid="h6a41146ege4b4g43edg9de7g69ad06aa5690" version="1">Pic de magie sauvage : 96</content>
+  <content contentuid="h4597e3beg2c8dg4906g9974g408ed6beab9d" version="1">Pic de magie sauvage : 97</content>
+  <content contentuid="hbdd5fa3fg04c0g410aga5e9gd246de72ee3b" version="1">Pic de magie sauvage : 98</content>
+  <content contentuid="hdcd6f25ag324dg4fd4g976bg746bd5db6f6c" version="1">Pic de magie sauvage : 99</content>
+  <content contentuid="hee3ba1bcg491bg4ccfga01dga481388560d0" version="1">Pic de magie sauvage : 100</content>
+  <content contentuid="h153c27b7gc595g470cg9d19g5a19530c68cc" version="1">Pendant la prochaine minute, cet effet de Pic de magie sauvage se déclenche à nouveau au début de chacun de vos tours.</content>
+  <content contentuid="h015bc3c0g3f79g416cg88a5gfd2327bfe9da" version="1">Pendant la prochaine minute, cet effet de Pic de magie sauvage se déclenche à nouveau au début de chacun de vos tours.</content>
+  <content contentuid="h4b9b2ad5ga9e1g44f8gb33ag5235039db854" version="1">Pendant la prochaine minute, cet effet de Pic de magie sauvage se déclenche à nouveau au début de chacun de vos tours.</content>
+  <content contentuid="h383d0ae6g7900g4f11gbf34gb183e51f5749" version="1">Pendant la prochaine minute, cet effet de Pic de magie sauvage se déclenche à nouveau au début de chacun de vos tours.</content>
+  <content contentuid="hcb3ea2f5geb40g4f6eg893eg1fe3d94c8c45" version="1">Un familier Chien, amical envers vous, apparaît à côté de vous et disparaît 1 minute plus tard.</content>
+  <content contentuid="h3e25f595g3a54g42e1gb67cgc51e7babaf61" version="1">Un familier Diablotin, amical envers vous, apparaît à côté de vous et disparaît 1 minute plus tard.</content>
+  <content contentuid="hd1c1c274gc558g4a5fg888fgadfc3d67f57b" version="1">Un Dévoreur d'intellect, amical envers vous, apparaît à côté de vous et disparaît 1 minute plus tard.</content>
+  <content contentuid="h0e6cf6c3g3696g400bg9730g8c9dbe0d258c" version="1">Un Hollyphant, amical envers vous, apparaît à côté de vous et disparaît 1 minute plus tard.</content>
+  <content contentuid="h74c74ba4gb774g4edag93c5gf0a9fc7cca3c" version="1">Pendant la prochaine minute, vous récupérez 5 Points de vie au début de chacun de vos tours.</content>
+  <content contentuid="h58d89263gbf17g436dg8578g99bcae32ef96" version="1">Pendant la prochaine minute, vous récupérez 5 Points de vie au début de chacun de vos tours.</content>
+  <content contentuid="hdd553524g8f17g4657gbe86g2a3e7ad0d374" version="1">Pendant la prochaine minute, vous récupérez 5 Points de vie au début de chacun de vos tours.</content>
+  <content contentuid="h766ed0dbgb5b6g4a49gbebag695f13670807" version="1">Pendant la prochaine minute, vous récupérez 5 Points de vie au début de chacun de vos tours.</content>
+  <content contentuid="h64ca2190ged79g48b3g8d97g05bf536c8d8f" version="1">Les créatures ont le Désavantage aux jets de sauvegarde contre le prochain sort impliquant un jet de sauvegarde que vous lancez avant la fin de votre prochain tour.</content>
+  <content contentuid="h2a865a6fg5c4dg4e27g9666g450ff7dac5e2" version="1">Les créatures ont le Désavantage aux jets de sauvegarde contre le prochain sort impliquant un jet de sauvegarde que vous lancez avant la fin de votre prochain tour.</content>
+  <content contentuid="h3718243fg9cfcg4bf3g8359gd817a9960b36" version="1">Les créatures ont le Désavantage aux jets de sauvegarde contre le prochain sort impliquant un jet de sauvegarde que vous lancez avant la fin de votre prochain tour.</content>
+  <content contentuid="h5bab9dedg533bg48acgb31fgef0a413db999" version="1">Les créatures ont le Désavantage aux jets de sauvegarde contre le prochain sort impliquant un jet de sauvegarde que vous lancez avant la fin de votre prochain tour.</content>
+  <content contentuid="ha2c5a26fg5dc7g4771gb8c1g900a95cb7d20" version="1">Votre taille augmente d'une catégorie de taille pendant 1 minute.</content>
+  <content contentuid="h44465c7fgaed5g43cdg9670gc3ab3be2886d" version="1">Votre taille diminue d'une catégorie de taille pendant 1 minute.</content>
+  <content contentuid="h6a96134bg56acg41dcga188g91af03e1b3d4" version="1">Pendant la prochaine minute, vous pouvez lancer des sorts même lorsque vous avez la condition Réduit au silence.</content>
+  <content contentuid="h92d3ff6eg813ag44a9g8052g69887f23ee35" version="1">Un maquillage de clown apparaît sur votre visage et y demeure jusqu'à ce que vous terminiez un Repos long.</content>
+  <content contentuid="h1ff7c8e0ge5ddg433fgab72ge3d7d6a14313" version="1">Pendant la prochaine minute, tous vos sorts avec un temps d'incantation d'une action ont un temps d'incantation d'une Action bonus.</content>
+  <content contentuid="hb2e52d7fgab74g47e9g91ffg9765943f3a54" version="1">Pendant la prochaine minute, tous vos sorts avec un temps d'incantation d'une action ont un temps d'incantation d'une Action bonus.</content>
+  <content contentuid="hcd1876e9g75d3g42a8g9566g3da476c57e8d" version="1">Pendant la prochaine minute, tous vos sorts avec un temps d'incantation d'une action ont un temps d'incantation d'une Action bonus.</content>
+  <content contentuid="h719aceeegcd4bg49c8ga9a2gc74e1485c405" version="1">Pendant la prochaine minute, tous vos sorts avec un temps d'incantation d'une action ont un temps d'incantation d'une Action bonus.</content>
+  <content contentuid="haecbe11fg6d60g47e2gb1a2g08f0d2c311f2" version="1">Vous êtes transporté dans le Plan Éthéré jusqu'à la fin de votre prochain tour, comme par le sort Clignotement. Vous revenez ensuite dans l'espace que vous occupiez précédemment, ou dans l'espace inoccupé le plus proche si celui-ci est occupé.</content>
+  <content contentuid="hbaae27bag3d21g4b92g824egab934089bcc0" version="1">Vous êtes transporté dans le Plan Éthéré jusqu'à la fin de votre prochain tour, comme par le sort Clignotement. Vous revenez ensuite dans l'espace que vous occupiez précédemment, ou dans l'espace inoccupé le plus proche si celui-ci est occupé.</content>
+  <content contentuid="hfd23c057g13d1g4881g84e9g8f3ccd39b79e" version="1">Vous êtes transporté dans le Plan Éthéré jusqu'à la fin de votre prochain tour, comme par le sort Clignotement. Vous revenez ensuite dans l'espace que vous occupiez précédemment, ou dans l'espace inoccupé le plus proche si celui-ci est occupé.</content>
+  <content contentuid="hb601c55dgad62g404eg95eeg2d21a1b38165" version="1">Vous êtes transporté dans le Plan Éthéré jusqu'à la fin de votre prochain tour, comme par le sort Clignotement. Vous revenez ensuite dans l'espace que vous occupiez précédemment, ou dans l'espace inoccupé le plus proche si celui-ci est occupé.</content>
+  <content contentuid="hd2a63fa4g8bc3g40d0gadafgbe4c69f9832c" version="2">Jusqu'à la fin de votre prochain tour, lancez deux fois chaque dé de dégâts pour les sorts qui infligent des dégâts, et utilisez le meilleur résultat pour chaque dé.</content>
+  <content contentuid="h5cb55472gb6b7g47b1g89e1g030b53720520" version="2">Jusqu'à la fin de votre prochain tour, lancez deux fois chaque dé de dégâts pour les sorts qui infligent des dégâts, et utilisez le meilleur résultat pour chaque dé.</content>
+  <content contentuid="hb2ec585cg90ddg450ag98dagbeb32d75fa7d" version="2">Jusqu'à la fin de votre prochain tour, lancez deux fois chaque dé de dégâts pour les sorts qui infligent des dégâts, et utilisez le meilleur résultat pour chaque dé.</content>
+  <content contentuid="ha4eee424g6b14g40beg8738g0cec17ad0409" version="2">Jusqu'à la fin de votre prochain tour, lancez deux fois chaque dé de dégâts pour les sorts qui infligent des dégâts, et utilisez le meilleur résultat pour chaque dé.</content>
+  <content contentuid="h39c12d1fgb5dcg4d51g87bbg18512a184b4e" version="1">Vous avez la Résistance à tous les dégâts pendant la prochaine minute.</content>
+  <content contentuid="h5f8b193egd0abg40e0g8557g3311b46354cc" version="1">Vous avez la Résistance à tous les dégâts pendant la prochaine minute.</content>
+  <content contentuid="h29599a87g8b49g4020g9e8bg84709ef67c1d" version="1">Vous avez la Résistance à tous les dégâts pendant la prochaine minute.</content>
+  <content contentuid="hc5ab4d91g0b67g4cf9ga593g3e5b2af9ac23" version="1">Vous avez la Résistance à tous les dégâts pendant la prochaine minute.</content>
+  <content contentuid="he8a359d2g85c2g4182g876cg6b35007745eb" version="1">Vous vous transformez en Mouton jusqu'au début de votre prochain tour. Tant que vous êtes un Mouton, vous avez la condition Neutralisé et la Vulnérabilité à tous les dégâts. Si vous tombez à 0 Point de vie, vous reprenez immédiatement votre forme.</content>
+  <content contentuid="hd4eb497cg5894g467ega7feg4d27550eff7f" version="1">Vous vous transformez en Mouton jusqu'au début de votre prochain tour. Tant que vous êtes un Mouton, vous avez la condition Neutralisé et la Vulnérabilité à tous les dégâts. Si vous tombez à 0 Point de vie, vous reprenez immédiatement votre forme.</content>
+  <content contentuid="h5809be0ega7e9g4091gb93cg6307099b32e3" version="1">Vous vous transformez en Mouton jusqu'au début de votre prochain tour. Tant que vous êtes un Mouton, vous avez la condition Neutralisé et la Vulnérabilité à tous les dégâts. Si vous tombez à 0 Point de vie, vous reprenez immédiatement votre forme.</content>
+  <content contentuid="hca1d09ecgac01g45a5gbf6ag1a6c36f93c81" version="1">Vous vous transformez en Mouton jusqu'au début de votre prochain tour. Tant que vous êtes un Mouton, vous avez la condition Neutralisé et la Vulnérabilité à tous les dégâts. Si vous tombez à 0 Point de vie, vous reprenez immédiatement votre forme.</content>
+  <content contentuid="h440d92c5g827eg4e83ga9d3gb18aaf0860dc" version="2">Pendant la prochaine minute, vous pouvez vous téléporter jusqu'à 9 mètres par une Action bonus à chacun de vos tours.</content>
+  <content contentuid="h76c410ccg5631g4bacg921eg33961cecb6b9" version="2">Pendant la prochaine minute, vous pouvez vous téléporter jusqu'à 9 mètres par une Action bonus à chacun de vos tours.</content>
+  <content contentuid="h313de399g6ff6g4c30ga121gd02ae57ae801" version="2">Pendant la prochaine minute, vous pouvez vous téléporter jusqu'à 9 mètres par une Action bonus à chacun de vos tours.</content>
+  <content contentuid="hbb61a1bfgd1cdg4166ga626g58ef98721406" version="2">Pendant la prochaine minute, vous pouvez vous téléporter jusqu'à 9 mètres par une Action bonus à chacun de vos tours.</content>
+  <content contentuid="hb3d1182cg5d54g444cgb977g26e77a6a099e" version="2">Vous avez la condition Invisible pendant 1 minute. Cette invisibilité prend fin pour une créature immédiatement après qu'elle a effectué un jet d'attaque, infligé des dégâts ou lancé un sort.</content>
+  <content contentuid="h3f87293dg3247g4d73gb758gf7485044db3c" version="2">Vous avez la condition Invisible pendant 1 minute. Cette invisibilité prend fin pour une créature immédiatement après qu'elle a effectué un jet d'attaque, infligé des dégâts ou lancé un sort.</content>
+  <content contentuid="hb4ffbe2cg154fg4614ga481g770425e23306" version="2">Vous avez la condition Invisible pendant 1 minute. Cette invisibilité prend fin pour une créature immédiatement après qu'elle a effectué un jet d'attaque, infligé des dégâts ou lancé un sort.</content>
+  <content contentuid="h8382539fg0076g44d2gb673g042eb6831f24" version="2">Vous avez la condition Invisible pendant 1 minute. Cette invisibilité prend fin pour une créature immédiatement après qu'elle a effectué un jet d'attaque, infligé des dégâts ou lancé un sort.</content>
+  <content contentuid="h55adfd44g7c29g4b67g894fg9b98ff76115a" version="1">Un bouclier spectral flotte près de vous pendant la prochaine minute, vous conférant un bonus de +2 à la CA et l'immunité contre Projectile magique.</content>
+  <content contentuid="h413145b9g72c2g4630ga50ag6b4c5d367395" version="1">Un bouclier spectral flotte près de vous pendant la prochaine minute, vous conférant un bonus de +2 à la CA et l'immunité contre Projectile magique.</content>
+  <content contentuid="hfedbac46g363eg4c64g9537g61335c5397d3" version="1">Un bouclier spectral flotte près de vous pendant la prochaine minute, vous conférant un bonus de +2 à la CA et l'immunité contre Projectile magique.</content>
+  <content contentuid="he5db46c7g00dag496fg9afag93806e384c00" version="1">Un bouclier spectral flotte près de vous pendant la prochaine minute, vous conférant un bonus de +2 à la CA et l'immunité contre Projectile magique.</content>
+  <content contentuid="h09794f54g28f6g4aadgb3dbg21bb411c3001" version="1">Vous pouvez effectuer une action supplémentaire pendant ce tour.</content>
+  <content contentuid="h8f0b35d8g848bg483dgb2a3gfe6f9fbea014" version="1">Vous pouvez effectuer une action supplémentaire pendant ce tour.</content>
+  <content contentuid="h30ea4db6gf500g4da7g85degd5038eb2214b" version="1">Vous pouvez effectuer une action supplémentaire pendant ce tour.</content>
+  <content contentuid="h13804bdfg230ag40f0ga4acgaf7d83493468" version="1">Vous pouvez effectuer une action supplémentaire pendant ce tour.</content>
+  <content contentuid="hba2aa50eg96e0g453egab74g08d15425875f" version="3">Vous lancez Image miroir sur vous-même.</content>
+  <content contentuid="hdd099d89g2153g4634ga753g2be8e4f70ebd" version="1">Vous lancez Image miroir sur vous-même.</content>
+  <content contentuid="h7f2f1a91g15beg482eg8145g5af0bd67471e" version="3">Vous lancez Image miroir sur vous-même.</content>
+  <content contentuid="hf32c9140g4ab5g43d0gaecdg9d7c7ff89c1c" version="3">Vous lancez Image miroir sur vous-même.</content>
+  <content contentuid="hafefa2e1g90b1g4c2bga373g2d641dd61b87" version="3">Chaque créature et objet à [1] ou moins commence à brûler et subit [2] par tour.</content>
+  <content contentuid="hd1b48940g58d3g4e8ega4dcg7ed2dee94101" version="3">Chaque créature et objet à [1] ou moins commence à brûler et subit [2] par tour.</content>
+  <content contentuid="hce4f5a31g0d0ag4b63g942egbffb8f14a92c" version="3">Chaque créature et objet à [1] ou moins commence à brûler et subit [2] par tour.</content>
+  <content contentuid="hed397eecg9b3bg4678gba35gcf91f0402409" version="3">Chaque créature et objet à [1] ou moins commence à brûler et subit [2] par tour.</content>
+  <content contentuid="h4ea41309gb768g42f0g8f88g2da72126a223" version="3">Vous gagnez les effets du sort Protection contre la mort jusqu'à ce que vous terminiez un Repos long.</content>
+  <content contentuid="h4a8aa733g3cefg4554g999bgc91e0bde4c64" version="3">Vous gagnez les effets du sort Protection contre la mort jusqu'à ce que vous terminiez un Repos long.</content>
+  <content contentuid="hbc9e47f3g27ffg491cg810dg8e81ad43467d" version="3">Vous gagnez les effets du sort Protection contre la mort jusqu'à ce que vous terminiez un Repos long.</content>
+  <content contentuid="h9172da8fgeee1g4ff0g9187g049ed9fe9a7b" version="3">Vous gagnez les effets du sort Protection contre la mort jusqu'à ce que vous terminiez un Repos long.</content>
+  <content contentuid="h1f99f5cdg1051g4c3ag9aaeg3de12140280c" version="1">Vous avez la condition Effrayé jusqu'à la fin de votre prochain tour.</content>
+  <content contentuid="h444dcbd8ge750g47a1g8435g2ef2a86cd29d" version="1">Vous avez la condition Effrayé jusqu'à la fin de votre prochain tour.</content>
+  <content contentuid="hdd3aa3bag0467g4cbdg8137ge567f9ff8c1e" version="1">Vous avez la condition Effrayé jusqu'à la fin de votre prochain tour.</content>
+  <content contentuid="h77ea0c5eg60afg490bgb41ag743886d5dd25" version="1">Vous avez la condition Effrayé jusqu'à la fin de votre prochain tour.</content>
+  <content contentuid="h1c8ca772g3d10g4830g9440g5bcc0b817e7f" version="3">Vous lancez Flou sur vous-même.</content>
+  <content contentuid="hdaaedfadgbbd6g42e5g987ag8394b76136cf" version="3">Vous lancez Flou sur vous-même.</content>
+  <content contentuid="h9ad8eb04g20c2g4e54gb276g2d76f4740060" version="3">Vous lancez Flou sur vous-même.</content>
+  <content contentuid="hc02e7cdege460g4239g8baeg6da5d09821fc" version="3">Vous lancez Flou sur vous-même.</content>
+  <content contentuid="h5c5ef942gcbf3g49cbg9accgc942edae5e84" version="3">Créez un nuage de brouillard autour de vous. Les créatures à l'intérieur sont en Visibilité nulle et &lt;LSTag Type="Status" Tooltip="BLINDED"&gt;Aveuglées&lt;/LSTag&gt;.</content>
+  <content contentuid="hc960f4b7g78deg40bbg965fgc1565ecade8e" version="3">Créez un nuage de brouillard autour de vous. Les créatures à l'intérieur sont en Visibilité nulle et &lt;LSTag Type="Status" Tooltip="BLINDED"&gt;Aveuglées&lt;/LSTag&gt;.</content>
+  <content contentuid="hb3b236fdg6f36g43e7gbd94gb9dab02f1422" version="3">Créez un nuage de brouillard autour de vous. Les créatures à l'intérieur sont en Visibilité nulle et &lt;LSTag Type="Status" Tooltip="BLINDED"&gt;Aveuglées&lt;/LSTag&gt;.</content>
+  <content contentuid="h98b8ca8bge009g418dgb454gf9c2863445c0" version="3">Créez un nuage de brouillard autour de vous. Les créatures à l'intérieur sont en Visibilité nulle et &lt;LSTag Type="Status" Tooltip="BLINDED"&gt;Aveuglées&lt;/LSTag&gt;.</content>
+  <content contentuid="hde366e14gd5b5g44c4g827bga2b49392cbca" version="2">Jusqu'à la fin de votre prochain tour, chaque sort que vous lancez restaure un nombre de Points de sorcellerie égal au niveau de son &lt;LSTag Tooltip="SpellSlot"&gt;emplacement de sort&lt;/LSTag&gt;.</content>
+  <content contentuid="h6ce73a81g4678g4a91ga52cg81e6fa1c24b3" version="2">Jusqu'à la fin de votre prochain tour, chaque sort que vous lancez restaure un nombre de Points de sorcellerie égal au niveau de son &lt;LSTag Tooltip="SpellSlot"&gt;emplacement de sort&lt;/LSTag&gt;.</content>
+  <content contentuid="hba496d7agd6f7g4bf8g8066g3041c4a139d5" version="2">Jusqu'à la fin de votre prochain tour, chaque sort que vous lancez restaure un nombre de Points de sorcellerie égal au niveau de son &lt;LSTag Tooltip="SpellSlot"&gt;emplacement de sort&lt;/LSTag&gt;.</content>
+  <content contentuid="h25c99944g196eg48c0ga7cbgd07dc433af9c" version="2">Jusqu'à la fin de votre prochain tour, chaque sort que vous lancez restaure un nombre de Points de sorcellerie égal au niveau de son &lt;LSTag Tooltip="SpellSlot"&gt;emplacement de sort&lt;/LSTag&gt;.</content>
+  <content contentuid="h79878215g2bfbg412eg851bgaded3f9b8188" version="3">Façonnez une parcelle de terrain autour de vous en pointes acérées. Une créature marchant sur les pointes subit [1] pour chaque [2] de déplacement.</content>
+  <content contentuid="h9cfd2cf9g3c6bg44d3gbc44g1db3354de7f0" version="3">Façonnez une parcelle de terrain autour de vous en pointes acérées. Une créature marchant sur les pointes subit [1] pour chaque [2] de déplacement.</content>
+  <content contentuid="h6ef2ef69g5a70g4e79gbec8g4d789ec34d39" version="3">Façonnez une parcelle de terrain autour de vous en pointes acérées. Une créature marchant sur les pointes subit [1] pour chaque [2] de déplacement.</content>
+  <content contentuid="h833c0955gffccg49b7g9c91gc755ac906512" version="3">Façonnez une parcelle de terrain autour de vous en pointes acérées. Une créature marchant sur les pointes subit [1] pour chaque [2] de déplacement.</content>
+  <content contentuid="hb5a352bfg05b6g438fga2c8g930246489691" version="2">Échangez de position avec une cible chaque fois que vous lancez un sort ou un &lt;LSTag Tooltip="Cantrip"&gt;sort mineur&lt;/LSTag&gt;.</content>
+  <content contentuid="hbe741660gb4b4g4a86g84a5g1091b8be5a8c" version="2">Échangez de position avec une cible chaque fois que vous lancez un sort ou un &lt;LSTag Tooltip="Cantrip"&gt;sort mineur&lt;/LSTag&gt;.</content>
+  <content contentuid="h59bc3445g9221g4057gaaa7g57e95c105dda" version="2">Échangez de position avec une cible chaque fois que vous lancez un sort ou un &lt;LSTag Tooltip="Cantrip"&gt;sort mineur&lt;/LSTag&gt;.</content>
+  <content contentuid="hfef17422ga705g4694g861dg3f8ac4ae97df" version="3">Enchantez l'arme de chaque créature à [1] ou moins. Leur prochaine attaque est un &lt;LSTag Tooltip="CriticalHit"&gt;Coup critique&lt;/LSTag&gt; et inflige [2] supplémentaires.</content>
+  <content contentuid="hfebb0c2eg259cg4a52g9a3cg4edf6de87e4e" version="2">Capable de soulever et de projeter objets et créatures par la pensée jusqu'à la fin de votre tour.</content>
+  <content contentuid="hb93e81d2g30f2g4d68gb901g6d3fc1641adf" version="2">Capable de soulever et de projeter objets et créatures par la pensée jusqu'à la fin de votre tour.</content>
+  <content contentuid="h0c900d97g6042g4a00g8692g209562838bd4" version="2">Capable de soulever et de projeter objets et créatures par la pensée jusqu'à la fin de votre tour.</content>
+  <content contentuid="h404bb326g3a7ag4766gbc53gb4c0cec521d8" version="4">Vous pouvez &lt;LSTag Type="Spell" Tooltip="Projectile_Fly"&gt;Voler&lt;/LSTag&gt; jusqu'à la fin du tour.</content>
+  <content contentuid="hef777ecbg83d4g4377g8d15g52a28ba8e05b" version="2">Lorsque vous touchez une cible avec un sort, soignez toutes les créatures à [1] ou moins de [2] par niveau d'&lt;LSTag Tooltip="SpellSlot"&gt;emplacement de sort&lt;/LSTag&gt; utilisé.</content>
+  <content contentuid="he838dc28gdd7ag4377g9eb3g08e15f2d29e1" version="3">Chaque créature à [1] ou moins est transformée aléatoirement en chat ou en chien.</content>
+  <content contentuid="hdde680a7g73b5g43f5g8a74g38ce84de8780" version="3">Enfermez-vous dans une sphère arcanique. Vous ne pouvez pas subir de dégâts des attaques ou des effets provenant de l'extérieur de la sphère, ni infliger de dégâts à quoi que ce soit à l'extérieur de la sphère. La &lt;LSTag Tooltip="MovementSpeed"&gt;vitesse de déplacement&lt;/LSTag&gt; est réduite de moitié.</content>
+  <content contentuid="h6e154639gd102g48cdg9302g9fc6aba3af7a" version="3">Invoquez un cambion depuis le nexus enflammé des Neuf Enfers. Il est hostile envers tous.</content>
+  <content contentuid="hd7c4e9bcgfaa1g320fg0084g4c415302c9e7" version="1">Pic de magie sauvage : Tour</content>
+  <content contentuid="hee561d22g37d0g6469gc0eag8357331f85c7" version="1">Pendant la prochaine minute, cet effet de Pic de magie sauvage se déclenche à nouveau au début de chacun de vos tours.</content>
+  <content contentuid="hbc7e05c5ge02cg94d7g5dc3g686e92bfd461" version="1">Pic de magie sauvage : Soin</content>
+  <content contentuid="h2adac2e6gb3ddga397ge4e1gecee044a8600" version="1">Pendant la prochaine minute, vous récupérez 5 Points de vie au début de chacun de vos tours.</content>
+  <content contentuid="h0b8ddabbg0198g0a5cg7a6cg3c0494222ffa" version="1">Pic de magie sauvage : Sort intensifié</content>
+  <content contentuid="h82a7caf7gb2d1g8404gf1b6g11cd548c764a" version="1">Les créatures ont le Désavantage aux jets de sauvegarde contre le prochain sort impliquant un jet de sauvegarde que vous lancez avant la fin de votre prochain tour.</content>
+  <content contentuid="h1c32e506g9819g329fge1c2gf454d3ab2804" version="1">Pic de magie sauvage : Sort subtil</content>
+  <content contentuid="h36d3d4a8g88feg0480gc523g478a7b4f0a76" version="1">Pendant la prochaine minute, tous vos sorts avec un temps d'incantation d'une action ont un temps d'incantation d'une Action bonus.</content>
+  <content contentuid="h0630aaa0g6aa0g06a9ge0fag26faab98fa0c" version="1">Pic de magie sauvage : Sort renforcé</content>
+  <content contentuid="h81455b0dge9d7gec74g4a50gc7fa88afc73e" version="1">Jusqu'à la fin de votre prochain tour, lancez deux fois chaque dé de dégâts pour les sorts qui infligent des dégâts, et utilisez le meilleur résultat pour chaque dé.</content>
+  <content contentuid="h7106d36agc729ga538g1905gc78f61424ecc" version="1">Pic de magie sauvage : Résistance</content>
+  <content contentuid="h98b4d72eg56f8g0a3dg5560g0b2c9cc14f5c" version="1">Vous avez la Résistance à tous les dégâts pendant la prochaine minute.</content>
+  <content contentuid="hbc163433g954fgc50cg70b0g7d2a79b50f85" version="1">Pic de magie sauvage : Bouclier</content>
+  <content contentuid="h6a41193fg5cabg4e1ege044g043eb23962dc" version="1">Un bouclier spectral flotte près de vous pendant la prochaine minute, vous conférant un bonus de +2 à la CA et l'immunité contre Projectile magique.</content>
+  <content contentuid="h847f06c4g2fddg015ag538cgf97b698de8f6" version="1">Pic de magie sauvage : Bouclier</content>
+  <content contentuid="hb2bb0f2eg9d2ag5515gead7g44579222fb75" version="1">Un bouclier spectral flotte près de vous pendant la prochaine minute, vous conférant un bonus de +2 à la CA et l'immunité contre Projectile magique.</content>
+  <content contentuid="h33261258g796fg3395g69a4gaddfad4937eb" version="1">Pendant la prochaine minute, vous pouvez lancer des sorts même lorsque vous avez la condition Réduit au silence.</content>
+  <content contentuid="hb2a8f231g4f09g0714g0977ga484944bbb45" version="1">Pic de magie sauvage : Sort accéléré</content>
+  <content contentuid="hf35665d0g7373g4d2dga1f3g0b7fc11ce883" version="1">Doué : Vous avez gagné la maîtrise de trois compétences. Bien choisi.</content>
+  <content contentuid="h5205e9a5g2faag4116g9482g9d62b12da058" version="1">Doué : Vous avez gagné la maîtrise de la compétence sélectionnée.</content>
+  <content contentuid="hffac3ddcg8327g4829g8b8fgec3bb18e4a7e" version="1">Initiation à la magie (Clerc) : Vous avez appris deux sorts mineurs. Bien choisi.</content>
+  <content contentuid="h64af36efg690cg437bg9309gc6f9d243ddc7" version="1">Initiation à la magie (Clerc) : Vous avez appris le sort mineur sélectionné.</content>
+  <content contentuid="hd4f0c01cgfa4cg494eg93dagc7401dc42e35" version="1">Initiation à la magie (Clerc) : Vous avez appris le sort sélectionné.</content>
+  <content contentuid="h42e9d28cgdac3g453ag98b9ge050ea1a6f39" version="1">Initiation à la magie (Druide) : Vous avez appris deux sorts mineurs. Bien choisi.</content>
+  <content contentuid="hc9f0aba8gd775g4df7gb799gd7c53747085b" version="1">Initiation à la magie (Druide) : Vous avez appris le sort mineur sélectionné.</content>
+  <content contentuid="h758b92a3gedfcg4ab3g8e8fg85ad854a1ce6" version="1">Initiation à la magie (Druide) : Vous avez appris le sort sélectionné.</content>
+  <content contentuid="hb26b5f09gacacg4ffdgb947g44c15c47929d" version="1">Initiation à la magie (Magicien) : Vous avez appris deux sorts mineurs. Bien choisi.</content>
+  <content contentuid="h60a4f1cegab44g4361g8e56ge21f825230e2" version="1">Initiation à la magie (Magicien) : Vous avez appris le sort mineur sélectionné.</content>
+  <content contentuid="h2e45d3c2gc1beg4101g9a04gcbaaaac11f0a" version="1">Initiation à la magie (Magicien) : Vous avez appris le sort sélectionné.</content>
+  <content contentuid="h70967e04gffcag4f16g93fag7c196b9e4823" version="1">Classes utilisables : Barde, Clerc, Magicien</content>
+  <content contentuid="h19eaac92g8ce9g40bcg900cga4ef08faeb00" version="1">Classes utilisables : Barde, Clerc, Magicien</content>
+  <content contentuid="hc63b5579g7f2ag4baagb760g89742ef59f21" version="1">Classes utilisables : Clerc, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="he2d9401fgf9bag4933g9d4fg8fb89bc284e2" version="1">Classes utilisables : Clerc, Occultiste, Magicien</content>
+  <content contentuid="h10f01d4bg7676g4859ga595g2712bce824c1" version="1">Classes utilisables : Clerc, Paladin, Occultiste, Magicien</content>
+  <content contentuid="h73c88544g3627g41a6gbe73g7f725f7093ce" version="1">Classes utilisables : Magicien</content>
+  <content contentuid="h9036825bg9a32g4e70g8c69gf202e0ae6384" version="1">Classes utilisables : Paladin</content>
+  <content contentuid="h5f032521g0f3bg457agaca7g37bad35cd378" version="1">Classes utilisables : Clerc, Druide, Paladin, Occultiste, Magicien</content>
+  <content contentuid="h0c4ae731g86b7g4cddg9448g2ec70d8c41e3" version="1">Classes utilisables : Magicien, Artificier</content>
+  <content contentuid="h3caacbafgd256g4d2bga846g1e0e85d5bfd9" version="1">Classes utilisables : Ensorceleur, Magicien</content>
+  <content contentuid="ha43d0c84g7029g4bb4g91b9g40464ff2451d" version="1">Classes utilisables : Druide, Ensorceleur, Magicien</content>
+  <content contentuid="h0f476bcdg9eefg4e31ga725g8d2b8048b540" version="1">Classes utilisables : Magicien, Artificier</content>
+  <content contentuid="he3ed5607gfd3bg4037g8cedg98e1474da744" version="1">Classes utilisables : Druide, Rôdeur, Ensorceleur, Magicien, Artificier</content>
+  <content contentuid="h850611abg9fa9g4ef3ga920g342e381d85db" version="1">Classes utilisables : Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h157bc8b6g7bd3g42b6gb126g8844ae4e6897" version="1">Classes utilisables : Magicien</content>
+  <content contentuid="hf517cb38gb91fg4b74g9651g9d26b04c4a4f" version="1">Classes utilisables : Ensorceleur, Magicien</content>
+  <content contentuid="hb93accaeg9237g4486g9fefg295f1501c7b3" version="1">Classes utilisables : Ensorceleur, Magicien</content>
+  <content contentuid="h07c5d370g49d6g4466ga8deg9b86e982e5dd" version="1">Classes utilisables : Barde, Druide, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h5545fdeegaf71g4a87gb389g8b033c437233" version="1">Classes utilisables : Barde, Ensorceleur, Magicien</content>
+  <content contentuid="h09f480c3g2968g4108g955cg52ea764a99e8" version="1">Classes utilisables : Ensorceleur, Magicien</content>
+  <content contentuid="ha6524e13ga393g46c6g81ccg8c0505a61fa6" version="1">Classes utilisables : Barde, Ensorceleur, Magicien, Artificier</content>
+  <content contentuid="hfdc5321bg8e80g4295gab40g23fc855ca270" version="1">Classes utilisables : Barde, Ensorceleur, Magicien</content>
+  <content contentuid="h989195e0gd334g4d2fga48cg60ac72b1b1d9" version="1">Classes utilisables : Ensorceleur, Magicien</content>
+  <content contentuid="h5198c509gbadfg4c26g8450g1fc86eb31633" version="1">Classes utilisables : Barde, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="hdf1a248bg7985g430egb25eg7767ee36487c" version="1">Classes utilisables : Barde, Druide, Rôdeur</content>
+  <content contentuid="h976e404eg3fdeg4338gaf2cgf6ba2a469a74" version="1">Classes utilisables : Clerc, Paladin</content>
+  <content contentuid="h053b6bdfg7d35g445egbe72ge4ed43fd3166" version="1">Classes utilisables : Barde, Ensorceleur, Magicien</content>
+  <content contentuid="hc6d3f124g2e9cg4554ga6eeg01dcc0ebadba" version="1">Classes utilisables : Ensorceleur, Magicien</content>
+  <content contentuid="hfa9345e1gc6c2g46a2gb695g7a77a059e302" version="1">Classes utilisables : Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="he9329f83ga933g46dfgabd0g37d583feacd1" version="1">Classes utilisables : Clerc, Paladin</content>
+  <content contentuid="h61e1a792g9f16g4e16ga50dg0ee6c9c7ccb1" version="1">Classes utilisables : Barde, Clerc, Druide, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h552f275cgee76g4947ga777g927bce86aa21" version="1">Classes utilisables : Druide, Rôdeur, Ensorceleur, Magicien</content>
+  <content contentuid="h54e64aa9g3189g44e2gbf65g0425fd20f75f" version="1">Classes utilisables : Barde, Ensorceleur, Occultiste, Magicien, Artificier</content>
+  <content contentuid="hc98b225eg8da0g4e31g8bc5g876e89935b90" version="1">Classes utilisables : Barde, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="hf769e1e7g4972g4edbg966dgd4372642ed9d" version="1">Classes utilisables : Druide, Rôdeur</content>
+  <content contentuid="h701629dfgc58dg4887g8faeg08469d671d32" version="1">Classes utilisables : Barde, Druide, Ensorceleur, Magicien, Artificier</content>
+  <content contentuid="haedcf633gdecdg416aga1c4gacc76d9402eb" version="1">Classes utilisables : Ensorceleur, Magicien, Artificier</content>
+  <content contentuid="h6b900209g8da2g4792gaf6dge1c9ef17c58a" version="1">Classes utilisables : Barde, Druide, Rôdeur, Magicien, Artificier</content>
+  <content contentuid="h57f41308g4badg4fe3gaac6gcc36d4dc3d8b" version="1">Classes utilisables : Ensorceleur, Magicien</content>
+  <content contentuid="h65bcba2fg62dfg4712gaae5g9ffa44f4a2b8" version="1">Classes utilisables : Barde, Ensorceleur, Magicien, Artificier</content>
+  <content contentuid="hd0f8bef5g3744g473bgb6f7g416cd1b21776" version="1">Classes utilisables : Barde, Occultiste, Magicien</content>
+  <content contentuid="h9f107cbeg704cg4efdg80f3gae22cf746ff8" version="1">Classes utilisables : Ensorceleur, Magicien</content>
+  <content contentuid="h4e563d34g5893g4564g93d3gbe30f8798c6d" version="1">Classes utilisables : Barde, Druide, Ensorceleur, Magicien</content>
+  <content contentuid="h45afcc46g07e8g413ega467g1230c256bb27" version="1">Classes utilisables : Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="hd6dbd33fg0848g46bdg93d0ga604e88b0045" version="1">Classes utilisables : Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h29717b0bgc570g4958gae52g7e29bf101fb7" version="1">Classes utilisables : Magicien</content>
+  <content contentuid="h57a34188gbe1dg4aecg9436g26c503c38ca5" version="1">Classes utilisables : Ensorceleur, Magicien, Artificier</content>
+  <content contentuid="ha55948cag17d3g4aa3gae23ga952030cb26c" version="1">Classes utilisables : Magicien</content>
+  <content contentuid="ha069636bg3b39g4b50gae6fg37e461b68a60" version="1">Classes utilisables : Barde, Ensorceleur, Magicien, Artificier</content>
+  <content contentuid="hc7c2f070g087bg4664ga8d0gf731f76c0a06" version="1">Classes utilisables : Ensorceleur, Magicien</content>
+  <content contentuid="hda5eeb36gf99bg4cc8gb43egb740c1c24b98" version="1">Classes utilisables : Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="hea2bda2fgbe08g4ab1g8a22g7f50ccea400e" version="1">Classes utilisables : Barde, Ensorceleur, Magicien</content>
+  <content contentuid="h0936d3bbg9d40g4b82g991bg63f298cdd927" version="1">Classes utilisables : Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h25ea32bcgf38dg464dg8a09g608fa6283272" version="1">Classes utilisables : Paladin, Rôdeur, Ensorceleur, Magicien, Artificier</content>
+  <content contentuid="h99cdb013gd519g46c8g8ee7g88ce569e971b" version="1">Classes utilisables : Occultiste, Magicien</content>
+  <content contentuid="he7c90888g22e0g4d75g85f4g768f561d6f30" version="1">Classes utilisables : Ensorceleur, Magicien</content>
+  <content contentuid="had587edfg3e1eg46a6g88e9gba4983e47b20" version="1">Classes utilisables : Ensorceleur, Magicien</content>
+  <content contentuid="hbbbaa8ebg9199g46ffgbeafg104d39c86b43" version="1">Classes utilisables : Druide, Rôdeur</content>
+  <content contentuid="h2223a50agc511g4d44gb143g94f0113311a5" version="1">Classes utilisables : Magicien</content>
+  <content contentuid="h0991a1dfgb4b0g45eagbbb3ga5ae65a31f0e" version="1">Classes utilisables : Druide, Rôdeur, Ensorceleur, Magicien, Artificier</content>
+  <content contentuid="hca88c584g8a5bg4e69g9eb7g5af56d234776" version="1">Classes utilisables : Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h37934098g756eg4431gaed9g88557c60ee6e" version="1">Classes utilisables : Ensorceleur, Magicien</content>
+  <content contentuid="h482dd2dbg9946g4f59g93baga4c4928fd097" version="1">Classes utilisables : Barde, Clerc, Paladin, Magicien</content>
+  <content contentuid="h2c2386e2g0722g480egaa8ag57417fd707f9" version="1">Classes utilisables : Ensorceleur, Occultiste, Magicien, Artificier</content>
+  <content contentuid="h6d713dd0gf384g4e20g81f0g0a61b2b73a86" version="1">Classes utilisables : Druide, Ensorceleur, Magicien</content>
+  <content contentuid="h102dd2b4gf963g41a5g8094g52a0af052bf9" version="1">Classes utilisables : Magicien</content>
+  <content contentuid="hed54d08eg254egab54g634egc5696f632258" version="1">Châtiment occulte (À distance)</content>
+  <content contentuid="h11a41e9fgad2fg3cbfg28b3gcc04b63b160f" version="1">Châtiment occulte (À distance)</content>
+  <content contentuid="h3dadabd2gf927g0c0eg86c7gef99a7a4e7ad" version="1">Châtiment occulte (À distance)</content>
+  <content contentuid="h8f7262a7gbdd0g1911g5132g67fcc1eacb9e" version="1">Châtiment occulte sur Coup critique (À distance)</content>
+  <content contentuid="h300d9c12g274eg82c1g8ba1g1bcef5722390" version="1">Châtiment occulte sur Coup critique (À distance)</content>
+  <content contentuid="h6a2383deg87c5g61b6g137cgf2184d150d39" version="1">Châtiment occulte sur Coup critique (À distance)</content>
+  <content contentuid="ha351e5dfg5a09g2d6agfd39geb9d1770a8f5" version="1">Châtiment occulte (À distance)</content>
+  <content contentuid="hcd8ed7acga54dg31f4gb831g3687c2792f10" version="1">Une fois par tour, lorsque vous touchez une créature avec votre arme de pacte, vous pouvez dépenser un emplacement de sort de Magie du pacte pour infliger 1d8 dégâts de Force supplémentaires à la cible, plus 1d8 supplémentaire par niveau de l'emplacement de sort, et vous pouvez imposer la condition À terre à la cible si elle est de taille Énorme ou inférieure.</content>
+  <content contentuid="h7282e855ge2c0g4f40gc42bgdec458d13ad3" version="1">Châtiment balistique</content>
+  <content contentuid="h13aa2cdag2fb5g8660ga803g42449d529329" version="1">Choisissez des dégâts d'Acide, de Froid, de Feu, de Foudre, de Poison ou de Tonnerre. La cible touchée par l'attaque subit des dégâts supplémentaires du type choisi.</content>
+  <content contentuid="h55e5be08g5ff7g2cf9g5dabg5964e7cfef5a" version="1">Châtiment balistique : Acide</content>
+  <content contentuid="h40f147a8g98d2gb22dg8665g35bdab166d32" version="1">Châtiment balistique : Froid</content>
+  <content contentuid="hbdc42068gbee7gfa65g006egbbd103dbaeae" version="1">Châtiment balistique : Feu</content>
+  <content contentuid="h96c1b9f4g4877g6b3eg89e6gff5592637883" version="1">Châtiment balistique : Foudre</content>
+  <content contentuid="hafc90845gfef4gbcabg21e1g4b507cd3aea3" version="1">Châtiment balistique : Poison</content>
+  <content contentuid="h56c89b94g9c5cg3e99g2ac5gc5f4723f0a66" version="2">Châtiment balistique : Tonnerre</content>
+  <content contentuid="h6bd9db98g1e8fg33a3g0a09gadb7f2151497" version="1">Entaille</content>
+  <content contentuid="h939f5eb1gd3c5g103bg2cdage99686250a71" version="1">Vous pouvez effectuer votre Attaque en main secondaire dans le cadre de votre action Attaquer ce tour-ci sans dépenser d'Action bonus.</content>
+  <content contentuid="h5e1086d5gb686g5218gd9b8g8728d0edb265" version="1">Entaille : Attaque en main secondaire utilisée</content>
+  <content contentuid="h112fb3e9g734ag7e2dg4366g1a44c9038a26" version="1">Vous avez déjà effectué votre Attaque en main secondaire gratuite d'Entaille ce tour-ci et ne pouvez pas en effectuer une autre.</content>
+  <content contentuid="h004828cbg6ae4g9d9fgef10g00102cb4f553" version="1">Combattant à deux armes : Attaque en main secondaire</content>
+  <content contentuid="h3a446706g6505g19b1g3826gb313d8b63d3f" version="1">Vous pouvez effectuer une Attaque en main secondaire supplémentaire par une Action bonus ce tour-ci.</content>
+  <content contentuid="hf7c771bbgba46g05a3g6c15g9c7c4ebba6b6" version="1">Absorption des éléments</content>
+  <content contentuid="h2127d371g53e2g616ag957cg184d49e115ef" version="1">Le sort capture une partie de l'énergie entrante, atténuant son effet sur vous et l'emmagasinant pour votre prochaine attaque de corps à corps. Vous avez la Résistance au type de dégâts déclencheur jusqu'au début de votre prochain tour. De plus, la première fois que vous touchez avec une attaque de corps à corps lors de votre prochain tour, la cible subit [1] dégâts supplémentaires du type déclencheur, et le sort prend fin.</content>
+  <content contentuid="hccbdbb9eg99b6gf54fgce8dg5a4b024a38a8" version="1">Absorption des éléments</content>
+  <content contentuid="h23f50accgc0b8gb376gbc26g1fff227eb3f5" version="1">Le sort capture une partie de l'énergie entrante, atténuant son effet sur vous et l'emmagasinant pour votre prochaine attaque de corps à corps. Vous avez la Résistance au type de dégâts déclencheur jusqu'au début de votre prochain tour. De plus, la première fois que vous touchez avec une attaque de corps à corps lors de votre prochain tour, la cible subit [1] dégâts supplémentaires du type déclencheur, et le sort prend fin.</content>
+  <content contentuid="h0d100dc2gb2a7ge09fg624dga1554d1a009c" version="1">Absorption des éléments</content>
+  <content contentuid="hab392145gc890gaa18g04cag5b0b653d9632" version="1">Le sort capture une partie de l'énergie entrante, atténuant son effet sur vous et l'emmagasinant pour votre prochaine attaque de corps à corps. Vous avez la Résistance au type de dégâts déclencheur jusqu'au début de votre prochain tour. De plus, la première fois que vous touchez avec une attaque de corps à corps lors de votre prochain tour, la cible subit [1] dégâts supplémentaires du type déclencheur, et le sort prend fin.</content>
+  <content contentuid="h93909048gc250g4ba0g8188g2450b9be939f" version="1">Initiation à la magie : Absorption des éléments</content>
+  <content contentuid="hc53cf966gb23fg281eg72e3g7fee38b6dede" version="1">Marée de ténèbres</content>
+  <content contentuid="h029cddf2gf1b9g86a2g45e7g18bf046b40f1" version="3">Vous déchaînez une vague d'ombres tourbillonnantes qui emplit une zone adjacente à vous. Chaque créature dans un Cube de Ténèbres de 3 mètres prenant sa source en vous lorsque vous lancez le sort effectue un jet de sauvegarde de Sagesse. En cas d'échec, une créature subit 2d8 dégâts Psychiques et est Aveuglée jusqu'au début de votre prochain tour. En cas de réussite, elle subit la moitié de ces dégâts et n'est pas Aveuglée.</content>
+  <content contentuid="hde134590g10deg4df4g9d4age5320c74f0fb" version="1">Initiation à la magie : Marée de ténèbres</content>
+  <content contentuid="h74c27673g4c1bga1beg5a49ga7aec2022773" version="1">Vrille d'ombre</content>
+  <content contentuid="h347e6fe4g42a8g22ecgdb29gefc97f004483" version="1">Vous créez une longue vrille d'ombre voleuse de vie qui fouette une créature que vous pouvez voir à portée.
+
+Effectuez une attaque de sort à distance contre la cible. En cas de touche, la cible subit des dégâts Nécrotiques. Relancez les dés de dégâts du sort et gagnez des Points de vie temporaires égaux au résultat.
+</content>
+  <content contentuid="ha3d984fag9166g3a51gbc9fg45fc0d47e563" version="1">Vrille d'ombre</content>
+  <content contentuid="h243a5f49gc364g1981gbc7fge75041c302f9" version="1">Gagnez des points de vie temporaires.</content>
+  <content contentuid="h6c91c1d0geff6g49ddg9fd0gd5d83740ee64" version="1">Initiation à la magie : Vrille d'ombre</content>
+  <content contentuid="h28992689gab7eg0bcega955gb5ee06d7deaf" version="1">Vous pouvez dépenser des Dés de points de vie pendant un Repos court pour récupérer des Points de vie.</content>
+  <content contentuid="hbd79e588g85a8ga317gab92g1dc3ec782773" version="1">Arme liée : Principale</content>
+  <content contentuid="h6193eaa0gbef3g3810gc2ffg05099e13d0ea" version="1">Arme liée : Secondaire</content>
+  <content contentuid="h886aaa36gd8ecg34edg11dbga02b0ae1f0f9" version="1">Arme liée : Principale</content>
+  <content contentuid="h70efd6b7g4433g80c7g7ceeg246f811e2c7c" version="1">Arme liée : Secondaire</content>
+  <content contentuid="h68c0c939g9c12g8d64g237dg0bcc02c524be" version="1">Frappes élémentaires : Acide</content>
+  <content contentuid="h1e811cadgb62eg0b4cgf227g305228f83fc7" version="1">Chaque fois que vous touchez avec votre Frappe à mains nues, vous pouvez lui faire infliger des dégâts d'Acide, de Froid, de Feu, de Foudre ou de Tonnerre selon votre choix plutôt que son type de dégâts normal.</content>
+  <content contentuid="hb2926a7dga9a0g4670g41dfgdf5650a0d520" version="1">Frappes élémentaires : Froid</content>
+  <content contentuid="hf7a5b3f5g2f88g5a34g7903g2114ecd26adf" version="1">Frappes élémentaires : Feu</content>
+  <content contentuid="h1cc7d9bbge33egb7e6gcb43g3b381b51b4ab" version="1">Frappes élémentaires : Foudre</content>
+  <content contentuid="h4028f5b6g1c7cg62bfgf7ceg0d2244ad20f2" version="1">Frappes élémentaires : Tonnerre</content>
+  <content contentuid="h890a9938gac70g797cg8e84g4f982f91e71f" version="1">Syntonisation élémentaire : Allonge</content>
+  <content contentuid="h11332473g3979g9abfg761agdee2787744e5" version="1">Lorsque vous effectuez une Frappe à mains nues, votre allonge est supérieure de 3 mètres à la normale, car une énergie élémentaire se projette depuis vous.</content>
+  <content contentuid="h1d8b58e5g0088g74d2g88a9g3d9a8a0831f8" version="8">Fouet</content>
+  <content contentuid="h218a19d0g0293g93efgc43egdb8e4642579a" version="1">Fouet +1</content>
+  <content contentuid="hf82478b0g8d8fgb88eg2f66gc23634841932" version="1">Fouet +2</content>
+  <content contentuid="heffa3bccgf354g0581ga23dg44eac5095fa6" version="1">Aura de Bouclier cacophonique</content>
+  <content contentuid="ha911b6bdg2959g695ag9c06gb0936ebd052e" version="2">Des réverbérations tonitruantes emplissent une Émanation de 3 mètres prenant sa source en vous pendant la durée. Chaque fois que l'Émanation entre dans l'espace d'une créature et chaque fois qu'une créature entre dans l'Émanation ou y termine son tour, la créature effectue un jet de sauvegarde de Constitution. En cas d'échec, la créature subit des dégâts de Tonnerre. En cas de réussite, la créature subit seulement la moitié des dégâts. Une créature n'effectue ce jet de sauvegarde qu'une fois par tour.
+
+De plus, vous avez la Résistance aux dégâts de Tonnerre, et les jets d'attaque à distance contre vous sont effectués avec le Désavantage.</content>
+  <content contentuid="h2a8fc538g7a44g3571g385dg12e8a9a60425" version="1">Bouclier cacophonique</content>
+  <content contentuid="h656c049cg0ff4g758bge643g1386718cedb8" version="1">Des réverbérations tonitruantes emplissent une Émanation de 3 mètres prenant sa source en vous pendant la durée. Chaque fois que l'Émanation entre dans l'espace d'une créature et chaque fois qu'une créature entre dans l'Émanation ou y termine son tour, la créature effectue un jet de sauvegarde de Constitution. En cas d'échec, la créature subit des dégâts de Tonnerre. En cas de réussite, la créature subit seulement la moitié des dégâts. Une créature n'effectue ce jet de sauvegarde qu'une fois par tour.
+
+De plus, vous avez la Résistance aux dégâts de Tonnerre, et les jets d'attaque à distance contre vous sont effectués avec le Désavantage.</content>
+  <content contentuid="h189c7c23gc92fg05ccg593egcb14bf67243c" version="1">Bouclier cacophonique</content>
+  <content contentuid="hf67f7f88ga42fgb7c6g3526gd17410ea4287" version="1">Des réverbérations tonitruantes emplissent une Émanation de 3 mètres prenant sa source en vous pendant la durée. Chaque fois que l'Émanation entre dans l'espace d'une créature et chaque fois qu'une créature entre dans l'Émanation ou y termine son tour, la créature effectue un jet de sauvegarde de Constitution. En cas d'échec, la créature subit des dégâts de Tonnerre. En cas de réussite, la créature subit seulement la moitié des dégâts. Une créature n'effectue ce jet de sauvegarde qu'une fois par tour.
+
+De plus, vous avez la Résistance aux dégâts de Tonnerre, et les jets d'attaque à distance contre vous sont effectués avec le Désavantage.</content>
+  <content contentuid="h96a4fdcdg6eedg4ccdgb453g193837a217e9" version="1">Foulée d'Ashardalon</content>
+  <content contentuid="h9b831d16g0360g4588g8217g0115979d8198" version="1">Les flammes tourbillonnantes d'un dragon jaillissent de vos pieds, vous conférant une vitesse explosive. Pendant la durée, votre Vitesse augmente de 6 mètres, et vos déplacements ne provoquent pas d'Attaques d'opportunité. Chaque fois que vous vous déplacez à 1,50 mètre ou moins d'une créature, elle subit des dégâts de Feu de votre traînée de chaleur. Une créature ne peut subir ces dégâts qu'une fois par tour.
+
+À des niveaux supérieurs : votre Vitesse augmente de 1,50 mètre supplémentaire, et les dégâts de Feu augmentent de 1d6, pour chaque niveau d'emplacement de sort au-delà du 3e.</content>
+  <content contentuid="h07bf103cg6fe9g48deg90e6g51cda963e2bb" version="1">Aura de Foulée d'Ashardalon</content>
+  <content contentuid="h015e6052gbb2eg4bc4g8148gac1a0bbffbf1" version="2">Les flammes tourbillonnantes d'un dragon jaillissent de vos pieds, vous conférant une vitesse explosive. Pendant la durée, votre Vitesse augmente de [1], et vos déplacements ne provoquent pas d'Attaques d'opportunité. Chaque fois que vous vous déplacez à [2] ou moins d'une créature, elle subit des dégâts de Feu de votre traînée de chaleur. Une créature ne peut subir ces dégâts qu'une fois par tour.</content>
+  <content contentuid="hefff3653g8439g5d57g7610g02ccec1105b6" version="1">Foulée d'Ashardalon</content>
+  <content contentuid="hc093f34eg734bg4909g8ea8g91e0aff0472a" version="2">Les flammes tourbillonnantes d'un dragon jaillissent de vos pieds, vous conférant une vitesse explosive. Pendant la durée, votre Vitesse augmente de [1], et vos déplacements ne provoquent pas d'Attaques d'opportunité. Chaque fois que vous vous déplacez à [2] ou moins d'une créature, elle subit des dégâts de Feu de votre traînée de chaleur. Une créature ne peut subir ces dégâts qu'une fois par tour.</content>
+  <content contentuid="he87b5a9cg9c3ag1b7fg2fefg3f7ae0ff3ef9" version="1">Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 4 ou supérieur, votre vitesse augmente de [1] pour chaque niveau d'emplacement de sort au-delà du 3e. Le sort inflige [2] supplémentaires pour chaque niveau d'emplacement au-delà du 3e.</content>
+  <content contentuid="hc28f4dcdgd614gc5b0g7be9g946be11c3809" version="1">Foulée d'Ashardalon</content>
+  <content contentuid="h87a45194g95b7g00ceg2f9eg6c288ed38884" version="1">Vigueur arcanique : D6</content>
+  <content contentuid="hebba7f87g6370g87ceg8319g29430a465253" version="1">Vigueur arcanique : D8</content>
+  <content contentuid="h61c3e42cg02b0g7f38gda65gdc3642939a49" version="1">Vigueur arcanique : D10</content>
+  <content contentuid="h2c125804g85eegc3ecgdd44g25edc8c0bb5c" version="1">Vigueur arcanique : D12</content>
+  <content contentuid="h2826d606g7d49g321cg9686gfc615a4ba31d" version="1">Le nombre de Dés de points de vie non dépensés que vous pouvez lancer augmente de un pour chaque niveau d'emplacement de sort au-delà du niveau 2.</content>
+  <content contentuid="h68cc0961gb6ceg3e67g1ae5g31162e46016b" version="1">Distorsion corporelle de Gorgoroth</content>
+  <content contentuid="h2ee464d4g6606g2b85g7008gfc6f4aaa15b0" version="1">Choisissez un Humanoïde de votre taille que vous pouvez voir à portée. Vous vous transformez physiquement pour devenir un double exact de cette créature pendant la durée. Même un examen physique approfondi ne révèle aucune différence entre vous et la cible.</content>
+  <content contentuid="h35b9b915g3bf7g0d1dg728fg2be8d9ced715" version="1">Distorsion corporelle de Gorgoroth</content>
+  <content contentuid="hfb5ff22bgbb91g4598ga3acg629a9bc0bbf5" version="1">Initiation à la magie : Distorsion corporelle de Gorgoroth</content>
+  <content contentuid="hff8c3953ga42fgb3bfgdad0g52582466fdd5" version="1">Catapulte</content>
+  <content contentuid="h33322b0egd4a5g9e80gdabdg3abd5d4b2ddc" version="1">Choisissez un objet pesant de 1 à 5 livres à portée qui n'est ni porté ni transporté. L'objet vole en ligne droite jusqu'à 18 mètres dans la direction de votre choix avant de tomber au sol, s'arrêtant prématurément s'il percute une surface solide. Si l'objet devait frapper une créature, cette créature doit effectuer un jet de sauvegarde de Dextérité. En cas d'échec, l'objet frappe la cible et cesse de se déplacer. Lorsque l'objet frappe quelque chose, l'objet et ce qu'il frappe subissent chacun des dégâts Contondants.</content>
+  <content contentuid="h531eb181g2185g4a8eg9a93g7866406491b2" version="1">Initiation à la magie : Catapulte</content>
+  <content contentuid="hcee9d863gb64eg2f43gf305g608bc4aa5061" version="1">Lame affamée</content>
+  <content contentuid="h0f617ea9g5fc5gff42gae8ag41a6861d59c0" version="1">Vous imprégnez une arme que vous tenez, ou vos Attaques à mains nues, d'une énergie négative vorace. Pendant la durée, lorsque vous touchez une créature avec une attaque utilisant l'arme ou l'Attaque à mains nues ainsi renforcée pour la première fois lors d'un tour, la cible subit des dégâts Nécrotiques égaux à votre modificateur de caractéristique d'incantation, et vous gagnez un nombre de Points de vie temporaires égal aux dégâts Nécrotiques infligés.</content>
+  <content contentuid="h700ed84bg957fg2a5dg1d50g4d69487d7001" version="1">Lame affamée</content>
+  <content contentuid="h353f6fe0g981eg9ab6gd5b9g0148d8001530" version="1">Vous imprégnez une arme que vous tenez, ou vos Attaques à mains nues, d'une énergie négative vorace. Pendant la durée, lorsque vous touchez une créature avec une attaque utilisant l'arme ou l'Attaque à mains nues ainsi renforcée pour la première fois lors d'un tour, la cible subit des dégâts Nécrotiques égaux à votre modificateur de caractéristique d'incantation, et vous gagnez un nombre de Points de vie temporaires égal aux dégâts Nécrotiques infligés.</content>
+  <content contentuid="hb6e6fab4gd077g545dge824g9e58b1ec530c" version="1">Lame affamée : Points de vie temporaires</content>
+  <content contentuid="h0903fdd3gbfadg55a1gd56cga67f82c909ac" version="1">A gagné [1] &lt;LSTag Tooltip="TemporaryHitPoints"&gt;points de vie temporaires&lt;/LSTag&gt;.</content>
+  <content contentuid="h4a76861cg2a42g5900gbd08gc593fbb9811e" version="1">Armure d'épines</content>
+  <content contentuid="h5f480b91gf52bg2751g6254gdd8113ff8e2e" version="1">Lorsque vous lancez ce sort, un exosquelette flexible couvert d'épines apparaît autour d'une cible consentante à portée. La cible gagne [1] Points de vie temporaires. Si une créature touche la cible avec un jet d'attaque de corps à corps avant la fin du sort, cette créature subit des dégâts Perforants égaux au nombre de Points de vie temporaires perdus à la suite de l'attaque. Ce sort prend fin prématurément si la cible n'a plus de Points de vie temporaires accordés par ce sort.</content>
+  <content contentuid="he725b302g9ad6g038fg90e3g3b6453195180" version="1">La cible gagne 2d6 Points de vie temporaires supplémentaires pour chaque niveau d'emplacement de sort au-delà du niveau 1.</content>
+  <content contentuid="h73991020g32ffg9f15g55bcgd13afd4a160b" version="1">Armure d'épines</content>
+  <content contentuid="hf4db5d55g3f59g3137gd662g4504298dce7d" version="1">Gagne [1] Points de vie temporaires. Si une créature touche la cible avec un jet d'attaque de corps à corps avant la fin du sort, cette créature subit des dégâts Perforants égaux au nombre de Points de vie temporaires perdus à la suite de l'attaque. Ce sort prend fin prématurément si la cible n'a plus de Points de vie temporaires accordés par ce sort.</content>
+  <content contentuid="h56d01007g7639g76b3g6944ge9e37780bfa3" version="1">Armure d'épines</content>
+  <content contentuid="h5aaf459egc2f8g443cgbd6cgea65032712ea" version="1">Initiation à la magie : Armure d'épines</content>
+  <content contentuid="h090fc065geb1dge3e6g22b1g1d5d2fa91c92" version="1">Lance d'argent de Laeral</content>
+  <content contentuid="h55dbf30agbd12g301dga596g935c9cd3ab5e" version="1">Une énergie argentée jaillit de vous en une Ligne de 36 mètres de long et 1,50 mètre de large. Chaque créature de votre choix dans la Ligne effectue un jet de sauvegarde de Force. En cas d'échec, une créature subit des dégâts de Force et a la condition À terre. En cas de réussite, une créature subit seulement la moitié des dégâts.</content>
+  <content contentuid="he19de47agde53g5b49gd45ag019467942cb7" version="1">Souffle du dragon</content>
+  <content contentuid="h0dcdc1c9g2349g6dc5g0490g2bd7268e6913" version="1">Vous touchez une créature consentante et choisissez Acide, Froid, Feu, Foudre ou Poison. Jusqu'à la fin du sort, la cible peut prendre une action Magique pour exhaler un Cône de 4,50 mètres. Chaque créature dans cette zone effectue un jet de sauvegarde de Dextérité, subissant des dégâts du type choisi en cas d'échec, ou la moitié de ces dégâts en cas de réussite.</content>
+  <content contentuid="h8b5c0d31g91fdg86d0g19aag926c55ff9469" version="1">Souffle du dragon</content>
+  <content contentuid="hb10c2d2ag537bg8220ge773g2f2eca39fdaa" version="1">Souffle du dragon</content>
+  <content contentuid="h5739f1d4gcac7g91f1g8878gc76bc894c921" version="1">Souffle du dragon</content>
+  <content contentuid="h44faa33fgf2e3gd86dg32ffgfdafe83f556a" version="1">Souffle du dragon</content>
+  <content contentuid="h3d58952cg99d7gd4e9g6ba3gf7ba2d2ccd6e" version="1">Souffle du dragon</content>
+  <content contentuid="hab751f1dg6ccdg30c4g0159g862e61032821" version="1">Souffle du dragon</content>
+  <content contentuid="ha1e2ad32g3698gf83fg3528g8d45c9c1bd0e" version="1">Exhalaison élémentaire</content>
+  <content contentuid="h85c7508bg337bg1507gd4ebg434eb4cc892b" version="1">Air. Le type de dégâts est Tonnerre. Chaque créature qui rate le jet de sauvegarde est repoussée de 3 mètres loin de vous.
+
+Feu froid. Le type de dégâts est Froid. Chaque créature qui rate le jet de sauvegarde a la condition Effrayé jusqu'au début de votre prochain tour.
+
+Terre. Le type de dégâts est Contondant. Chaque créature qui rate le jet de sauvegarde voit sa Vitesse réduite à 0 jusqu'à la fin de son prochain tour.
+
+Feu. Le type de dégâts est Feu. Chaque créature qui rate le jet de sauvegarde est engloutie par les flammes et subit des dégâts de Feu à la fin de son prochain tour. Par une action, elle peut éteindre le feu sur elle-même en se donnant la condition À terre et en se roulant au sol. Le feu s'éteint également s'il est arrosé, submergé ou étouffé.
+
+Eau. Le type de dégâts est Acide. Chaque créature qui rate le jet de sauvegarde a la condition À terre.
+
+Chaque créature dans un Cône d'énergie élémentaire destructrice de 9 mètres doit effectuer un jet de sauvegarde de Dextérité. En cas d'échec, une cible subit des dégâts du type choisi. En cas de réussite, la cible subit seulement la moitié des dégâts.</content>
+  <content contentuid="hdb0aa103g9344gc10cg7143gabd5c9c363de" version="1">Exhalaison élémentaire</content>
+  <content contentuid="h1042549ag1908gfbe0g5f54g6b7fb0d8ba00" version="2">Lorsque vous lancez ce sort, choisissez l'un des effets suivants, qui détermine le type de dégâts du sort :
+
+Air. Le type de dégâts est Tonnerre. Chaque créature qui rate le jet de sauvegarde est repoussée de 3 mètres loin de vous.
+
+Feu froid. Le type de dégâts est Froid. Chaque créature qui rate le jet de sauvegarde a la condition Effrayé jusqu'au début de votre prochain tour.
+
+Terre. Le type de dégâts est Contondant. Chaque créature qui rate le jet de sauvegarde voit sa Vitesse réduite à 0 jusqu'à la fin de son prochain tour.
+
+Feu. Le type de dégâts est Feu. Chaque créature qui rate le jet de sauvegarde est engloutie par les flammes et subit des dégâts de Feu à la fin de son prochain tour. Par une action, elle peut éteindre le feu sur elle-même en se donnant la condition À terre et en se roulant au sol. Le feu s'éteint également s'il est arrosé, submergé ou étouffé.
+
+Eau. Le type de dégâts est Acide. Chaque créature qui rate le jet de sauvegarde a la condition À terre.
+
+Chaque créature dans un Cône d'énergie élémentaire destructrice de 9 mètres doit effectuer un jet de sauvegarde de Dextérité. En cas d'échec, une cible subit des dégâts du type choisi. En cas de réussite, la cible subit seulement la moitié des dégâts.</content>
+  <content contentuid="hbdbf38edg682agb073g615cgd0646d705eb5" version="1">Air. Le type de dégâts est Tonnerre. Chaque créature qui rate le jet de sauvegarde est repoussée de 3 mètres loin de vous.
+
+Chaque créature dans un Cône d'énergie élémentaire destructrice de 9 mètres doit effectuer un jet de sauvegarde de Dextérité. En cas d'échec, une cible subit des dégâts du type choisi. En cas de réussite, la cible subit seulement la moitié des dégâts.</content>
+  <content contentuid="h7bd2461bgfa71g3829g28e1gaef49599b4e9" version="1">Feu froid. Le type de dégâts est Froid. Chaque créature qui rate le jet de sauvegarde a la condition Effrayé jusqu'au début de votre prochain tour.
+
+Terre. Le type de dégâts est Contondant. Chaque créature qui rate le jet de sauvegarde voit sa Vitesse réduite à 0 jusqu'à la fin de son prochain tour.
+
+Chaque créature dans un Cône d'énergie élémentaire destructrice de 9 mètres doit effectuer un jet de sauvegarde de Dextérité. En cas d'échec, une cible subit des dégâts du type choisi. En cas de réussite, la cible subit seulement la moitié des dégâts.</content>
+  <content contentuid="hc45e0fa7gb4cege9f5g982fg7301666e820d" version="1">Terre. Le type de dégâts est Contondant. Chaque créature qui rate le jet de sauvegarde voit sa Vitesse réduite à 0 jusqu'à la fin de son prochain tour.
+
+Chaque créature dans un Cône d'énergie élémentaire destructrice de 9 mètres doit effectuer un jet de sauvegarde de Dextérité. En cas d'échec, une cible subit des dégâts du type choisi. En cas de réussite, la cible subit seulement la moitié des dégâts.</content>
+  <content contentuid="h8d7f1f17ge505g0aa1gebcag3a7e09bf05d6" version="1">Feu. Le type de dégâts est Feu. Chaque créature qui rate le jet de sauvegarde est engloutie par les flammes et subit des dégâts de Feu à la fin de son prochain tour. Par une action, elle peut éteindre le feu sur elle-même en se donnant la condition À terre et en se roulant au sol. Le feu s'éteint également s'il est arrosé, submergé ou étouffé.
+
+Chaque créature dans un Cône d'énergie élémentaire destructrice de 9 mètres doit effectuer un jet de sauvegarde de Dextérité. En cas d'échec, une cible subit des dégâts du type choisi. En cas de réussite, la cible subit seulement la moitié des dégâts.</content>
+  <content contentuid="haebb0bd5g858bg5610gf623g1dcd18a2a0dd" version="1">Eau. Le type de dégâts est Acide. Chaque créature qui rate le jet de sauvegarde a la condition À terre.
+
+Chaque créature dans un Cône d'énergie élémentaire destructrice de 9 mètres doit effectuer un jet de sauvegarde de Dextérité. En cas d'échec, une cible subit des dégâts du type choisi. En cas de réussite, la cible subit seulement la moitié des dégâts.</content>
+  <content contentuid="h3c1b94c0g3b79g0911g3aa7ge6561bd5cb56" version="1">Songe</content>
+  <content contentuid="h73861110g988dg24c3g72e2gfe79f0ecaf49" version="1">En cas d'échec au jet de sauvegarde de Sagesse, la cible est piégée dans un rêve et ne tire aucun bénéfice de son repos. Lorsque la cible se réveille, elle subit 3d6 dégâts Psychiques.</content>
+  <content contentuid="hb0fea27dgc56fg62a0ge057g7c9ddc6f463e" version="1">La cible est piégée dans un rêve et ne tire aucun bénéfice de son repos. Lorsque la cible se réveille, elle subit 3d6 dégâts Psychiques.</content>
+  <content contentuid="hb36377c1g08c0g556fge8fbg80cbd9b569ef" version="1">En plein songe</content>
+  <content contentuid="h94c38ff4g24d8gdff5gf15bg1ec208dddd2d" version="1">Aura d'Invocation d'êtres sylvestres</content>
+  <content contentuid="h2b042bbdga167g0335g0c96gd2fc48c2ea13" version="1">Vous invoquez des esprits de la nature qui voltigent autour de vous dans une Émanation de 3 mètres pendant la durée. Chaque fois que l'Émanation entre dans l'espace d'une créature que vous pouvez voir et chaque fois qu'une créature que vous pouvez voir entre dans l'Émanation ou y termine son tour, vous pouvez forcer cette créature à effectuer un jet de sauvegarde de Sagesse. La créature subit des dégâts de Force en cas d'échec, ou la moitié de ces dégâts en cas de réussite. Une créature n'effectue ce jet de sauvegarde qu'une fois par tour.
+
+De plus, vous pouvez prendre l'action Se désengager en tant qu'Action bonus pendant la durée du sort.</content>
+  <content contentuid="h7a848bcagaa30g63d3g3125g77c908213cd3" version="1">Invocation d'êtres sylvestres</content>
+  <content contentuid="haf633c9dg1492gf659gb336g2332cda3f768" version="1">Vous invoquez des esprits de la nature qui voltigent autour de vous dans une Émanation de 3 mètres pendant la durée. Chaque fois que l'Émanation entre dans l'espace d'une créature que vous pouvez voir et chaque fois qu'une créature que vous pouvez voir entre dans l'Émanation ou y termine son tour, vous pouvez forcer cette créature à effectuer un jet de sauvegarde de Sagesse. La créature subit des dégâts de Force en cas d'échec, ou la moitié de ces dégâts en cas de réussite. Une créature n'effectue ce jet de sauvegarde qu'une fois par tour.
+
+De plus, vous pouvez prendre l'action Se désengager en tant qu'Action bonus pendant la durée du sort.</content>
+  <content contentuid="hfefb5384gcdb9g70a3g4fd3g5796fed23526" version="1">Éveil</content>
+  <content contentuid="h4016a9a2g8d51g2860gce0aga3dae07e0895" version="2">Vous tentez de mettre au pas une créature à l'esprit borné. Une créature avec une &lt;LSTag Tooltip="Intelligence"&gt;Intelligence&lt;/LSTag&gt; de 3 ou moins doit réussir un &lt;LSTag Tooltip="SavingThrow"&gt;jet de sauvegarde&lt;/LSTag&gt; d'&lt;LSTag Tooltip="Intelligence"&gt;Intelligence&lt;/LSTag&gt;, sans quoi elle devient &lt;LSTag Type="Status" Tooltip="AWAKEN"&gt;Dominée&lt;/LSTag&gt; par vous jusqu'à ce que vous terminiez un &lt;LSTag Tooltip="LongRest"&gt;Repos long&lt;/LSTag&gt;.</content>
+  <content contentuid="h98169436gc6eagd39ag00f1g64c904ff7649" version="2">Éveillé</content>
+  <content contentuid="h947e61d6g7b1fg7654gbc73g3ec51f29fd5a" version="2">L'esprit de cette créature a été plié à la volonté de son lanceur et elle obéit à ses ordres sans poser de question. L'effet prend fin lorsque le lanceur termine un &lt;LSTag Tooltip="LongRest"&gt;Repos long&lt;/LSTag&gt;.</content>
+  <content contentuid="h36f0d51cg768fg6fcegfd4cg9f24f3efb0a1" version="1">Soif de sang</content>
+  <content contentuid="hc7b7932cg1da7g2183g00f2g206583dcf7ef" version="1">Vol</content>
+  <content contentuid="h285600aag7ea5gc76dg7ee0gf02eee80c3a6" version="1">Vous touchez une créature consentante. Pendant la durée, la cible gagne une Vitesse de vol de 18 mètres et peut faire du vol stationnaire. Lorsque le sort prend fin, la cible tombe si elle est encore en l'air, à moins qu'elle ne puisse arrêter sa chute.</content>
+  <content contentuid="h9de09bd7gc9d1g08d0gcd2fg85f226c678d3" version="1">Vol</content>
+  <content contentuid="h4e086e1dgb445g00e5g933agb84d51e37356" version="1">Vol</content>
+  <content contentuid="h4d6a7f0cg4b59gf232g16f9gaaf7e6aa8dfb" version="1">Vol</content>
+  <content contentuid="hc3d38c0eg2fe4g7216g4d25g664b8ca1c301" version="1">Vous touchez une créature consentante. Pendant la durée, la cible gagne une Vitesse de vol de 18 mètres et peut faire du vol stationnaire. Lorsque le sort prend fin, la cible tombe si elle est encore en l'air, à moins qu'elle ne puisse arrêter sa chute.</content>
+  <content contentuid="h406d239cgf596g3642g0c30g97eb1a38e37a" version="1">Vous touchez une créature consentante. Pendant la durée, la cible gagne une Vitesse de vol de 18 mètres et peut faire du vol stationnaire. Lorsque le sort prend fin, la cible tombe si elle est encore en l'air, à moins qu'elle ne puisse arrêter sa chute.</content>
+  <content contentuid="h680a104dg18d0g6bfeg6161ga38f884a1c38" version="1">Vous touchez une créature consentante. Pendant la durée, la cible gagne une Vitesse de vol de 18 mètres et peut faire du vol stationnaire. Lorsque le sort prend fin, la cible tombe si elle est encore en l'air, à moins qu'elle ne puisse arrêter sa chute.</content>
+  <content contentuid="h9cf5d531g4949g8b3ag675egdf76db2f6a46" version="1">Danse de feu</content>
+  <content contentuid="h19186d60g16e9g1e3bgcbc7g45d59987d331" version="1">Vous invoquez des particules de flamme dansante qui flottent et dérivent autour de vous pendant la durée. Au début de chacun de leurs tours, les créatures non alliées à 6 mètres ou moins des flammes doivent réussir un jet de sauvegarde de Sagesse ou devenir Charmées jusqu'au début de leur prochain tour. Tant qu'elle est Charmée de cette façon, la créature est Neutralisée et a une vitesse de 0.</content>
+  <content contentuid="h3a8c610bga3d0g98a5g372eg5d265e61eef9" version="1">Danse de feu</content>
+  <content contentuid="h35662d22ga130g4004gd1e2g502f46f7dbd4" version="1">Vous invoquez des particules de flamme dansante qui flottent et dérivent autour de vous pendant la durée. Au début de chacun de leurs tours, les créatures non alliées à 6 mètres ou moins des flammes doivent réussir un jet de sauvegarde de Sagesse ou devenir Charmées jusqu'au début de leur prochain tour. Tant qu'elle est Charmée de cette façon, la créature est Neutralisée et a une vitesse de 0.</content>
+  <content contentuid="h39f64ea5gb60eg3361ga734gb5f1af066885" version="1">Aura de Danse de feu</content>
+  <content contentuid="h6f008cdbg3350gd976g5f94g72ed94e99398" version="1">Taillade spectrale</content>
+  <content contentuid="hc78c376dg616ag7239gb066ga93738880899" version="2">Attaque d'arme de Taillade spectrale</content>
+  <content contentuid="h63ced89eg89ebg0483ga272g25ce1e27bec3" version="1">Cible de Taillade spectrale</content>
+  <content contentuid="h95052719gb237gac57g92e1g14b60980710f" version="1">Attaque de Taillade spectrale</content>
+  <content contentuid="he35c6486g7f21gd1fag785egf414f915b565" version="1">Vous projetez une copie spectrale de vous-même pour terrasser votre ennemi. Effectuez une attaque de sort de corps à corps contre une créature à 6 mètres ou moins de vous. En cas de touche, la cible subit [1] dégâts du type de dégâts de votre arme.
+
+Vous pouvez ensuite dépenser votre action pour vous déplacer jusqu'à 6 mètres en ligne droite vers la cible, filant à travers une traînée spectrale, et prendre l'action Attaquer contre elle. Pour utiliser cette action, vous devez attaquer avec l'arme de corps à corps utilisée pour l'incantation de ce sort.</content>
+  <content contentuid="h1baba05fg926fg3fbeg861bg6aa1ecd27bef" version="1">Les dégâts augmentent de 1d8 et la distance parcourue de 3 mètres pour chaque niveau d'emplacement de sort au-delà du niveau 1.</content>
+  <content contentuid="hd212fcfagf0edg6619ga792g36f58b10cd9d" version="1">Cercle de pouvoir</content>
+  <content contentuid="h72f29464ga410gf4f8g9388gc7bc97ac7ac0" version="1">Une aura irradie de vous dans une Émanation de 9 mètres pendant la durée. Dans l'aura, vous et vos alliés avez l'Avantage aux jets de sauvegarde contre les sorts et autres effets magiques et ne subissez que la moitié des dégâts qu'ils infligent.</content>
+  <content contentuid="h5f04addfg41ecgbc72gedadga5ba2a2eea90" version="1">Aura de Cercle de pouvoir</content>
+  <content contentuid="hc52cdfedg87a2g694bg6d16g81bc875203c5" version="1">Une aura irradie de vous dans une Émanation de 9 mètres pendant la durée. Dans l'aura, vous et vos alliés avez l'Avantage aux jets de sauvegarde contre les sorts et autres effets magiques et ne subissez que la moitié des dégâts qu'ils infligent.</content>
+  <content contentuid="h5e4da7bfg3d53g34b0g1618g433a0364acc2" version="1">Cercle de pouvoir</content>
+  <content contentuid="hbf2c5134g52beg6d66g0aa1ga4e82c15a448" version="1">Vous avez l'Avantage aux jets de sauvegarde contre les sorts et les effets magiques. De plus, vous avez la Résistance aux dégâts infligés par les sorts.</content>
+  <content contentuid="h27836587g410fg18dbg70f1g00b3cfa0c1c9" version="1">Activer Énervation</content>
+  <content contentuid="h200d6e32g6f1cge25cg2d27g8bab65f46465" version="1">Vous pouvez utiliser votre action à chacun de vos tours pour infliger automatiquement [1] dégâts Nécrotiques à la cible.</content>
+  <content contentuid="hb0a6474bg13f1g3902g0e55g5cd782210550" version="1">Énervation</content>
+  <content contentuid="h0680f65eg2944g3595ga9d1gc7b9d923668f" version="1">Une vrille de ténèbres d'encre s'étend depuis vous et touche une créature que vous pouvez voir à portée pour drainer sa vie. La cible doit effectuer un jet de sauvegarde de Dextérité. En cas de réussite, la cible subit [1] dégâts Nécrotiques, et le sort prend fin. En cas d'échec, la cible subit [2] dégâts Nécrotiques, et jusqu'à la fin du sort, vous pouvez utiliser votre action à chacun de vos tours pour infliger automatiquement 4d8 dégâts Nécrotiques à la cible. Le sort prend fin si vous utilisez votre action pour faire quoi que ce soit d'autre, si la cible se trouve hors de portée du sort, ou si la cible bénéficie d'un abri total contre vous.
+
+Chaque fois que le sort inflige des dégâts à une cible, vous récupérez un nombre de points de vie égal à la moitié des dégâts Nécrotiques subis par la cible.</content>
+  <content contentuid="h6f070cfeg02fbgebecga6d1gb5a5d6ee555e" version="1">Cible d'Énervation</content>
+  <content contentuid="hf4df8f40g734eg4a1cgb8fagea08b40b8073" version="5">Parchemin de Châtiment balistique</content>
+  <content contentuid="hb8962a55g8344g4835ga773g610c4b802669" version="5">Classes utilisables : Artificier, Paladin</content>
+  <content contentuid="h3ef06543gb18dg44b9gb236g44997392d5a6" version="1">Parchemin de Distorsion corporelle de Gorgoroth</content>
+  <content contentuid="h048e9757gf877g4790g9da6ga7ed07014d56" version="1">Classes utilisables : Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h21f28158g6fd4g4f13gaeb5g46ebd693793f" version="1">Parchemin de Catapulte</content>
+  <content contentuid="h36ab8ce6g4ba6g476ag8f30ga885fc028382" version="1">Classes utilisables : Artificier, Ensorceleur, Magicien</content>
+  <content contentuid="hb76f98a1gdaddg4951gb182gc6db746c906f" version="1">Parchemin de Lame affamée</content>
+  <content contentuid="h865d57bag46d3g4e6egb4b9g4b2be8c9fa2e" version="1">Classes utilisables : Paladin, Rôdeur, Occultiste</content>
+  <content contentuid="h96f8024cg9940g41e2g8738g75f648f13e41" version="1">Parchemin de Taillade spectrale</content>
+  <content contentuid="h3717a414g9da0g4603g8f54gf8f54abd91df" version="1">Classes utilisables : Paladin, Rôdeur</content>
+  <content contentuid="h7f376c57g932ag412dgb3e9g4b25218c4a93" version="1">Parchemin d'Armure d'épines</content>
+  <content contentuid="hc159efe9g9b0fg4607g8661g446cd5c3514a" version="1">Classes utilisables : Druide, Rôdeur</content>
+  <content contentuid="h585a3b94g72a3g4797gb3e3g845026e4c95c" version="1">Parchemin de Marée de ténèbres</content>
+  <content contentuid="h69963318g8028g4cd8g9edfg2f5bf09f1ba9" version="1">Classes utilisables : Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h2dfbe2f6gbfbcg4453ga3e1g74861452ce15" version="1">Parchemin de Vrille d'ombre</content>
+  <content contentuid="h2d081af1g7463g4b13gb75cga2f474f1f345" version="1">Classes utilisables : Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h365e83bfgbaa3g4ed5g8b43gf8e3cb6b0f1b" version="1">Parchemin de Châtiment courroucé</content>
+  <content contentuid="h2d010845g555bg4d03g8d82gd5d53c0a75e7" version="1">Classes utilisables : Paladin</content>
+  <content contentuid="h29012509g9a1ag4f12gb771g80fea8b18f27" version="1">Parchemin de Foulée d'Ashardalon</content>
+  <content contentuid="ha87130cag43b6g43aagb72eg9039f36dbbf5" version="1">Classes utilisables : Artificier, Rôdeur, Ensorceleur, Magicien</content>
+  <content contentuid="h1e76b51fg30f1g4826gbff9g56fb7ca775d4" version="1">Parchemin de Bouclier cacophonique</content>
+  <content contentuid="hd129c79fg4974g4468gbeccgb1048964db88" version="1">Classes utilisables : Barde, Ensorceleur, Magicien</content>
+  <content contentuid="h6fd871efg483cg46a3g84e7g5145abb4d358" version="1">Parchemin d'Exhalaison élémentaire</content>
+  <content contentuid="hcacc217bg86aag40fega7afgb9e50fa8df71" version="1">Classes utilisables : Druide, Ensorceleur</content>
+  <content contentuid="he909a532gc660g4e69gba70gd205498f491d" version="1">Parchemin de Lance d'argent de Laeral</content>
+  <content contentuid="h5b6e7cafg0dcfg4fcdg93e2g9d8a41b1e736" version="1">Classes utilisables : Clerc, Ensorceleur, Magicien</content>
+  <content contentuid="hab8760e0gc159g4556gbcf6g5d72a286a4ba" version="1">Parchemin de Danse de feu</content>
+  <content contentuid="h70e6f2e6g358eg4ae7g9aa0g3d86098495d9" version="1">Classes utilisables : Barde, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h78ffd663g8746g4be7gad92g4add7a2d4ba6" version="1">Parchemin d'Éveil</content>
+  <content contentuid="hd440179cg42e2g4c50g8d76gf6e182d07046" version="1">Classes utilisables : Barde, Druide</content>
+  <content contentuid="h7275dc3dg3a1eg4eeagb827gff7687b3e5d7" version="1">Parchemin de Songe</content>
+  <content contentuid="hf51361c7g0bdcg49bcga863g2bc73ce22f6e" version="1">Classes utilisables : Barde, Clerc, Occultiste, Magicien</content>
+  <content contentuid="h713b476fg66a5g4653ga065gd0eabad305c9" version="1">Parchemin d'Énervation</content>
+  <content contentuid="h4b7db2ffg085fg4b20g8ed8g4d26a4634f00" version="1">Classes utilisables : Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h1fb28cd1g312fg4a30g9c6fg88c9d787974a" version="1">Parchemin de Souffle du dragon</content>
+  <content contentuid="h43c7ed41g0c76g4c1cg8555g3622987390d2" version="1">Classes utilisables : Artificier, Ensorceleur, Magicien</content>
+  <content contentuid="h68f18197gef59g4d42g89d4g359f077b2f65" version="1">Parchemin de Cercle de pouvoir</content>
+  <content contentuid="h45bfef77gc136g4fcdga0c9g905ed940113b" version="1">Classes utilisables : Clerc, Magicien</content>
+  <content contentuid="h7a6dd032g8505g4c5agb68cgdd27768b296f" version="1">Parchemin de Déflagration occulte</content>
+  <content contentuid="hb8333042ga43bg4fb8g9ebegc1dc00106cdc" version="1">Classes utilisables : Occultiste</content>
+  <content contentuid="h01124f5bg5522g461dgb0aeg4f68be71b1c3" version="1">Parchemin de Pistolets-doigts</content>
+  <content contentuid="hefcb8274gb96dg453agbff3g26f6c5ec90ae" version="1">Classes utilisables : Artificier, Barde, Ensorceleur, Magicien</content>
+  <content contentuid="h32cb692bgdd16g43c9g892dg3c4da0676c57" version="1">Parchemin de Sursaut d'effroi</content>
+  <content contentuid="h7f53e712g4b92g496egad03gd289e5e44822" version="1">Classes utilisables : Barde, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h177e18f7g6dc3g474bg9532g74fcb3c4f440" version="1">Parchemin de Lame aux flammes vertes</content>
+  <content contentuid="h2b6b0081g8d02g432fga25fg5cea43d6ad1d" version="1">Classes utilisables : Artificier, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="hbde1c1b9g49b7g4bf5gb05bgb6e611fc395a" version="1">Parchemin de Feu infernal</content>
+  <content contentuid="h19ef7182g0461g4729g9bd7gb3a83834d046" version="1">Classes utilisables : Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h807cf0e0gb4e2g4ca7g8b0agbe30dda8c3ee" version="1">Parchemin de Mot sacré</content>
+  <content contentuid="h4d264dfag8787g4c7fgab49g4c93bcedf6e8" version="1">Classes utilisables : Clerc</content>
+  <content contentuid="h3eefa19dg5779g4ec2gab7bg0b4ec8deb583" version="1">Parchemin de Piqûre mentale</content>
+  <content contentuid="h36b9bd7cgd3ffg4451gab20g2407d989d8c1" version="1">Classes utilisables : Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h1e4e1990g501dg4f11g8b2egf4a3766ee6ad" version="1">Parchemin de Stabilisation</content>
+  <content contentuid="h65a17f23g538bg4660g8ddcgf15764bb8f9c" version="1">Classes utilisables : Artificier, Clerc, Druide</content>
+  <content contentuid="haddbee20g6f91g4707gb100g19e0d1c9979d" version="1">Parchemin de Poussière d'étoile</content>
+  <content contentuid="h7923fe7dg7483g4e09gb200g403b36ab0c43" version="1">Classes utilisables : Barde, Druide</content>
+  <content contentuid="h398e6d03gc7e5g4d33g9722gbd9206f05133" version="1">Parchemin d'Éruption de lames</content>
+  <content contentuid="he6a9e927g508eg48ebgbe13g101b2c1e7adb" version="1">Classes utilisables : Artificier, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="hfbe03474g4d63g47c6ga736gb204c33c193f" version="1">Parchemin de Coup de tonnerre</content>
+  <content contentuid="h7e719dddg56a4g4792g9d5fgebc975efc849" version="1">Classes utilisables : Artificier, Barde, Druide, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h303255c0g1aceg4f8fg8a84gd85c4d39af19" version="1">Parchemin de Lame vengeresse</content>
+  <content contentuid="hc805ebbcg7821g44d9g89b8g04dbf30e50fe" version="1">Classes utilisables : Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h934a6c93ge8fbg41e6g9e9dg8ff631afa06e" version="1">Parchemin de Mot de radiance</content>
+  <content contentuid="h0ab87652g61f7g4878gaf77g6d3f4c2727e8" version="1">Classes utilisables : Clerc</content>
+  <content contentuid="h95f509e1g6538g434cgb444g5121e0e7b0ba" version="1">Parchemin d'Aura de vitalité</content>
+  <content contentuid="h78980a5cg47bdg4715gad11g64e52fa03cec" version="1">Classes utilisables : Clerc, Druide, Paladin</content>
+  <content contentuid="hcb30eea5g0d75g45adgb302g4835f16ea7af" version="1">Parchemin de Monture fantôme</content>
+  <content contentuid="h54acce3ag0998g4f67g829eg1a3af0043508" version="1">Classes utilisables : Magicien</content>
+  <content contentuid="h98058138gc85fg4eeagb856g0f31a491a570" version="1">Parchemin de Lame retentissante</content>
+  <content contentuid="h2c792efagc3c7g448eg8c6ag52bf02b25d32" version="1">Classes utilisables : Artificier, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h4c544d69g6d1fg46fegb8a2g30a5726c36e2" version="1">Parchemin d'Éruption ensorcelée</content>
+  <content contentuid="h4a5affa6g47b3g4704gb66dg389fd6211b47" version="1">Classes utilisables : Ensorceleur</content>
+  <content contentuid="h483976a4g540ag445dgb277gb00b31441f0c" version="1">Parchemin de Maléfice</content>
+  <content contentuid="h2489a6ebgebfeg4a6ag873bg5e21f84887bc" version="1">Classes utilisables : Occultiste</content>
+  <content contentuid="hca44ba39g3097g46a3gac48g9b6019d3e27a" version="1">Parchemin de Contagion</content>
+  <content contentuid="h350dac1eg1492g4804gba82g445fe02a46ea" version="1">Classes utilisables : Clerc, Druide</content>
+  <content contentuid="ha0cd15ddg0aabg4626gb9e7g4247772148ba" version="3">Panthère</content>
+  <content contentuid="hf7fc2047ga596g401dg9482gcb6cc2037cf9" version="3">Tigre à dents de sabre</content>
+  <content contentuid="h7b45a178g006bg4210gb636g69e7b0272a40" version="1">Parchemin d'Aspersion acide</content>
+  <content contentuid="h42e7c0a6g17efg428dg8696g5e39b360bf45" version="1">Classes utilisables : Artificier, Ensorceleur, Magicien</content>
+  <content contentuid="hf156bfc1gdd2eg4f41gad34g1c9eb6624388" version="1">Parchemin de Protection contre les armes</content>
+  <content contentuid="h442b48b7g5fd1g45bfgb68bgc8dc56f80471" version="1">Classes utilisables : Barde, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h9e4e7db2g8e7bg46eega5f1gdb891d8cf6e0" version="1">Parchemin de Tendon éclaté</content>
+  <content contentuid="hf86775abg3ed7g414cga752g2779876b3c2b" version="1">Classes utilisables : Clerc, Ensorceleur, Magicien</content>
+  <content contentuid="h78290588g0282g4151g95cag5baef69c1634" version="1">Parchemin de Lumières dansantes</content>
+  <content contentuid="ha1e89b4eg8d92g4aecg97e6g412ea9b904ac" version="1">Classes utilisables : Artificier, Barde, Ensorceleur, Magicien</content>
+  <content contentuid="h2104ae25g8fedg4919gb897gadbc9e42ee72" version="1">Parchemin d'Amis</content>
+  <content contentuid="h8b7b0898gbdedg4063g9934gc756b66c18e9" version="1">Classes utilisables : Barde, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="hd6c2558bgc523g47bcgb14ag057c67c1c3a8" version="1">Parchemin d'Assistance</content>
+  <content contentuid="h81ca2d82g0058g40b9g822eg48d00fa390f1" version="1">Classes utilisables : Artificier, Clerc, Druide</content>
+  <content contentuid="hb579f1c3gfd84g4b25ga4eagc3746dba60c9" version="1">Parchemin de Lumière</content>
+  <content contentuid="hbbfea48fg9939g4a68g9f77g75b827833bb9" version="1">Classes utilisables : Artificier, Barde, Clerc, Ensorceleur, Magicien</content>
+  <content contentuid="h72cfddcagd9adg46e5g9370g300ae4624cf3" version="1">Parchemin de Main du mage</content>
+  <content contentuid="h64daa63ag9736g4405gbd0fgb7a1a6818a53" version="1">Classes utilisables : Artificier, Barde, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h06c20aa3ga24ag4712g8d65gef0c57b09d88" version="1">Parchemin d'Illusion mineure</content>
+  <content contentuid="h51f7caaeg9372g4e86gaf59g32f47c7ca3fd" version="1">Classes utilisables : Barde, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h80896363g0d60g4d9aga98dg6683f010415d" version="1">Parchemin de Bouffée de poison</content>
+  <content contentuid="h47e76386g3be1g40b1g97deg21f1ba49349a" version="1">Classes utilisables : Artificier, Druide, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h4d344a13g13e1g4670g9671g6a65e9c8db6b" version="1">Parchemin de Production de flamme</content>
+  <content contentuid="heb1c0ea3geae1g43b3g9275g4eb4542e750c" version="1">Classes utilisables : Druide</content>
+  <content contentuid="h7e24e8c4gd619g4b7bgbb8fgf6e69df662bd" version="1">Parchemin de Résistance</content>
+  <content contentuid="h2684b3a8g5785g4b36g91aag1a15e2d6235a" version="1">Classes utilisables : Artificier, Clerc, Druide</content>
+  <content contentuid="hd6b957e7gf997g46f7gb34cgd07ed973fb49" version="1">Parchemin de Flamme sacrée</content>
+  <content contentuid="hc5261503g7ffeg44f4g9adeg4a453b390776" version="1">Classes utilisables : Clerc</content>
+  <content contentuid="h969e79f8ga241g4f3eg904ag8f4858d7c146" version="1">Parchemin de Gourdin magique</content>
+  <content contentuid="hf6ca44c0g6ba9g4f48g9216g56a087c03808" version="1">Classes utilisables : Druide</content>
+  <content contentuid="h4e359edbgd14fg48e3gaaa8gec2f6f104eff" version="1">Parchemin de Thaumaturgie</content>
+  <content contentuid="h68e674cegfb0eg4833g9161g16eb4a4a0ae6" version="1">Classes utilisables : Clerc</content>
+  <content contentuid="hd8acfaf2gdc2fg4a8bg85d8g786e61843d71" version="1">Parchemin de Fouet épineux</content>
+  <content contentuid="h2cec4524g94f3g406cg949bgabc8f7ab61a8" version="1">Classes utilisables : Artificier, Druide</content>
+  <content contentuid="hd794ebceg972cg429aga2fbg3d9a7db47812" version="1">Parchemin de Glas</content>
+  <content contentuid="h9776cce3ga97cg44bag8675g5a02e511c687" version="1">Classes utilisables : Clerc, Occultiste, Magicien</content>
+  <content contentuid="h096ebfe5g0cb5g4dfeg934cg08534e139de2" version="1">Parchemin de Coup au but</content>
+  <content contentuid="hd82e1bf6g1c8dg4df4g85e8ge5cc7b209599" version="1">Classes utilisables : Artificier, Barde, Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="hd6dc4fb0ga5fag40e4g94a8gf532a76634c0" version="1">Parchemin de Moquerie cruelle</content>
+  <content contentuid="h5b8d54d1ga5f7g44ebgb131g294190f528a8" version="1">Classes utilisables : Barde</content>
+  <content contentuid="h13714915ge8a8g4f94g810egd8c9ba002446" version="1">Parchemin d'Armure d'Agathys</content>
+  <content contentuid="h5ab42ef9g6590g4406g96c5g85893df14e9d" version="1">Classes utilisables : Occultiste</content>
+  <content contentuid="h05676470gf169g4cf0g9d65g403316fae14c" version="1">Parchemin de Tentacules d'Hadar</content>
+  <content contentuid="h3911d261g028eg4d6eg81a7g190f0c68e29b" version="1">Classes utilisables : Occultiste</content>
+  <content contentuid="hbe0bca25ge643g45e5g8678gfc458da357f4" version="1">Parchemin d'Imprécation</content>
+  <content contentuid="h6463c609gb0b9g4640g8d41g75423740e731" version="1">Classes utilisables : Barde, Clerc, Occultiste</content>
+  <content contentuid="he3c7d0a6g96b1g42c9g83e1g78c6366800d2" version="1">Parchemin de Bénédiction</content>
+  <content contentuid="hc6a4456cg98a4g45e5g9913g29050df55476" version="1">Classes utilisables : Clerc, Paladin</content>
+  <content contentuid="h271f8b43g2fc8g42efg8291g2ba140c8aa4a" version="1">Parchemin d'Injonction</content>
+  <content contentuid="h87352624g7a49g488bg83fbged7cf00fa351" version="1">Classes utilisables : Barde, Clerc, Paladin</content>
+  <content contentuid="h733f9731g4484g4313g987cga5792d08061f" version="1">Parchemin de Duel forcé</content>
+  <content contentuid="hd3eba5dagff83g410cgb73bg920141c0a6a4" version="1">Classes utilisables : Paladin</content>
+  <content contentuid="h652294ddg8ca4g4600gb068g4c65f5fc27f9" version="1">Parchemin de Création ou destruction d'eau</content>
+  <content contentuid="hf064b5feg4877g4e8bg8a64g84ce7bbef50a" version="1">Classes utilisables : Clerc, Druide</content>
+  <content contentuid="h6c69e211gc0fdg446dgb4a6gc5f6f6b1df24" version="1">Parchemin de Soin des blessures</content>
+  <content contentuid="h7f314a75g180ag4b5fgb292g79d9ab6b5e9d" version="1">Classes utilisables : Artificier, Barde, Clerc, Druide, Paladin, Rôdeur</content>
+  <content contentuid="ha240a28bgac40g47f6g81c8g9397f5b7151f" version="1">Parchemin de Murmures dissonants</content>
+  <content contentuid="h882af9a4gb72dg433fg81bfg913a9ca05fb3" version="1">Classes utilisables : Barde</content>
+  <content contentuid="hc05fd5f0gabeag4800gad2eg36539cdcef6e" version="1">Parchemin de Faveur divine</content>
+  <content contentuid="hea95aad3g8011g4695g98fbgb7e528739872" version="1">Classes utilisables : Paladin</content>
+  <content contentuid="h92a5b85bgbf5ag46c6g815fgaa776936f6b9" version="1">Parchemin de Frappe piégeuse</content>
+  <content contentuid="h240835ffg849dg4c2agb157g4665f8dc5787" version="1">Classes utilisables : Rôdeur</content>
+  <content contentuid="h4d2440a7g773eg4df5ga298ge47b7cb7545d" version="1">Parchemin d'Enchevêtrement</content>
+  <content contentuid="heb239ae8gb512g4a22gb543g9b98c9f2df9d" version="1">Classes utilisables : Druide, Rôdeur</content>
+  <content contentuid="h74437106g3801g4e49gb67bge87de1f118c5" version="1">Parchemin de Lueurs féériques</content>
+  <content contentuid="h53a09d3agfa14g4382ga82bga385c31825d6" version="1">Classes utilisables : Artificier, Barde, Druide</content>
+  <content contentuid="h7ef4ab92ge90ag48bdgb4deg1e7f771f5319" version="1">Parchemin de Rayon traçant</content>
+  <content contentuid="hef54eecfgdce9g4473gb994g4113b91775fb" version="1">Classes utilisables : Clerc</content>
+  <content contentuid="h5271ce83g7c0fg4956gb2afg0a429f41a26e" version="1">Parchemin de Grêle d'épines</content>
+  <content contentuid="hbe4b287bg4438g4a3dg9254g7f67718dba54" version="1">Classes utilisables : Rôdeur</content>
+  <content contentuid="h6e9279b3ge5f5g46a2gb43aga7a7cff5b37a" version="1">Parchemin de Mot de guérison</content>
+  <content contentuid="hcd5a67dfg2658g49f0g9f75g091450907eda" version="1">Classes utilisables : Barde, Clerc, Druide</content>
+  <content contentuid="h1d614ddagb290g44e4g90c4gf1d0dbff174e" version="1">Parchemin d'Héroïsme</content>
+  <content contentuid="h6e43759ag12b4g42f0ga135g15ce363eeb40" version="1">Classes utilisables : Barde, Paladin</content>
+  <content contentuid="he80f0a15g5df9g44bbg92e7g880e56e9ea3f" version="1">Parchemin de Marque du chasseur</content>
+  <content contentuid="h94fcd654gb691g4f27g89e4gf9ff5a1de879" version="1">Classes utilisables : Rôdeur</content>
+  <content contentuid="hf42b7ddfg2028g4ec4gb854g9528bb39b818" version="1">Parchemin de Blessure</content>
+  <content contentuid="h17266dddg8a8bg426bgb096g6b9bf2eca717" version="1">Classes utilisables : Clerc</content>
+  <content contentuid="he05c72e9g0761g4a5cgbe1bgfe115ce91c95" version="1">Parchemin de Sanctuaire</content>
+  <content contentuid="h6dab634bg7fcdg455bg97fag943f3d768fb1" version="1">Classes utilisables : Artificier, Clerc</content>
+  <content contentuid="hf58661b8gab76g47ebg8450g07dbcd2e223e" version="1">Parchemin de Châtiment calcinant</content>
+  <content contentuid="hb5ca2a00g713ag4654g8663g5f27ac95a237" version="1">Classes utilisables : Paladin</content>
+  <content contentuid="h68efba27gab0dg43f4ga260gea1789a83134" version="1">Parchemin de Bouclier de la foi</content>
+  <content contentuid="hb7865f71gc9dbg4beega25agd429d35c82a0" version="1">Classes utilisables : Clerc, Paladin</content>
+  <content contentuid="h18d457f4g80ecg43acg829cg11afd73ec108" version="1">Parchemin de Communication avec les animaux</content>
+  <content contentuid="hf972a7c0ge2f1g4e13g84cbgb2eb21931d53" version="1">Classes utilisables : Barde, Druide, Rôdeur, Occultiste</content>
+  <content contentuid="hd630115dg356eg4f68g8a96g710ed0b808e7" version="1">Parchemin de Châtiment tonnant</content>
+  <content contentuid="hf65383c6g0bc1g428cg9721g7922e6de4cfa" version="1">Classes utilisables : Paladin</content>
+  <content contentuid="hea19e09cg0f06g47b9gb3c2g7fb62c2c96e2" version="1">Parchemin de Peau d'écorce</content>
+  <content contentuid="hb15c91a6g6880g44a9g8fb0gce00ff78e460" version="1">Classes utilisables : Druide, Rôdeur</content>
+  <content contentuid="h35519665ge949g4374ga365g7bda4404fe86" version="1">Parchemin de Châtiment révélateur</content>
+  <content contentuid="h51ea462dg7af4g46c6g98ddga2de23fe1459" version="1">Classes utilisables : Paladin</content>
+  <content contentuid="hc0e72a85g7d23g4c2dgb4f1gbe82eaa88e00" version="1">Parchemin d'Apaisement des émotions</content>
+  <content contentuid="hc298c1d3g5b1fg4a35gb89bga87a125fb109" version="1">Classes utilisables : Barde, Clerc</content>
+  <content contentuid="heca566f5g65fcg4803g8dd1g682cc5887e4b" version="1">Parchemin d'Amélioration de capacité</content>
+  <content contentuid="hbdd71080g88bag48b8gbbe9g6e98deccccfd" version="1">Classes utilisables : Artificier, Barde, Clerc, Druide, Rôdeur, Ensorceleur, Magicien</content>
+  <content contentuid="h728428ccg46b4g4d4fga3e5gbf83f178944e" version="1">Parchemin de Fascination</content>
+  <content contentuid="hb7b57624g2a86g4643gabd8g3c71b0683ff1" version="1">Classes utilisables : Barde</content>
+  <content contentuid="h804ae2f1g0930g4491g8763g4b06563c2821" version="1">Parchemin de Métal brûlant</content>
+  <content contentuid="hc7c754fag911ag47a7ga5beg7f98f8c469f8" version="1">Classes utilisables : Artificier, Barde, Druide</content>
+  <content contentuid="he504d141gc259g45f8gb80dg3c310b21a85b" version="1">Parchemin de Restauration partielle</content>
+  <content contentuid="h6f2f1343gd3ecg4b9eg85e2g2ef6cc31d097" version="1">Classes utilisables : Artificier, Barde, Clerc, Druide, Paladin, Rôdeur</content>
+  <content contentuid="he10d9305g8cf6g4ccbgad7bgd2746ea46ca4" version="1">Parchemin de Rayon de lune</content>
+  <content contentuid="h250348d7ge71dg40a2ga944g6f665b8e18c0" version="1">Classes utilisables : Druide</content>
+  <content contentuid="h45d0b5d3ga398g445cga7f9gd75da7a8aae3" version="1">Parchemin de Passage sans trace</content>
+  <content contentuid="hfeb4fe3ag8905g4d2bgb6a9g7ee7674d54b6" version="1">Classes utilisables : Druide, Rôdeur</content>
+  <content contentuid="hc6d61f66ga59cg4754gac48ge00fb1fb5ddd" version="1">Parchemin de Prière de soins</content>
+  <content contentuid="h65a54d96gda00g48f3gb956gbf5821b6ed10" version="1">Classes utilisables : Clerc, Paladin</content>
+  <content contentuid="h4df0a731g189eg4843gb14fg950fd7625872" version="1">Parchemin de Protection contre le poison</content>
+  <content contentuid="h5427b5b7g9e41g4bbeg8e31g82d493a9b617" version="1">Classes utilisables : Artificier, Clerc, Druide, Paladin, Rôdeur</content>
+  <content contentuid="hb45b2deeg7891g4ef5g9247g6271029e08c6" version="1">Parchemin de Lame des ombres</content>
+  <content contentuid="h87e57107g3fd4g43dcga492g90ec809f3f7a" version="1">Classes utilisables : Ensorceleur, Occultiste, Magicien</content>
+  <content contentuid="h07d70d75gb311g4b65gaf4eg8807c20ff75d" version="1">Parchemin de Silence</content>
+  <content contentuid="h72e6f048g2dbag460egbdbcg13df38c3298c" version="1">Classes utilisables : Barde, Clerc, Rôdeur</content>
+  <content contentuid="h2fd14680g25deg43cdg9566gbe966a172cd8" version="1">Parchemin de Croissance d'épines</content>
+  <content contentuid="hd0519165g9dffg4e5fg82eegf51c3855776a" version="1">Classes utilisables : Druide, Rôdeur</content>
+  <content contentuid="h63eb55ccgfb97g429agbc6dg76a3f91ba6dc" version="1">Parchemin d'Arme spirituelle</content>
+  <content contentuid="hd9f0d1begbcf0g4bf7g854ageeacf34955bf" version="1">Classes utilisables : Clerc</content>
+  <content contentuid="h6e60a515g883fg4bf9ga2d5g7744828b2d6f" version="1">Parchemin de Lien de protection</content>
+  <content contentuid="h8a827975g3fc5g445fgbdc1g25c34240201d" version="1">Classes utilisables : Clerc, Paladin</content>
+  <content contentuid="h08ad9844gea2dg4d56ga406g6d04f66b0031" version="1">Parchemin de Lueur d'espoir</content>
+  <content contentuid="he9f6e2b1g23dfg41e9g9a07gbc2cec13be20" version="1">Classes utilisables : Clerc</content>
+  <content contentuid="h55a35097g5dd8g4e9fg877ag564708edc728" version="1">Parchemin de Châtiment aveuglant</content>
+  <content contentuid="h9bf76849g3018g4f96gbac5gcd39839b2394" version="1">Classes utilisables : Paladin</content>
+  <content contentuid="hca7ebb00g47b4g4574g953bgdb15df0bca67" version="1">Parchemin d'Appel de la foudre</content>
+  <content contentuid="h9c7aa655g6161g4dedg9ffbg92220abe2475" version="1">Classes utilisables : Druide</content>
+  <content contentuid="hbaf05e9cg8b9ag48dagb7eag7903cf5bc3c3" version="1">Parchemin de Hérissement de projectiles</content>
+  <content contentuid="he94292e5gd3a9g44eegaaf6gdfc66d5bd1e2" version="1">Classes utilisables : Rôdeur</content>
+  <content contentuid="hb3a50517g8c9fg42b2g8757g2a419821af02" version="1">Parchemin d'Aura du croisé</content>
+  <content contentuid="he0963b4bgda4eg4bafgb796g5b7ec6410ca1" version="1">Classes utilisables : Paladin</content>
+  <content contentuid="h5b3aa645gc718g46fcgb3b1g48cced477759" version="1">Parchemin de Lumière du jour</content>
+  <content contentuid="h73580f96ga9bag489aga276gaa2200b19c22" version="1">Classes utilisables : Clerc, Druide, Paladin, Rôdeur, Ensorceleur</content>
+  <content contentuid="haf04e176g4abeg4764gb773gf6644ec21fac" version="1">Parchemin d'Arme élémentaire</content>
+  <content contentuid="hd2abd846g45b3g427dgb7a8g08a2cd62544a" version="1">Classes utilisables : Artificier, Druide, Paladin, Rôdeur</content>
+  <content contentuid="hf37a3668g5485g462dgb8bfg24f366499655" version="1">Parchemin de Faim d'Hadar</content>
+  <content contentuid="hdcedefeeg8769g45e9ga84bgac21bffb520f" version="1">Classes utilisables : Occultiste</content>
+  <content contentuid="h2d37feacg6e1dg4330ga540gcd5096a455e8" version="1">Parchemin de Flèche de foudre</content>
+  <content contentuid="ha40f0509gf80eg4b7agb932gee31a11de074" version="1">Classes utilisables : Rôdeur</content>
+  <content contentuid="h21fd31cfg39c3g427egbc9egf048a4cf21a5" version="1">Parchemin de Mot de guérison de groupe</content>
+  <content contentuid="h665b1f14gbe43g44f5g9a56ga2e7cb2fa287" version="1">Classes utilisables : Barde, Clerc</content>
+  <content contentuid="hbdf82ee0g0a92g43e1g8697gbaa2fd5aecf7" version="1">Parchemin de Croissance végétale</content>
+  <content contentuid="habb3d245gf146g4a01g8fd5g6d0eaf22fede" version="1">Classes utilisables : Barde, Druide, Rôdeur</content>
+  <content contentuid="h50778009g9d87g418bg87b5g2254454260ed" version="1">Parchemin d'Esprits gardiens</content>
+  <content contentuid="h8fe1d517gfd0dg43f7gb1b5ge42cd5ffc705" version="1">Classes utilisables : Clerc</content>
+  <content contentuid="h55d62a6fge1a3g4d2fg93cfg89f4f3459f11" version="1">Parchemin d'Invocation d'êtres sylvestres</content>
+  <content contentuid="h5e1c76d8g5917g4dcfgaf4bg102510402809" version="1">Classes utilisables : Druide</content>
+  <content contentuid="h6610ee0eg1eb2g4ce7g9ca1gcf3d85a89aee" version="1">Parchemin de Protection contre la mort</content>
+  <content contentuid="h8b1f4993ga883g4f66g9bb9g24d8dd30700d" version="1">Classes utilisables : Clerc</content>
+  <content contentuid="hfa5194fdga498g4753g845eg38616d41d105" version="1">Parchemin de Domination d'animal</content>
+  <content contentuid="ha49988b7g0aaag4c53gb135g16e4a7d028ca" version="1">Classes utilisables : Druide, Ensorceleur</content>
+  <content contentuid="h8587bf57g8e23g47eeg855ag694f1815cca7" version="1">Parchemin de Liberté de mouvement</content>
+  <content contentuid="h924ee79agb241g4343g9a17g84d939186d74" version="1">Classes utilisables : Barde, Clerc, Druide</content>
+  <content contentuid="h0ae3a512ga30bg4e55gaacfg84dc3f72dda1" version="1">Parchemin de Liane avide</content>
+  <content contentuid="hea395c9ag018fg4009g9180g6a41e317a1e4" version="1">Classes utilisables : Druide</content>
+  <content contentuid="hfd260509g0e4bg4d5fgb5d2gd0e37328a597" version="1">Parchemin de Gardien de la foi</content>
+  <content contentuid="hab2b3ccagbed1g40b3gb1bbg58fd80b5531e" version="1">Classes utilisables : Clerc</content>
+  <content contentuid="he70e6205gdf4fg4d5cg9dc6gdc22475bfbf4" version="1">Parchemin de Danse macabre</content>
+  <content contentuid="hb9d9d80cg39e7g43cagabd7g4b093f1e2863" version="1">Classes utilisables : Occultiste, Magicien</content>
+  <content contentuid="hca48287cg09ddg475eg984dgb74dd7555661" version="1">Parchemin de Dissipation du mal et du bien</content>
+  <content contentuid="ha59d7b3cg42aeg4b10gae24g03767f5b5588" version="1">Classes utilisables : Clerc</content>
+  <content contentuid="hb48ea529ga046g4da2ga1d7g7a6603bceb12" version="1">Parchemin de Colonne de flammes</content>
+  <content contentuid="h34eac281g5918g45fbg9d4egdf30d279379c" version="1">Classes utilisables : Clerc</content>
+  <content contentuid="ha8754ab8g046eg429dgb826g072b90ae711c" version="1">Parchemin de Restauration suprême</content>
+  <content contentuid="h29c82c0eg24ccg4d14ga127g3278b7b2fa8b" version="1">Classes utilisables : Barde, Clerc, Druide</content>
+  <content contentuid="h93979a42gdc26g4964ga7f7gc4974506e66a" version="1">Parchemin de Fléau d'insectes</content>
+  <content contentuid="hab57462agb792g494bg9462g32ca3e45469e" version="1">Classes utilisables : Clerc, Druide, Ensorceleur</content>
+  <content contentuid="hf954e01dg9e5fg497fga5d3g2cef68a76aec" version="1">Parchemin de Soins de groupe</content>
+  <content contentuid="h2a19ce2dg5763g4613g9861g7c187ef6cb3e" version="1">Classes utilisables : Barde, Clerc, Druide</content>
+  <content contentuid="hff3d0226g6612g46cdg82f8g7d47e749c7f5" version="1">Parchemin de Portail arcanique</content>
+  <content contentuid="hdb0e30bbgc764g4d02gb2d8g7ec827bccb17" version="1">Classes utilisables : Ensorceleur, Magicien</content>
+  <content contentuid="hfd5fe6cbg9e79g4506gbd98g47f8fa71ae2c" version="1">Parchemin de Barrière de lames</content>
+  <content contentuid="hb91babffg2098g4a95g8d11g80cbabdbd5f4" version="1">Classes utilisables : Clerc</content>
+  <content contentuid="h70a619eeg6ec3g4740g9447gdafb23e4c3bd" version="1">Parchemin de Création de mort-vivant</content>
+  <content contentuid="h8288432dge8adg48dcgb39ag463d70eae5e5" version="1">Classes utilisables : Clerc, Magicien</content>
+  <content contentuid="he1063367gd781g4567g8184gcff119cfbc4d" version="1">Parchemin de Contamination</content>
+  <content contentuid="hc7337917gc650g450egb66cg48f29d82ed25" version="1">Classes utilisables : Clerc</content>
+  <content contentuid="hd2cff643g1314g451dg8b52g3c72ab9cc277" version="1">Parchemin de Guérison</content>
+  <content contentuid="h5a3b8f8dg1fa6g4882g9145g812f10a1971d" version="1">Classes utilisables : Clerc, Druide</content>
+  <content contentuid="h8dce5792g2335g4226gb661gca3e4cf933f9" version="1">Parchemin de Festin des héros</content>
+  <content contentuid="hda55ee17gdadfg4de3g9bf8g049e90d394f8" version="1">Classes utilisables : Barde, Clerc, Druide</content>
+  <content contentuid="hf577238eg5e24g45b6gb0a2g141a090436e0" version="1">Parchemin d'Allié planaire</content>
+  <content contentuid="hc4d67b9ag8485g41a4gaf7ag052379dbe08f" version="1">Classes utilisables : Clerc</content>
+  <content contentuid="h2ecfc655g0140g46e2gb3a1g79eb47deb506" version="1">Parchemin de Mur d'épines</content>
+  <content contentuid="h2f0b64a4geb48g4c40g9076g26cb973d6c00" version="1">Classes utilisables : Druide</content>
+  <content contentuid="hc2613126g1447g4fd3g9ecdg5f633dce7f75" version="1">Parchemin de Marche sur le vent</content>
+  <content contentuid="h6c3bff41ge93bg4284g9158gfe616f679bae" version="1">Classes utilisables : Barde, Druide</content>
+  <content contentuid="hbdab1650g7fcegb743g3bf5gb818b5acb043" version="2">Changelin</content>
+  <content contentuid="hb280ba69g6538g2683g4a87gc4ce53e3c3c6" version="1">Changelin</content>
+  <content contentuid="ha27abf3bg3071ga32fgef9ag63d508f82314" version="1">Changelin</content>
+  <content contentuid="h5844527eg5bc7g6d08gb8bdg836fe861ad65" version="1">Avec leurs apparences en perpétuel changement, les changelins vivent au sein de nombreuses sociétés sans être détectés. Chaque changelin peut adopter par des moyens surnaturels n'importe quel visage à sa guise. Pour certains changelins, un nouveau visage peut révéler un aspect de leur âme.
+
+Les premiers changelins du multivers sont apparus dans la Féérie sauvage, et l'essence merveilleuse et changeante de ce plan demeure aujourd'hui dans les changelins — même chez ceux qui n'ont jamais mis les pieds dans le royaume féérique.
+
+Sous leur véritable forme, les changelins paraissent délavés, leurs traits presque dépourvus de détails. Il est rare d'en voir un sous cette forme, car un changelin typique modifie son apparence comme d'autres changent de vêtements. Cependant, de nombreux changelins développent des identités plus profondes, façonnant pour chaque forme un persona complet, avec son histoire et ses convictions. Un changelin aventurier peut avoir des personas pour de nombreuses situations, notamment la négociation, l'investigation et le combat.
+
+Plusieurs changelins peuvent partager un même persona. Les personas peuvent même se transmettre au sein d'une famille, permettant à un jeune changelin de profiter des contacts établis par les précédents utilisateurs du persona.</content>
+  <content contentuid="h8489e5a6g8d98ga6aega0e4g053a3fec88c7" version="1">Changelin</content>
+  <content contentuid="h00779e8dg1144g5eecg3f98g33292e8dea42" version="1">Avec leurs apparences en perpétuel changement, les changelins vivent au sein de nombreuses sociétés sans être détectés. Chaque changelin peut adopter par des moyens surnaturels n'importe quel visage à sa guise. Pour certains changelins, un nouveau visage peut révéler un aspect de leur âme.
+
+Les premiers changelins du multivers sont apparus dans la Féérie sauvage, et l'essence merveilleuse et changeante de ce plan demeure aujourd'hui dans les changelins — même chez ceux qui n'ont jamais mis les pieds dans le royaume féérique.
+
+Sous leur véritable forme, les changelins paraissent délavés, leurs traits presque dépourvus de détails. Il est rare d'en voir un sous cette forme, car un changelin typique modifie son apparence comme d'autres changent de vêtements. Cependant, de nombreux changelins développent des identités plus profondes, façonnant pour chaque forme un persona complet, avec son histoire et ses convictions. Un changelin aventurier peut avoir des personas pour de nombreuses situations, notamment la négociation, l'investigation et le combat.
+
+Plusieurs changelins peuvent partager un même persona. Les personas peuvent même se transmettre au sein d'une famille, permettant à un jeune changelin de profiter des contacts établis par les précédents utilisateurs du persona.</content>
+  <content contentuid="h92492e20g45c0gf0a3g825eg51894d948693" version="1">Métamorphe</content>
+  <content contentuid="h842fd89bg0642gf761gc3e7ga95824e9c738" version="1">Par une action, vous pouvez vous métamorphoser pour changer votre apparence et votre voix. Vous déterminez les détails des changements, y compris votre teint, la longueur de vos cheveux et votre sexe. Vous pouvez également ajuster votre taille et votre poids, et changer votre catégorie de taille entre Moyenne et Petite. Vous pouvez vous faire passer pour un membre d'une autre espèce jouable, bien qu'aucune de vos statistiques de jeu ne change. Vous ne pouvez pas reproduire l'apparence d'un individu que vous n'avez jamais vu, et vous devez adopter une forme qui possède la même disposition de membres que la vôtre. Ce trait ne change ni vos vêtements ni votre équipement.
+
+Tant que vous êtes métamorphosé grâce à ce trait, vous avez l'Avantage aux tests de Charisme.
+
+Vous restez sous votre nouvelle forme jusqu'à ce que vous preniez une action pour reprendre votre véritable forme.</content>
+  <content contentuid="h3aa8fe16g20f5gd9bcg6b2ag37c43ec4a76a" version="1">Instincts de changelin</content>
+  <content contentuid="he0997113gd8aeg5a32g0cadg6583a1780b19" version="1">Grâce à votre lien avec le royaume féérique, vous gagnez la maîtrise de deux des compétences suivantes de votre choix : Tromperie, Perspicacité, Intimidation, Représentation ou Persuasion.</content>
+  <content contentuid="h45db1baag1a66g5173g7046g451d6c939820" version="1">Métamorphe</content>
+  <content contentuid="haddbec72gf9c4g510bg8c8cgba4bcfd87301" version="1">Par une action, vous pouvez vous métamorphoser pour changer votre apparence et votre voix. Vous déterminez les détails des changements, y compris votre teint, la longueur de vos cheveux et votre sexe. Vous pouvez également ajuster votre taille et votre poids, et changer votre catégorie de taille entre Moyenne et Petite. Vous pouvez vous faire passer pour un membre d'une autre espèce jouable, bien qu'aucune de vos statistiques de jeu ne change. Vous ne pouvez pas reproduire l'apparence d'un individu que vous n'avez jamais vu, et vous devez adopter une forme qui possède la même disposition de membres que la vôtre. Ce trait ne change ni vos vêtements ni votre équipement.
+
+Tant que vous êtes métamorphosé grâce à ce trait, vous avez l'Avantage aux tests de Charisme.
+
+Vous restez sous votre nouvelle forme jusqu'à ce que vous preniez une action pour reprendre votre véritable forme.</content>
+  <content contentuid="h91db12d5g8008g270dg0954g09a1733b596c" version="1">Dissiper la métamorphose</content>
+  <content contentuid="h92a4c2d5gc8f0g7ee9g69d9gbcc22fbfd18f" version="3">Vol à la tire</content>
+  <content contentuid="h38834643g8993gebb9g329bg7091b7ffff24" version="1">Lorsque vous lancez Main du mage, vous pouvez le lancer en tant qu'Action bonus, et vous pouvez rendre la main spectrale Invisible. La main peut également tenter de faire les poches, en effectuant un test de Dextérité (Escamotage) qui utilise votre propre modificateur en tant qu'Arnaqueur arcanique.</content>
+  <content contentuid="hf1072944g3718g45edgace3ga7e816803e30" version="1">Fouillez les poches de la cible et tentez de voler un objet. Le test de Dextérité (Escamotage) utilise votre propre modificateur en tant qu'Arnaqueur arcanique.</content>
+  <content contentuid="hc7b21ba7g1c09g7de4g9eaag014c9a24930a" version="1">Lorsque vous lancez un sort qui force une créature à effectuer un jet de sauvegarde, vous pouvez dépenser 2 Points de sorcellerie pour imposer à une cible du sort le Désavantage aux jets de sauvegarde contre le sort.</content>
+  <content contentuid="ha614b061ga252gec97g0245gecd6aee49796" version="1">Lorsque vous lancez un sort avec un temps d'incantation d'une action, vous pouvez dépenser 2 Points de sorcellerie pour changer le temps d'incantation en Action bonus pour cette incantation. Vous ne pouvez pas modifier un sort de cette façon si vous avez déjà lancé un sort de niveau 1 ou supérieur pendant le tour en cours, ni lancer un sort de niveau 1 ou supérieur pendant ce tour après avoir modifié un sort de cette façon.</content>
+  <content contentuid="hd25a31d6gfc99g5602g7ce2gdace45ce4abf" version="1">Lorsque vous lancez un sort qui force d'autres créatures à effectuer un jet de sauvegarde, vous pouvez protéger certaines de ces créatures de la pleine puissance du sort. Pour ce faire, dépensez 1 Point de sorcellerie et choisissez un nombre de ces créatures allant jusqu'à votre modificateur de Charisme (minimum d'une créature). Une créature choisie réussit automatiquement son jet de sauvegarde contre le sort, et elle ne subit aucun dégât si elle ne devait normalement subir que la moitié des dégâts en cas de réussite.</content>
+  <content contentuid="hcb1875bdg0b82gd5fbg0db6g263e63afba9e" version="1">Lorsque vous lancez un sort avec une portée d'au moins 1,50 mètre, vous pouvez dépenser 1 Point de sorcellerie pour doubler la portée du sort. Ou lorsque vous lancez un sort avec une portée de Contact, vous pouvez dépenser 1 Point de sorcellerie pour porter la portée du sort à 9 mètres.</content>
+  <content contentuid="h27bcf565gc4a7g7770gc0c5g968e23a6925d" version="1">Lorsque vous lancez les dégâts d'un sort, vous pouvez dépenser 1 Point de sorcellerie pour relancer un nombre de dés de dégâts allant jusqu'à votre modificateur de Charisme (minimum de un), et vous devez utiliser les nouveaux résultats.
+
+Vous pouvez utiliser Sort renforcé même si vous avez déjà utilisé une autre option de Métamagie pendant l'incantation du sort.</content>
+  <content contentuid="ha5c27440g356cg3255gc01fgf7ee2e2426cd" version="1">Lorsque vous lancez un sort avec une durée de 1 minute ou plus, vous pouvez dépenser 1 Point de sorcellerie pour doubler sa durée, jusqu'à une durée maximale de 24 heures.
+
+Si le sort affecté nécessite la Concentration, vous avez l'Avantage à tout jet de sauvegarde que vous effectuez pour maintenir cette Concentration.</content>
+  <content contentuid="h70a6ac30g5ca3g2d63ga068gd36a9bb01eab" version="1">Lorsque vous lancez un sort, vous pouvez dépenser 1 Point de sorcellerie pour le lancer sans composantes Verbales, Somatiques ou Matérielles, à l'exception des composantes Matérielles qui sont consommées par le sort ou dont le coût est précisé dans le sort.</content>
+  <content contentuid="h3aef575agcbdfgd3e8g1850ge006a44a0100" version="1">Lorsque vous lancez un sort, tel que Charme-personne, qui peut être lancé avec un emplacement de sort de niveau supérieur pour cibler une créature supplémentaire, vous pouvez dépenser 1 Point de sorcellerie pour augmenter le niveau effectif du sort de 1.</content>
+  <content contentuid="hee9de861gce1eg6f92gb26dg7eabdea5edc3" version="1">Métamagie : Sort chercheur</content>
+  <content contentuid="h4350095ege773ga624g7919g62f04bb30b95" version="1">Si vous effectuez un jet d'attaque pour un sort et que vous ratez, vous pouvez dépenser 1 Point de sorcellerie pour relancer le d20, et vous devez utiliser le nouveau résultat.
+
+Vous pouvez utiliser Sort chercheur même si vous avez déjà utilisé une autre option de Métamagie pendant l'incantation du sort.</content>
+  <content contentuid="habd56c76g31abgf710gce13g306dcdaeece5" version="1">Métamagie : Sort chercheur</content>
+  <content contentuid="h28f9a741ga446ga31eg8889g3b0e1ddcb286" version="1">Si vous effectuez un jet d'attaque pour un sort et que vous ratez, vous pouvez dépenser 1 Point de sorcellerie pour relancer le d20, et vous devez utiliser le nouveau résultat.
+
+Vous pouvez utiliser Sort chercheur même si vous avez déjà utilisé une autre option de Métamagie pendant l'incantation du sort.</content>
+  <content contentuid="h96663848g22b6g4fd3g0749gcca87a42edab" version="2">Vous invoquez des esprits de la nature qui voltigent autour de vous dans une Émanation de 3 mètres pendant la durée. Chaque fois que l'Émanation entre dans l'espace d'une créature que vous pouvez voir et chaque fois qu'une créature que vous pouvez voir entre dans l'Émanation ou y termine son tour, vous pouvez forcer cette créature à effectuer un jet de sauvegarde de Sagesse. La créature subit des dégâts de Force en cas d'échec, ou la moitié de ces dégâts en cas de réussite. Une créature n'effectue ce jet de sauvegarde qu'une fois par tour.
+
+De plus, vous pouvez prendre l'action Se désengager en tant qu'Action bonus pendant la durée du sort.</content>
+  <content contentuid="hfbad83efgcb7cg321ag47a0g402ce027568b" version="2">Vous invoquez des esprits de la nature qui voltigent autour de vous dans une Émanation de 3 mètres pendant la durée. Chaque fois que l'Émanation entre dans l'espace d'une créature que vous pouvez voir et chaque fois qu'une créature que vous pouvez voir entre dans l'Émanation ou y termine son tour, vous pouvez forcer cette créature à effectuer un jet de sauvegarde de Sagesse. La créature subit des dégâts de Force en cas d'échec, ou la moitié de ces dégâts en cas de réussite. Une créature n'effectue ce jet de sauvegarde qu'une fois par tour.
+
+De plus, vous pouvez prendre l'action Se désengager en tant qu'Action bonus pendant la durée du sort.</content>
+  <content contentuid="hc98c1c9egd99agca86ged41g2a76a0c61645" version="2">Vous invoquez des esprits de la nature qui voltigent autour de vous dans une Émanation de 3 mètres pendant la durée. Chaque fois que l'Émanation entre dans l'espace d'une créature que vous pouvez voir et chaque fois qu'une créature que vous pouvez voir entre dans l'Émanation ou y termine son tour, vous pouvez forcer cette créature à effectuer un jet de sauvegarde de Sagesse. La créature subit des dégâts de Force en cas d'échec, ou la moitié de ces dégâts en cas de réussite. Une créature n'effectue ce jet de sauvegarde qu'une fois par tour.
+
+De plus, vous pouvez prendre l'action Se désengager en tant qu'Action bonus pendant la durée du sort.</content>
+  <content contentuid="hbdf571dag5ab3g15d9gdff5gce87ff23aeab" version="1">Bouclier arcanique : 2</content>
+  <content contentuid="h6a8a77f9g49d3g85c9g66d6g5339634103dc" version="2">Bouclier arcanique : 5</content>
+  <content contentuid="hdbeee3f4g51d1ga6a2g38e4g117b18d0ded2" version="2">Bouclier arcanique : 10</content>
+  <content contentuid="hab1b1092g6641g6579gf21fg826e0233e223" version="2">Bouclier arcanique : 15</content>
+  <content contentuid="hd316ed92gc935g3e5ag2680g5fe344efd87e" version="3">Bouclier arcanique : 25</content>
+  <content contentuid="h1fb287e1g9868g51e1gb05bg26f19c367e9d" version="2">Bouclier arcanique : 2</content>
+  <content contentuid="h36d4544fg5333g6da5gaa73g9d6577de11a3" version="1">Bouclier arcanique : 5</content>
+  <content contentuid="h1cb5ab02gf336ge150g0148g642f1196f8a5" version="1">Bouclier arcanique : 10</content>
+  <content contentuid="h7934c92cg8530g3159g655ag6b05c5e60aef" version="1">Bouclier arcanique : 15</content>
+  <content contentuid="h4f08c9a8gd738g8d4dg31c2gb975d622852c" version="1">Bouclier arcanique : 20</content>
+  <content contentuid="h3e550e8eg5409g3a80g52e3ga4f1d383264d" version="1">Bouclier projeté : 2</content>
+  <content contentuid="h621ec36dg3794g4862g4538gb2c4399f06cd" version="1">Lorsqu'une créature que vous pouvez voir à 9 mètres ou moins de vous subit des dégâts, vous pouvez prendre une Réaction pour que votre Bouclier arcanique absorbe ces dégâts.</content>
+  <content contentuid="h9cb11bc4g520dg35a2g4731g7635211c5e76" version="1">Chaque fois que vous subissez des dégâts, le bouclier les subit à votre place, et si vous avez des Résistances ou des Vulnérabilités, appliquez-les avant de réduire les Points de vie du bouclier. Si les dégâts réduisent le bouclier à 0 Point de vie, vous subissez les dégâts restants. Tant que le bouclier a 0 Point de vie, il ne peut pas absorber de dégâts, mais sa magie demeure.</content>
+  <content contentuid="h295148d7ga456gb0ffg5573g8f507e9bf7fe" version="1">Bouclier projeté : 5</content>
+  <content contentuid="hcd21cc8fgd961g0feeg16afgf78a1e0a3fba" version="1">Lorsqu'une créature que vous pouvez voir à 9 mètres ou moins de vous subit des dégâts, vous pouvez prendre une Réaction pour que votre Bouclier arcanique absorbe ces dégâts.</content>
+  <content contentuid="hd1cf6300g0d28g0951g5071g79972ff7f6ac" version="1">Bouclier projeté : 10</content>
+  <content contentuid="h221aec9fgee6dgf291gdaedg74950253b4a2" version="1">Lorsqu'une créature que vous pouvez voir à 9 mètres ou moins de vous subit des dégâts, vous pouvez prendre une Réaction pour que votre Bouclier arcanique absorbe ces dégâts.</content>
+  <content contentuid="h2a863d0egbd90g1d88g062fgd7908dabd2e0" version="1">Bouclier projeté : 15</content>
+  <content contentuid="h97912cc4g21bfg2c6egbd0cgbc22ad403d83" version="1">Lorsqu'une créature que vous pouvez voir à 9 mètres ou moins de vous subit des dégâts, vous pouvez prendre une Réaction pour que votre Bouclier arcanique absorbe ces dégâts.</content>
+  <content contentuid="hc26cfac5g1d2cg4692g1e56g8a0726a5fa88" version="1">Bouclier projeté : 20</content>
+  <content contentuid="h6df157b5g12d3g2b2bgd643g1dd6b4025001" version="1">Lorsqu'une créature que vous pouvez voir à 9 mètres ou moins de vous subit des dégâts, vous pouvez prendre une Réaction pour que votre Bouclier arcanique absorbe ces dégâts.</content>
+  <content contentuid="hc2e7a124g2079gd707g16edg7f33dc23e62e" version="1">Bouclier projeté : 25</content>
+  <content contentuid="hb4209506g884fg3190g8d94g0432d0658315" version="1">Lorsqu'une créature que vous pouvez voir à 9 mètres ou moins de vous subit des dégâts, vous pouvez prendre une Réaction pour que votre Bouclier arcanique absorbe ces dégâts.</content>
+  <content contentuid="h08045ad1gb50dgc96dg8318gd971f112b84f" version="1">Vous pouvez faire appel à votre patron fiélon pour infléchir le destin en votre faveur. Lorsque vous effectuez un test de caractéristique ou un jet de sauvegarde, vous pouvez utiliser cette fonctionnalité pour ajouter 1d10 à votre jet. Vous pouvez le faire après avoir vu le résultat du jet, mais avant que ses effets ne s'appliquent.</content>
+  <content contentuid="h3deb4586gfae5g7a55gadcagd4ee75ff94b8" version="1">Vous pouvez utiliser cette fonctionnalité un nombre de fois égal à votre modificateur de Charisme (minimum une fois), mais vous ne pouvez l'utiliser qu'une seule fois par jet. Vous récupérez toutes les utilisations dépensées lorsque vous terminez un Repos long.</content>
+  <content contentuid="h8b958c8ag5476g5bd5g1951gae850853f115" version="1">Chance du ténébreux</content>
+  <content contentuid="h6c5d2c6egd7c2gfb23g896eg360dd2c50b66" version="1">Vous pouvez faire appel à votre patron fiélon pour infléchir le destin en votre faveur. Lorsque vous effectuez un test de caractéristique ou un jet de sauvegarde, vous pouvez utiliser cette fonctionnalité pour ajouter 1d10 à votre jet. Vous pouvez le faire après avoir vu le résultat du jet, mais avant que ses effets ne s'appliquent.</content>
+  <content contentuid="h2944739bg0fccgd61eg92c1g5c03f06fda01" version="1">Gnoll</content>
+  <content contentuid="hb1e1f1ccg8b1fg0c0eg7a39gdbe307c41c2a" version="1">Fiélons sauvages semblables à des hyènes, qui massacrent sans distinction pour tenter d'apaiser la faim insatiable de leur créateur démoniaque, Yeenoghu.</content>
+  <content contentuid="hcfaede04g37feg52c1g02a1g79498988da95" version="1">Flind</content>
+  <content contentuid="h2c4006d3g73ecg08bfg17a3g3faf573592f2" version="1">Fiélons sauvages semblables à des hyènes, qui massacrent sans distinction pour tenter d'apaiser la faim insatiable de leur créateur démoniaque, Yeenoghu.</content>
+  <content contentuid="h2fc7ca1ag45b3g3d7fg4bc3g7371ce249b55" version="1">Gobelours</content>
+  <content contentuid="h793f78b0g01begbadeg6726gad9c2d6ba04d" version="1">Fées velues qui convoitent à parts égales le carnage et les trésors.</content>
+  <content contentuid="he33b1ccdg8743geb43g8025g2191e3ade81a" version="2">Fées faibles et égoïstes. Bien qu'elles servent souvent des races plus fortes, elles convoitent le pouvoir et abusent de l'autorité qu'elles obtiennent.</content>
+  <content contentuid="h5ced74f8g76e0g5eddg048cgd4d89dcb4b6d" version="1">Gobelin</content>
+  <content contentuid="h9d1db6edgfe03gd1b6g95aeg9d83628a6e5e" version="1">Hobgobelin</content>
+  <content contentuid="h9b3f6d84g9d96g983bgdd29g677ab15e8c87" version="1">Grandes fées brutales qui vivent pour les prouesses martiales, la guerre et la gloire.</content>
+  <content contentuid="haaeaefd6ge211ge406g3964g5d846312973c" version="1">Kobold</content>
+  <content contentuid="h670b4035g1e83g155bg1b6bgbe2c3ed49f65" version="1">Reptiliens rusés mais couards qui compensent leur inaptitude physique en s'unissant.</content>
+  <content contentuid="h49f573e0g51d8gab8ag3788g56d525e94705" version="1">Kuo-toa</content>
+  <content contentuid="hf0fa09deg1153gff8agc30fgf43e347dc403" version="1">Habitants pisciformes et fous des Tréfonds Obscurs. Ils vénèrent des dieux imaginaires avec une ferveur religieuse démente.</content>
+  <content contentuid="h3f9f2b2agdef2g4181g854bgea3484c5155b" version="2">Sahuagin</content>
 </contentList>


### PR DESCRIPTION
This PR brings the French localization to full parity with English (4,688 entries), as a single commit touching only `french.xml`.

- **1,129 missing entries translated** — feats, subclasses (Shadow Domain, College of Spirits, Blade of Radiance, Path of the Fractured…), homebrew spells, the full Wild Magic Surge table, spell scrolls, the Changeling species, 2024 metamagic, and the latest Kobold/Kuo-toa/Sahuagin additions.
- **29 stale entries retranslated** and re-versioned to match the current English text.
- **11 truncated translations completed** (missing paragraphs and domain/patron spell lists).
- **Terminology harmonized corpus-wide**: pre-existing divergent translations were unified (Occultiste, sort mineur, Drakéide, Tieffelin, Témérité, Pic de magie sauvage, Conduit divin, ~25 spell names…).
- **Distances converted to metres** (391 entries, strict ×0.3 table): BG3 is natively metric in every language, and the official French D&D translation is metric as well.

Terminology was never translated from memory. Every term follows a strict priority: **BG3 base-game French localization** (extracted from `French.pak`) → **official French D&D translation** (2024 preferred) → **existing corpus** → new translation.

**Machine-verified before submission**: FR = EN = 4,688 entries; 0 missing, 0 stale, 0 orphan, 0 duplicate uid; per-entry inline structure (LSTag tags, entities, placeholders, paragraphs), dice and number multisets identical to English; well-formed XML; entry order and encoding unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
