### PR TITLE
loc(ru): fix feat/spell terminology per dnd.su canon

### DIFF
--- a/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Russian/russian.xml
+++ b/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/Russian/russian.xml
@@ -739,11 +739,11 @@
   <content contentuid="h92b0f41cg7222g57a1gf293g5f9b67f6c76a" version="1">Заговоры Колдуна, требующие броска атаки: когда ты попадаешь по Большому или более мелкому существу таким заговором, ты можешь оттолкнуть существо на [1] прямо от себя.</content>
   <content contentuid="h63854322g2981gf688g3b17g3be3eb3cbaea" version="1">Колдовской взрыв</content>
   <content contentuid="h5821657eg6a48gdd10gb380ga906788793a5" version="1">Создай [1] луч(ей) потрескивающей энергии.</content>
-  <content contentuid="ha82b5e6dgb4b1gb2a1g8b53g475515ffec20" version="1">Гремящий клинок</content>
+  <content contentuid="ha82b5e6dgb4b1gb2a1g8b53g475515ffec20" version="1">Громовой клинок</content>
   <content contentuid="h0e37672dgdb7bg5838g12bcg8e96a88d3d98" version="1">Порази врага своим оружием, поразив его резонансом, который наносит [1] урона при перемещении.</content>
-  <content contentuid="hde7eade7g981dg355bg6e30g0089c6fe0377" version="1">Верный удар (Ближний бой)</content>
+  <content contentuid="hde7eade7g981dg355bg6e30g0089c6fe0377" version="1">Меткий удар (Ближний бой)</content>
   <content contentuid="hfc5b991fgffcdgbc3bgbe4eg4bbb47637ce8" version="2">Направляемый вспышкой магического озарения, ты совершаешь одну атаку оружием, использованным при сотворении заклинания. Для бросков атаки и урона используется твоя заклинательная характеристика вместо Силы или Ловкости. Если атака наносит урон, он может быть Лучистым уроном или обычным типом урона оружия (на твой выбор).</content>
-  <content contentuid="hc48575fbg3411gc50ag88aeg18f05fb53a0f" version="1">Верный удар (Дальний бой)</content>
+  <content contentuid="hc48575fbg3411gc50ag88aeg18f05fb53a0f" version="1">Меткий удар (Дальний бой)</content>
   <content contentuid="he4de88abg8ba4g6afeg8c45g9069fad18699" version="2">Направляемый вспышкой магического озарения, ты совершаешь одну атаку оружием, использованным при сотворении заклинания. Для бросков атаки и урона используется твоя заклинательная характеристика вместо Силы или Ловкости. Если атака наносит урон, он может быть Лучистым уроном или обычным типом урона оружия (на твой выбор).</content>
   <content contentuid="h573020b3g1241g8748g5cccgf1a7c580e5d4" version="2">Направляемый вспышкой магического озарения, ты совершаешь одну атаку оружием, использованным при сотворении заклинания. Для бросков атаки и урона используется твоя заклинательная характеристика вместо Силы или Ловкости. Если атака наносит урон, он может быть Лучистым уроном или обычным типом урона оружия (на твой выбор).</content>
   <content contentuid="h17b4c239g8209gd0fbg57b8gadfb6d1e2826" version="1">Твой &lt;LSTag Type="Spell" Tooltip="Target_FindFamiliar"&gt;фамильяр&lt;/LSTag&gt; получает Дополнительную атаку.</content>
@@ -801,12 +801,12 @@
   <content contentuid="h74e5b82bg3e1eg42d0g108ag8296ce9e9f59" version="1">Требование: Колдун 1-го уровня+</content>
   <content contentuid="h89cc571cg9734g0e75g9d8fg69ec4116823f" version="1">Требование: Колдун 1-го уровня+</content>
   <content contentuid="hda66831fg300fg893ega428gd807bb12f766" version="1">Служитель</content>
-  <content contentuid="h18021532g7cf1g263eg148bg852a52db6cf5" version="3">Фит: Маг-недоучка (Жрец)
+  <content contentuid="h18021532g7cf1g263eg148bg852a52db6cf5" version="3">Черта: Посвященный в магию (Жрец)
 
 Ты провёл жизнь, служа храму, изучая священные обряды и принося жертвы богу или богам, которым поклоняешься. Служение богам и открытие их священных трудов приведут тебя к величию.</content>
-  <content contentuid="hd660fd06g45aeg25f4g7e9dg6fd338c66f83" version="1">Фит предыстории: Маг-недоучка (Жрец)</content>
-  <content contentuid="ha980b3fbg98dcgc88eg9edbg89be32a4b191" version="2">Маг-недоучка (Жрец): Заговор</content>
-  <content contentuid="hd57d4d53gfb82gc5e5ge39eg18ccf99d11ac" version="1">Маг-недоучка (Жрец): Заговор 2</content>
+  <content contentuid="hd660fd06g45aeg25f4g7e9dg6fd338c66f83" version="1">Черта предыстории: Посвященный в магию (Жрец)</content>
+  <content contentuid="ha980b3fbg98dcgc88eg9edbg89be32a4b191" version="2">Посвященный в магию (Жрец): Заговор</content>
+  <content contentuid="hd57d4d53gfb82gc5e5ge39eg18ccf99d11ac" version="1">Посвященный в магию (Жрец): Заговор 2</content>
   <content contentuid="hee720882g4ca7g0c82g0f6dgda96a14a144e" version="3">Активирован режим изучения заговоров. Все заговоры Жреца добавлены в твой список заклинаний.
 
 Выбор заговора для сотворения навсегда обучает тебя ему — тебе не нужна допустимая цель или завершение сотворения.
@@ -817,12 +817,12 @@
 Выбор заговора для сотворения навсегда обучает тебя ему — тебе не нужна допустимая цель или завершение сотворения.
 
 После выбора двух разных заговоров этот режим завершается.</content>
-  <content contentuid="he64b4a45gba6eg30a6g9703gb0f13f9230e8" version="1">Маг-недоучка (Жрец): Заговор</content>
-  <content contentuid="hd21b5377g2221gaafdga39bgea72f3a697d1" version="1">Маг-недоучка (Друид): Заговор</content>
-  <content contentuid="h3522b895gaf8eg23c8ge2a5g19305a3832ce" version="1">Фит предыстории: Маг-недоучка (Друид)</content>
-  <content contentuid="h3be2808fgdf36g2f49g651dgd7072fe1c369" version="1">Маг-недоучка (Друид): Заговор</content>
-  <content contentuid="hcf7beb3cg8662gd7d0ga3aag9f047d9b8897" version="1">Маг-недоучка (Волшебник): Заговор</content>
-  <content contentuid="h7fd3e98dg8cddgd47cg0aeag9f03355feaaa" version="1">Два заговора. Ты изучаешь два заговора по своему выбору из списков заклинаний Жреца, Друида или Волшебника. При выборе этого фита выбери Интеллект, Мудрость или Харизму в качестве заклинательной характеристики для этих заклинаний.
+  <content contentuid="he64b4a45gba6eg30a6g9703gb0f13f9230e8" version="1">Посвященный в магию (Жрец): Заговор</content>
+  <content contentuid="hd21b5377g2221gaafdga39bgea72f3a697d1" version="1">Посвященный в магию (Друид): Заговор</content>
+  <content contentuid="h3522b895gaf8eg23c8ge2a5g19305a3832ce" version="1">Черта предыстории: Посвященный в магию (Друид)</content>
+  <content contentuid="h3be2808fgdf36g2f49g651dgd7072fe1c369" version="1">Посвященный в магию (Друид): Заговор</content>
+  <content contentuid="hcf7beb3cg8662gd7d0ga3aag9f047d9b8897" version="1">Посвященный в магию (Волшебник): Заговор</content>
+  <content contentuid="h7fd3e98dg8cddgd47cg0aeag9f03355feaaa" version="1">Два заговора. Ты изучаешь два заговора по своему выбору из списков заклинаний Жреца, Друида или Волшебника. При выборе этой черты выбери Интеллект, Мудрость или Харизму в качестве заклинательной характеристики для этих заклинаний.
 
 Заклинание 1-го уровня. Выбери одно заклинание 1-го уровня из того же списка, который ты выбрал для заговоров. Это заклинание всегда у тебя подготовлено, и ты получаешь одну ячейку заклинания 1-го уровня для его сотворения.</content>
   <content contentuid="hb18213feg1443g46dfg66c8g43152a53cf75" version="3">Активирован режим изучения заговоров. Все заговоры Друида добавлены в твой список заклинаний.
@@ -835,138 +835,138 @@
 Выбор заговора для сотворения навсегда обучает тебя ему — тебе не нужна допустимая цель или завершение сотворения.
 
 После выбора двух разных заговоров этот режим завершается.</content>
-  <content contentuid="h948ef541g3485gbf64g5f3ag0b03af06a06a" version="1">Маг-недоучка (Жрец): Заклинание</content>
+  <content contentuid="h948ef541g3485gbf64g5f3ag0b03af06a06a" version="1">Посвященный в магию (Жрец): Заклинание</content>
   <content contentuid="h0452adf6gbffcga716g8490gdad124c18bb6" version="3">Активирован режим изучения заклинаний. Все заклинания Жреца добавлены в твой список заклинаний.
 
 Выбор заклинания для сотворения навсегда обучает тебя ему — тебе не нужна допустимая цель или завершение сотворения.
 
 После выбора заклинания этот режим завершается.</content>
-  <content contentuid="hc1a2947cg6d72g0cb9g22eagc5ff105e4237" version="1">Маг-недоучка (Друид): Заклинание</content>
+  <content contentuid="hc1a2947cg6d72g0cb9g22eagc5ff105e4237" version="1">Посвященный в магию (Друид): Заклинание</content>
   <content contentuid="he3771dbcg23f0g570dg2d5egf79cec30d589" version="3">Активирован режим изучения заклинаний. Все заклинания Друида добавлены в твой список заклинаний.
 
 Выбор заклинания для сотворения навсегда обучает тебя ему — тебе не нужна допустимая цель или завершение сотворения.
 
 После выбора заклинания этот режим завершается.</content>
-  <content contentuid="hc6335af1g4129g0308g8518g3cb980ec4a55" version="1">Маг-недоучка (Волшебник): Заклинание</content>
+  <content contentuid="hc6335af1g4129g0308g8518g3cb980ec4a55" version="1">Посвященный в магию (Волшебник): Заклинание</content>
   <content contentuid="hffa4fb6cg516eg4f17g0656geecaebcd5045" version="3">Активирован режим изучения заклинаний. Все заклинания Волшебника добавлены в твой список заклинаний.
 
 Выбор заклинания для сотворения навсегда обучает тебя ему — тебе не нужна допустимая цель или завершение сотворения.
 
 После выбора заклинания этот режим завершается.</content>
-  <content contentuid="h711b7815g70c9g4712ga219g0ff6e0b8c207" version="1">Маг-недоучка: Кислотный всплеск</content>
-  <content contentuid="h70fd1410g49a4g44d1g9f8eg7f6bc1c21fea" version="1">Маг-недоучка: Друзья</content>
-  <content contentuid="ha6ce862fg4edeg49f7g9320gb8580541d70a" version="1">Маг-недоучка: Огненный снаряд</content>
-  <content contentuid="h97d2ab9cgaaf9g4bd4gb544g5862fb5d10b9" version="1">Маг-недоучка: Танцующие огоньки</content>
-  <content contentuid="hc5fa63acg91f7g498fg8be8g4f77f6e608e1" version="1">Маг-недоучка: Леденящее касание</content>
-  <content contentuid="h8cab8439g423ag41e7ga45bg7c1a4c23cde3" version="1">Маг-недоучка: Разрывающее сухожилие</content>
-  <content contentuid="h4def798ag029dg4d00g8d1eg8929e03098d6" version="1">Маг-недоучка: Гремящий клинок</content>
-  <content contentuid="h83dc6116g533dg4e65g8c4ag7f3230f15b56" version="1">Маг-недоучка: Оберег клинка</content>
-  <content contentuid="hc43d9642g1590g42d6gbab6ga3dc6574eb50" version="1">Маг-недоучка: Наставление</content>
-  <content contentuid="haada0dc8gc767g45e4g98c2g6c5644d040c1" version="1">Маг-недоучка: Клинок зелёного пламени</content>
-  <content contentuid="h1e7a31c9g35c0g4b54g8f69g25b327a4c999" version="1">Маг-недоучка: Свет</content>
-  <content contentuid="hee3244d3g6916g4229gb4b7gd98a4f519f8e" version="1">Маг-недоучка: Волшебная рука</content>
-  <content contentuid="hd455a5aag6fb4g48ccgbec8gdf13c11a88ab" version="1">Маг-недоучка: Ментальная щепка</content>
-  <content contentuid="h965b7dc5ga4acg4b60g9e4bgcd236212e8b4" version="1">Маг-недоучка: Малая иллюзия</content>
-  <content contentuid="hcb1e67e1g69e7g4710g9cd5ga81a12763305" version="1">Маг-недоучка: Брызги яда</content>
-  <content contentuid="hf6e4b463g8945g4e41g8f63g065eb4ecdd0b" version="1">Маг-недоучка: Создание пламени</content>
-  <content contentuid="h4f7e0ea1g2ff6g48b2g937bg7cc4f590d0e7" version="1">Маг-недоучка: Фокус</content>
-  <content contentuid="h893b82a7g6490g43ebg981ag9315af05142b" version="1">Маг-недоучка: Луч холода</content>
-  <content contentuid="heda822d9g6ca8g4d69g862cg8e593ceb6f22" version="1">Маг-недоучка: Сопротивление</content>
-  <content contentuid="h04241b75g4f7eg40dagbac2g1acb8e2326f5" version="1">Маг-недоучка: Священное пламя</content>
-  <content contentuid="hdd5d9c2cg059eg4e76gb6b6g01e4d851171d" version="1">Маг-недоучка: Шиллег</content>
-  <content contentuid="h4527bdb1gf97cg4adcg9003g64255fe6abdf" version="1">Маг-недоучка: Поражающий захват</content>
-  <content contentuid="h29d6991cg8d76g4e4bga787g7f988a72fe15" version="1">Маг-недоучка: Пощада умирающего</content>
-  <content contentuid="hb163e2e9gb2d2g4adeg8801g80dbb2b50492" version="1">Маг-недоучка: Звёздный огонёк</content>
-  <content contentuid="h9f283e92g10dfg43b6g837dg39ee82977d4b" version="1">Маг-недоучка: Всплеск меча</content>
-  <content contentuid="h66c0ac32gf014g42dag9841g3b01a76087d3" version="1">Маг-недоучка: Чудотворство</content>
-  <content contentuid="hc3c05220gcdefg4521g8152g4898ef5b675d" version="1">Маг-недоучка: Шипованный хлыст</content>
-  <content contentuid="h663fe553g789ag4344gba16g9856c5fe1f6c" version="1">Маг-недоучка: Громовой хлопок</content>
-  <content contentuid="h8a1afdf9g8010g4ad9gbda9ged21cac57381" version="1">Маг-недоучка: Погребальный звон</content>
-  <content contentuid="hfc64fd6bgba50g4748gaa9fg22adb16ff81b" version="1">Маг-недоучка: Верный удар</content>
-  <content contentuid="hc24e0712g664bg4e59gad6fg394d985f4bfb" version="1">Маг-недоучка: Мстительный клинок</content>
-  <content contentuid="he02ce6f7gdbe0g4af4g8e20g9e0b3c31c653" version="1">Маг-недоучка: Слово сияния</content>
-  <content contentuid="hb0e3941dgfac2g426ag9ccdgee197b362bd8" version="1">Маг-недоучка: Святое слово</content>
-  <content contentuid="h749a56acgdc0fg4869g9757g0be1a08703ea" version="1">Маг-недоучка: Пугающее начало</content>
-  <content contentuid="h21645e9ag9d9cg418aga245g6a9015289552" version="1">Маг-недоучка: Дружба с животными</content>
-  <content contentuid="hdf583f63gea12g4423g9944g3daa981713d3" version="1">Маг-недоучка: Создание или уничтожение воды</content>
-  <content contentuid="hcc29c239gc13fg4023gb368g06aa956b1eb2" version="1">Маг-недоучка: Приказ</content>
-  <content contentuid="hce902b37g2b1fg4c69gb496g34f99e16b2db" version="1">Маг-недоучка: Цветной всплеск</content>
-  <content contentuid="hc3ea7a0bg4a33g447egab4cg59b3544f61a4" version="1">Маг-недоучка: Покров тени</content>
-  <content contentuid="h20d0eed4gb780g487cg8ab2g2a8f0df204ec" version="1">Маг-недоучка: Хроматическая сфера</content>
-  <content contentuid="hbcff1db6g661fg44b2gaa19ge984fa1cedb3" version="1">Маг-недоучка: Очарование личности</content>
-  <content contentuid="h32091888g9007g441cgb899gf48ab4745ec0" version="1">Маг-недоучка: Горящие руки</content>
-  <content contentuid="hb964961egd956g43e4gb1f4gbbd5199911f7" version="1">Маг-недоучка: Благословение</content>
-  <content contentuid="hcf286fcbga673g4b58g9ca2g7cb218338271" version="1">Маг-недоучка: Злоключение</content>
-  <content contentuid="h40603322g7144g4076ga600g816c1a3bf347" version="1">Маг-недоучка: Лечение ран</content>
-  <content contentuid="h21dc2164g914fg40f1g96f0g6370fd2112f5" version="1">Маг-недоучка: Опутывание</content>
-  <content contentuid="h1b472549g17edg4c6bgac27gf0b44463bc4c" version="1">Маг-недоучка: Спешное отступление</content>
-  <content contentuid="hffc26135gf1a3g4a40ga837gc93edb478e30" version="1">Маг-недоучка: Свет фей</content>
-  <content contentuid="h4ded108bga017g4608gbf95g21aa64af5306" version="1">Маг-недоучка: Фальшивая жизнь</content>
-  <content contentuid="haba60ef6g99aag4749g96b9g8d1f04316129" version="1">Маг-недоучка: Падение пера</content>
-  <content contentuid="h38f40cc0g5620g4711g8d56gdd9c138dc7bf" version="1">Маг-недоучка: Поиск фамильяра</content>
-  <content contentuid="hf8e02fcbgdb8bg4268gb21cg13293d623b07" version="1">Маг-недоучка: Облако тумана</content>
-  <content contentuid="h7fe00d2bgea8ag4b0fgbbacgdbf44e74157c" version="1">Маг-недоучка: Добрая ягода</content>
-  <content contentuid="hc6e80bc7gdc11g4a8egafadg36b0c70eecad" version="1">Маг-недоучка: Жир</content>
-  <content contentuid="h06ce1335g4a93g488eg9ce8g7f24e3f055ce" version="1">Маг-недоучка: Направляющий снаряд</content>
-  <content contentuid="h050d8dc6gbc79g42dbg906dg75bd310a68ea" version="1">Маг-недоучка: Лечащее слово</content>
-  <content contentuid="h3ea7727eg6fb7g4437g8abfg5b8b01c08404" version="1">Маг-недоучка: Чудовищный смех</content>
-  <content contentuid="hdc5cb67eg6726g4f71ga0a5g19d3f916892d" version="1">Маг-недоучка: Ледяной нож</content>
-  <content contentuid="h86f50d94gf85eg4f54g9043g7300025a6b85" version="1">Маг-недоучка: Наложение ран</content>
-  <content contentuid="h57c34580gbbf4g41acgbcb6g5f4b946ba3e2" version="1">Маг-недоучка: Прыжок</content>
-  <content contentuid="h931b6d31gbc0cg42a0ga0fdg6bf79513d2f8" version="1">Маг-недоучка: Длинноход</content>
-  <content contentuid="h3cb9ecd6gc656g434eg9178g4828fbd9e74c" version="1">Маг-недоучка: Магический доспех</content>
-  <content contentuid="hc12ab9b5ga37dg4463g97c9gcfaef383ed25" version="1">Маг-недоучка: Волшебная стрела</content>
-  <content contentuid="h7380d024gd726g4ecbgaf7bg7053d764150b" version="1">Маг-недоучка: Защита от зла и добра</content>
-  <content contentuid="h8ec3e1ffgcbf4g4037g9bc0g84441c8fa842" version="1">Маг-недоучка: Луч болезни</content>
-  <content contentuid="h124523e9g22fbg4ef6g9eadg44197da47bfb" version="1">Маг-недоучка: Убежище</content>
-  <content contentuid="h2cd9127cg7278g4d0fgb936g380f15ea9889" version="1">Маг-недоучка: Щит</content>
-  <content contentuid="h2ad87388g142dg4348gbbedg0e1f69d37af7" version="1">Маг-недоучка: Щит веры</content>
-  <content contentuid="h11e7e65ag5981g4ae2g8c38gc618d023f94b" version="1">Маг-недоучка: Сон</content>
-  <content contentuid="hcacff426g1d0ag44e6g9598gd4e780c75798" version="1">Маг-недоучка: Разговор с животными</content>
-  <content contentuid="h5aa03de7gf337g42a1gb453ge89a6f671278" version="1">Маг-недоучка: Громовая волна</content>
-  <content contentuid="h4a25b113gd59eg4b37gb1fag1d64b4e65972" version="1">Маг-недоучка: Отпугивание</content>
-  <content contentuid="h4a465394gc707g4e0bga071g165709a73a35" version="1">Маг-недоучка: Ведьмин снаряд</content>
+  <content contentuid="h711b7815g70c9g4712ga219g0ff6e0b8c207" version="1">Посвященный в магию: Кислотный всплеск</content>
+  <content contentuid="h70fd1410g49a4g44d1g9f8eg7f6bc1c21fea" version="1">Посвященный в магию: Друзья</content>
+  <content contentuid="ha6ce862fg4edeg49f7g9320gb8580541d70a" version="1">Посвященный в магию: Огненный снаряд</content>
+  <content contentuid="h97d2ab9cgaaf9g4bd4gb544g5862fb5d10b9" version="1">Посвященный в магию: Танцующие огоньки</content>
+  <content contentuid="hc5fa63acg91f7g498fg8be8g4f77f6e608e1" version="1">Посвященный в магию: Леденящее касание</content>
+  <content contentuid="h8cab8439g423ag41e7ga45bg7c1a4c23cde3" version="1">Посвященный в магию: Разрывающее сухожилие</content>
+  <content contentuid="h4def798ag029dg4d00g8d1eg8929e03098d6" version="1">Посвященный в магию: Громовой клинок</content>
+  <content contentuid="h83dc6116g533dg4e65g8c4ag7f3230f15b56" version="1">Посвященный в магию: Защита от оружия</content>
+  <content contentuid="hc43d9642g1590g42d6gbab6ga3dc6574eb50" version="1">Посвященный в магию: Наставление</content>
+  <content contentuid="haada0dc8gc767g45e4g98c2g6c5644d040c1" version="1">Посвященный в магию: Клинок зелёного пламени</content>
+  <content contentuid="h1e7a31c9g35c0g4b54g8f69g25b327a4c999" version="1">Посвященный в магию: Свет</content>
+  <content contentuid="hee3244d3g6916g4229gb4b7gd98a4f519f8e" version="1">Посвященный в магию: Волшебная рука</content>
+  <content contentuid="hd455a5aag6fb4g48ccgbec8gdf13c11a88ab" version="1">Посвященный в магию: Ментальная щепка</content>
+  <content contentuid="h965b7dc5ga4acg4b60g9e4bgcd236212e8b4" version="1">Посвященный в магию: Малая иллюзия</content>
+  <content contentuid="hcb1e67e1g69e7g4710g9cd5ga81a12763305" version="1">Посвященный в магию: Брызги яда</content>
+  <content contentuid="hf6e4b463g8945g4e41g8f63g065eb4ecdd0b" version="1">Посвященный в магию: Создание пламени</content>
+  <content contentuid="h4f7e0ea1g2ff6g48b2g937bg7cc4f590d0e7" version="1">Посвященный в магию: Фокус</content>
+  <content contentuid="h893b82a7g6490g43ebg981ag9315af05142b" version="1">Посвященный в магию: Луч холода</content>
+  <content contentuid="heda822d9g6ca8g4d69g862cg8e593ceb6f22" version="1">Посвященный в магию: Сопротивление</content>
+  <content contentuid="h04241b75g4f7eg40dagbac2g1acb8e2326f5" version="1">Посвященный в магию: Священное пламя</content>
+  <content contentuid="hdd5d9c2cg059eg4e76gb6b6g01e4d851171d" version="1">Посвященный в магию: Дубинка</content>
+  <content contentuid="h4527bdb1gf97cg4adcg9003g64255fe6abdf" version="1">Посвященный в магию: Поражающий захват</content>
+  <content contentuid="h29d6991cg8d76g4e4bga787g7f988a72fe15" version="1">Посвященный в магию: Уход за умирающим</content>
+  <content contentuid="hb163e2e9gb2d2g4adeg8801g80dbb2b50492" version="1">Посвященный в магию: Звёздный огонёк</content>
+  <content contentuid="h9f283e92g10dfg43b6g837dg39ee82977d4b" version="1">Посвященный в магию: Вспышка мечей</content>
+  <content contentuid="h66c0ac32gf014g42dag9841g3b01a76087d3" version="1">Посвященный в магию: Чудотворство</content>
+  <content contentuid="hc3c05220gcdefg4521g8152g4898ef5b675d" version="1">Посвященный в магию: Шипованный хлыст</content>
+  <content contentuid="h663fe553g789ag4344gba16g9856c5fe1f6c" version="1">Посвященный в магию: Громовой хлопок</content>
+  <content contentuid="h8a1afdf9g8010g4ad9gbda9ged21cac57381" version="1">Посвященный в магию: Погребальный звон</content>
+  <content contentuid="hfc64fd6bgba50g4748gaa9fg22adb16ff81b" version="1">Посвященный в магию: Меткий удар</content>
+  <content contentuid="hc24e0712g664bg4e59gad6fg394d985f4bfb" version="1">Посвященный в магию: Мстительный клинок</content>
+  <content contentuid="he02ce6f7gdbe0g4af4g8e20g9e0b3c31c653" version="1">Посвященный в магию: Слово сияния</content>
+  <content contentuid="hb0e3941dgfac2g426ag9ccdgee197b362bd8" version="1">Посвященный в магию: Святое слово</content>
+  <content contentuid="h749a56acgdc0fg4869g9757g0be1a08703ea" version="1">Посвященный в магию: Пугающее начало</content>
+  <content contentuid="h21645e9ag9d9cg418aga245g6a9015289552" version="1">Посвященный в магию: Дружба с животными</content>
+  <content contentuid="hdf583f63gea12g4423g9944g3daa981713d3" version="1">Посвященный в магию: Создание или уничтожение воды</content>
+  <content contentuid="hcc29c239gc13fg4023gb368g06aa956b1eb2" version="1">Посвященный в магию: Приказ</content>
+  <content contentuid="hce902b37g2b1fg4c69gb496g34f99e16b2db" version="1">Посвященный в магию: Цветной всплеск</content>
+  <content contentuid="hc3ea7a0bg4a33g447egab4cg59b3544f61a4" version="1">Посвященный в магию: Покров тени</content>
+  <content contentuid="h20d0eed4gb780g487cg8ab2g2a8f0df204ec" version="1">Посвященный в магию: Хроматическая сфера</content>
+  <content contentuid="hbcff1db6g661fg44b2gaa19ge984fa1cedb3" version="1">Посвященный в магию: Очарование личности</content>
+  <content contentuid="h32091888g9007g441cgb899gf48ab4745ec0" version="1">Посвященный в магию: Горящие руки</content>
+  <content contentuid="hb964961egd956g43e4gb1f4gbbd5199911f7" version="1">Посвященный в магию: Благословение</content>
+  <content contentuid="hcf286fcbga673g4b58g9ca2g7cb218338271" version="1">Посвященный в магию: Порча</content>
+  <content contentuid="h40603322g7144g4076ga600g816c1a3bf347" version="1">Посвященный в магию: Лечение ран</content>
+  <content contentuid="h21dc2164g914fg40f1g96f0g6370fd2112f5" version="1">Посвященный в магию: Опутывание</content>
+  <content contentuid="h1b472549g17edg4c6bgac27gf0b44463bc4c" version="1">Посвященный в магию: Спешное отступление</content>
+  <content contentuid="hffc26135gf1a3g4a40ga837gc93edb478e30" version="1">Посвященный в магию: Свет фей</content>
+  <content contentuid="h4ded108bga017g4608gbf95g21aa64af5306" version="1">Посвященный в магию: Фальшивая жизнь</content>
+  <content contentuid="haba60ef6g99aag4749g96b9g8d1f04316129" version="1">Посвященный в магию: Падение пёрышком</content>
+  <content contentuid="h38f40cc0g5620g4711g8d56gdd9c138dc7bf" version="1">Посвященный в магию: Поиск фамильяра</content>
+  <content contentuid="hf8e02fcbgdb8bg4268gb21cg13293d623b07" version="1">Посвященный в магию: Облако тумана</content>
+  <content contentuid="h7fe00d2bgea8ag4b0fgbbacgdbf44e74157c" version="1">Посвященный в магию: Добрая ягода</content>
+  <content contentuid="hc6e80bc7gdc11g4a8egafadg36b0c70eecad" version="1">Посвященный в магию: Жир</content>
+  <content contentuid="h06ce1335g4a93g488eg9ce8g7f24e3f055ce" version="1">Посвященный в магию: Направляющий снаряд</content>
+  <content contentuid="h050d8dc6gbc79g42dbg906dg75bd310a68ea" version="1">Посвященный в магию: Лечащее слово</content>
+  <content contentuid="h3ea7727eg6fb7g4437g8abfg5b8b01c08404" version="1">Посвященный в магию: Чудовищный смех</content>
+  <content contentuid="hdc5cb67eg6726g4f71ga0a5g19d3f916892d" version="1">Посвященный в магию: Ледяной нож</content>
+  <content contentuid="h86f50d94gf85eg4f54g9043g7300025a6b85" version="1">Посвященный в магию: Нанесение ран</content>
+  <content contentuid="h57c34580gbbf4g41acgbcb6g5f4b946ba3e2" version="1">Посвященный в магию: Прыжок</content>
+  <content contentuid="h931b6d31gbc0cg42a0ga0fdg6bf79513d2f8" version="1">Посвященный в магию: Скороход</content>
+  <content contentuid="h3cb9ecd6gc656g434eg9178g4828fbd9e74c" version="1">Посвященный в магию: Магический доспех</content>
+  <content contentuid="hc12ab9b5ga37dg4463g97c9gcfaef383ed25" version="1">Посвященный в магию: Волшебная стрела</content>
+  <content contentuid="h7380d024gd726g4ecbgaf7bg7053d764150b" version="1">Посвященный в магию: Защита от зла и добра</content>
+  <content contentuid="h8ec3e1ffgcbf4g4037g9bc0g84441c8fa842" version="1">Посвященный в магию: Луч болезни</content>
+  <content contentuid="h124523e9g22fbg4ef6g9eadg44197da47bfb" version="1">Посвященный в магию: Убежище</content>
+  <content contentuid="h2cd9127cg7278g4d0fgb936g380f15ea9889" version="1">Посвященный в магию: Щит</content>
+  <content contentuid="h2ad87388g142dg4348gbbedg0e1f69d37af7" version="1">Посвященный в магию: Щит веры</content>
+  <content contentuid="h11e7e65ag5981g4ae2g8c38gc618d023f94b" version="1">Посвященный в магию: Сон</content>
+  <content contentuid="hcacff426g1d0ag44e6g9598gd4e780c75798" version="1">Посвященный в магию: Разговор с животными</content>
+  <content contentuid="h5aa03de7gf337g42a1gb453ge89a6f671278" version="1">Посвященный в магию: Громовая волна</content>
+  <content contentuid="h4a25b113gd59eg4b37gb1fag1d64b4e65972" version="1">Посвященный в магию: Отпугивание</content>
+  <content contentuid="h4a465394gc707g4e0bga071g165709a73a35" version="1">Посвященный в магию: Ведьмин снаряд</content>
   <content contentuid="hb75003cbgf00cga299gd802g14c70c5d2869" version="1">Шарлатан</content>
-  <content contentuid="hcc3c36c6gd341g9ef3g75a6gd57375a199cd" version="3">Фит: Обученный
+  <content contentuid="hcc3c36c6gd341g9ef3g75a6gd57375a199cd" version="3">Черта: Обученный
 
 Ты — эксперт по манипуляции, склонный к преувеличениям и более чем радый извлечь из этого выгоду. Искажение правды и натравливание союзников друг на друга приведут к большему успеху в будущем.</content>
   <content contentuid="h4b835e70g04c6g5a06g0c6dg1a3127667686" version="1">Преступник</content>
-  <content contentuid="hbcaf83c9gb788g62e0g6965g3fa62228f254" version="3">Фит: Бдительный
+  <content contentuid="hbcaf83c9gb788g62e0g6965g3fa62228f254" version="3">Черта: Бдительный
 
 Ты имеешь историю нарушения закона и выживаешь, используя сомнительные связи. Извлечение выгоды из криминальной деятельности приведёт к новым возможностям в будущем.</content>
   <content contentuid="h71130c00gf7fegc295g7a78g226b23bab525" version="1">Артист</content>
-  <content contentuid="h2716640cg5333g5237g4376g52bc2bce3db6" version="3">Фит: Музыкант
+  <content contentuid="h2716640cg5333g5237g4376g52bc2bce3db6" version="3">Черта: Музыкант
 
 Ты живёшь, чтобы увлекать и подчинять свою аудиторию, привлекая как простую толпу, так и высшее общество. Сохранение искусства и принесение радости обездоленным и угнетённым усиливает твою харизматичную ауру.</content>
   <content contentuid="h08144bfegc7fbg3b4cg2a08gf4711304db2f" version="1">Народный герой</content>
-  <content contentuid="h16aa023egdc3cg5bc2g7476g71950aebff42" version="3">Фит: Выносливый
+  <content contentuid="h16aa023egdc3cg5bc2g7476g71950aebff42" version="3">Черта: Выносливый
 
 Ты — защитник простого народа, бросающий вызов тиранам и чудовищам ради защиты беспомощных. Спасение невинных от неминуемой опасности позволит твоей легенде расти.</content>
   <content contentuid="h8872efb5g9022g184cg8400gc8622021c434" version="1">Гильдейский ремесленник</content>
-  <content contentuid="hecaca218g03ebge2e3g1541g30dab1f4df21" version="3">Фит: Обученный
+  <content contentuid="hecaca218g03ebge2e3g1541g30dab1f4df21" version="3">Черта: Обученный
 
 Твоё мастерство в определённом ремесле позволило тебе вступить в торговую гильдию, дающую привилегии и защиту при занятии твоим искусством. Починка и обнаружение редких изделий принесут новое вдохновение.</content>
   <content contentuid="h68877c75g37c1gbf22gf33fg60fb10459cda" version="1">Дворянин</content>
-  <content contentuid="h11a3cb02g94efge2aagfd7eg2559e2181833" version="3">Фит: Обученный
+  <content contentuid="h11a3cb02g94efge2aagfd7eg2559e2181833" version="3">Черта: Обученный
 
 Ты вырос в семье социальной элиты, привыкнув к власти и привилегиям. Накопление славы, власти и преданности повысит твой статус.</content>
   <content contentuid="hdffa4c4fgb9e6g20ebg7a88g407a2ca29c32" version="1">Чужеземец</content>
-  <content contentuid="h5039598cg6db2g2d04g6e52gb5d4956c7773" version="3">Фит: Выносливый
+  <content contentuid="h5039598cg6db2g2d04g6e52gb5d4956c7773" version="3">Черта: Выносливый
 
 Ты вырос в диких землях, научившись выживать вдали от благ цивилизации. Преодоление необычных опасностей дикой природы усилит твоё мастерство и понимание.</content>
   <content contentuid="h95a25eaegdeafgb7b8g4801g7a8367fc65a7" version="1">Мудрец</content>
-  <content contentuid="hca28ebc2ga938g8c68g1dbag7edf639c41fc" version="3">Фит: Маг-недоучка (Волшебник)
+  <content contentuid="hca28ebc2ga938g8c68g1dbag7edf639c41fc" version="3">Черта: Посвященный в магию (Волшебник)
 
 Ты любопытен и начитан, с ненасытной жаждой знаний. Изучение редких преданий мира вдохновит тебя применить эти знания для более великих целей.</content>
   <content contentuid="h8109bc16gabcag925cgdd47gb46dba14be0c" version="1">Солдат</content>
-  <content contentuid="hc868035bgcc3dg4f6ag8137g0a3e325b8ba7" version="3">Фит: Свирепый атакующий
+  <content contentuid="hc868035bgcc3dg4f6ag8137g0a3e325b8ba7" version="3">Черта: Свирепый атакующий
 
 Ты обучен тактике боя и сражениям, служа в ополчении, наёмничьей компании или офицерском корпусе. Проявляй грамотную тактику и храбрость на поле боя, чтобы усилить своё мастерство.</content>
   <content contentuid="hc87a3f0fgaf2eg6057g69fbg9ba7b0e2f7bb" version="1">Беспризорник</content>
-  <content contentuid="h9f4e80c6g4dd1gb652gbb63g04b844b503ae" version="3">Фит: Свирепый атакующий
+  <content contentuid="h9f4e80c6g4dd1gb652gbb63g04b844b503ae" version="3">Черта: Свирепый атакующий
 
 Пережив бедное и мрачное детство, ты знаешь, как извлечь максимум из малого. Использование твоей уличной смекалки укрепит твой дух перед грядущим путешествием.</content>
-  <content contentuid="h15a25456g93c5g2128g2199gd75ca7acd724" version="1">Фит предыстории: Обученный</content>
+  <content contentuid="h15a25456g93c5g2128g2199gd75ca7acd724" version="1">Черта предыстории: Обученный</content>
   <content contentuid="h9c4f90acg7e1cg80f9g49b9g223423a07c77" version="1">Ты получаешь владение в любой комбинации из трёх навыков или инструментов по твоему выбору.</content>
   <content contentuid="h0b1ce19fg660ag4802g476bg8c05a68222d8" version="1">Обученный: Акробатика</content>
   <content contentuid="h0c81c67cgb4c6g4561g00beg5a12ada00691" version="1">Обученный: Уход за животными</content>
@@ -1007,28 +1007,28 @@
   <content contentuid="h4ba0cf67g55f2ge128g4fefg499a17387298" version="1">Анализ</content>
   <content contentuid="h58264943ge8a3g47cdg09c2gd71af9051c26" version="1">Медицина</content>
   <content contentuid="h5ec953edgae89gbe4fgbc37g46d66f973083" version="1">Ты получил владение этим навыком.</content>
-  <content contentuid="h641b1b35g1b60g780egb004g145a37f818b3" version="1">Фит предыстории: Бдительный</content>
-  <content contentuid="h45825d61g1009g094fgd261g57f7112238f9" version="1">Фит предыстории: Музыкант</content>
+  <content contentuid="h641b1b35g1b60g780egb004g145a37f818b3" version="1">Черта предыстории: Бдительный</content>
+  <content contentuid="h45825d61g1009g094fgd261g57f7112238f9" version="1">Черта предыстории: Музыкант</content>
   <content contentuid="h658ed514ge9dcg9a0fg207fg2dacf4e5e1ad" version="2">Обучение игре на инструментах. Ты получаешь владение тремя музыкальными инструментами.
 
 Воодушевляющая песня. При завершении Короткого или Долгого отдыха ты можешь сыграть песню на музыкальном инструменте, которым ты владеешь, и дать Бардское вдохновение союзникам, слышащим песню. Количество союзников, на которых ты так можешь повлиять, равно твоему Бонусу мастерства.</content>
   <content contentuid="h65160f8dg63e2g4feeg3550g6feca8c4a710" version="1">Воодушевляющая песня</content>
-  <content contentuid="he19df11dgdf2cg862cgbb31g4b99b16b69d4" version="1">Фит предыстории: Выносливый</content>
-  <content contentuid="h7cf9e06ag9d1dga32egceb0gbe819d69f976" version="1">Фит предыстории: Свирепый атакующий</content>
+  <content contentuid="he19df11dgdf2cg862cgbb31g4b99b16b69d4" version="1">Черта предыстории: Выносливый</content>
+  <content contentuid="h7cf9e06ag9d1dga32egceb0gbe819d69f976" version="1">Черта предыстории: Свирепый атакующий</content>
   <content contentuid="hdea0235fg740bg417fgb072ga3c6f349d4c3" version="1">При совершении атак оружием ты бросаешь кости урона дважды и используешь наибольший результат.</content>
   <content contentuid="h4c3975fag2626gb08fg2d75g1948720b803b" version="1">Преследуемый</content>
-  <content contentuid="h7177de01ge0f7g8a37g6b7cgdf616c3162ac" version="3">Фит: Бдительный
+  <content contentuid="h7177de01ge0f7g8a37g6b7cgdf616c3162ac" version="3">Черта: Бдительный
 
 Злобный момент, человек или нечто, что нельзя убить ни мечом, ни заклинанием, преследует твой разум и мелькает на периферии твоего зрения. Ты несёшь это, куда бы ни привели тебя приключения — или, возможно, это несёт тебя.</content>
-  <content contentuid="h474bba76g8c7bgfd74gc3c7g3360b0f62570" version="1">Фит предыстории: Везучий</content>
-  <content contentuid="h9adf9274g7e39g2ca0g6e19gf06b6f52aea1" version="1">Фит предыстории: Везучий</content>
-  <content contentuid="h6406ffe0g3bf9g37c9g6ad7g2ba1f01b1075" version="1">Фит предыстории: Кабацкий драчун</content>
+  <content contentuid="h474bba76g8c7bgfd74gc3c7g3360b0f62570" version="1">Черта предыстории: Везучий</content>
+  <content contentuid="h9adf9274g7e39g2ca0g6e19gf06b6f52aea1" version="1">Черта предыстории: Везучий</content>
+  <content contentuid="h6406ffe0g3bf9g37c9g6ad7g2ba1f01b1075" version="1">Черта предыстории: Кабацкий драчун</content>
   <content contentuid="h1f7fcfe8g6d82ga644g381cg16c2d77b873e" version="1">При совершении безоружных атак ты бросаешь кости урона дважды и используешь наибольший результат.</content>
   <content contentuid="h2d1c35beg6336gdd1eg258dg69afd0b6b19f" version="1">Атлет</content>
   <content contentuid="he017d973g0291gbe65g86dbgfc62954d6af5" version="3">Быстрый подъём. Пока ты находишься в состоянии Распростёрт, ты можешь встать, потратив только 5 футов движения.
 
 Прыжок. Один раз за ход ты можешь совершить Прыжок, потратив только 10 футов движения.</content>
-  <content contentuid="h4fa37f8dgea0ag8e9eg9222g12cdf8ef50af" version="1">Фит: Атлет</content>
+  <content contentuid="h4fa37f8dgea0ag8e9eg9222g12cdf8ef50af" version="1">Черта: Атлет</content>
   <content contentuid="hac8cf59bgb29dg6896g2a11g689bf333570e" version="3">Быстрый подъём. Пока ты находишься в состоянии Распростёрт, ты можешь встать, потратив только 5 футов движения.
 
 Прыжок. Один раз за ход ты можешь совершить Прыжок, потратив только 10 футов движения.</content>
@@ -1036,7 +1036,7 @@
   <content contentuid="h9ed109c6ga680g6d73gce1ag6e136e676cb2" version="2">Улучшенный рывок. При совершении действия Рывок твоя Скорость увеличивается на 10 футов для этого действия.
 
 Атака с разгона. Если ты перемещаешься минимум на 10 футов по прямой линии к цели непосредственно перед попаданием по ней броском ближней атаки как частью действия Атаки, выбери один из следующих эффектов: получи бонус 1d8 к броску урона атаки или оттолкни цель до 10 футов, если она не более чем на одну категорию размера больше тебя. Ты можешь использовать это преимущество только один раз в каждый свой ход.</content>
-  <content contentuid="hbc6e4744g6835g4d25g3453g224b9eed2a70" version="1">Фит: Налётчик</content>
+  <content contentuid="hbc6e4744g6835g4d25g3453g224b9eed2a70" version="1">Черта: Налётчик</content>
   <content contentuid="h4e972de5g72bbgc7d9gfda3g1c89f2af41d0" version="2">Улучшенный рывок. При совершении действия Рывок твоя Скорость увеличивается на 10 футов для этого действия.
 
 Атака с разгона. Если ты перемещаешься минимум на 10 футов по прямой линии к цели непосредственно перед попаданием по ней броском ближней атаки как частью действия Атаки, выбери один из следующих эффектов: получи бонус 1d8 к броску урона атаки или оттолкни цель до 10 футов, если она не более чем на одну категорию размера больше тебя. Ты можешь использовать это преимущество только один раз в каждый свой ход.</content>
@@ -1044,18 +1044,18 @@
   <content contentuid="hc7b891e9gd9c0g1617g0233ga492c5e47dc7" version="2">Стрельба в ближнем бою. Нахождение в пределах 5 футов от врага не налагает Помеху на броски атаки из арбалета.
 
 Ранящий болт. При попадании по существу дальней атакой есть шанс перевести его в состояние &lt;LSTag Type="Status" Tooltip="GAPING_WOUND"&gt;Зияющая рана&lt;/LSTag&gt;.</content>
-  <content contentuid="h2b11e796g7a1fga346gb3e4g85e96274b6ef" version="1">Фит: Мастер арбалета (Ранящий)</content>
+  <content contentuid="h2b11e796g7a1fga346gb3e4g85e96274b6ef" version="1">Черта: Мастер арбалета (Ранящий)</content>
   <content contentuid="h48bb1d7fga4e5g9f8fga414g0fe42c7616ac" version="1">При попадании по существу дальней атакой есть шанс перевести его в состояние &lt;LSTag Type="Status" Tooltip="GAPING_WOUND"&gt;Зияющая рана&lt;/LSTag&gt;.</content>
-  <content contentuid="h9dde7fdcgac74g74cag98d7g044c58ef3023" version="1">Фит: Мастер арбалета (В упор)</content>
+  <content contentuid="h9dde7fdcgac74g74cag98d7g044c58ef3023" version="1">Черта: Мастер арбалета (В упор)</content>
   <content contentuid="h32eff9e8g416dgc4dagd8e6g74260b215e68" version="1">Защитный дуэлянт</content>
   <content contentuid="hd032f660g8a39g73eagc4bdgd4038c7dc8de" version="2">Парирование. Если ты держишь Изящное оружие и другое существо попадает по тебе ближней атакой, ты можешь использовать Реакцию, чтобы добавить свой Бонус мастерства к Классу доспеха, потенциально заставив атаку промахнуться. Ты получаешь этот бонус к КД против ближних атак до начала твоего следующего хода.</content>
-  <content contentuid="h208b7de3g5f3cge001gfe82gdd2940dee59c" version="1">Фит: Защитный дуэлянт</content>
+  <content contentuid="h208b7de3g5f3cge001gfe82gdd2940dee59c" version="1">Черта: Защитный дуэлянт</content>
   <content contentuid="hfd0b3091g52f6g2cd7ga7cbg9c61332d3252" version="1">Парирование. Если ты держишь Изящное оружие и другое существо попадает по тебе ближней атакой, ты можешь использовать Реакцию, чтобы добавить свой Бонус мастерства к Классу доспеха, потенциально заставив атаку промахнуться. Ты получаешь этот бонус к КД против ближних атак до начала твоего следующего хода.</content>
   <content contentuid="hfa2c5254ge5fag62b7gffb6g392787c61974" version="1">Боец с двумя оружиями</content>
   <content contentuid="h2d809685g28ffge26ag3e6ag5fa20f63c9e3" version="7">Ты можешь использовать Сражение двумя оружиями, даже если твоё оружие не &lt;LSTag Tooltip="Light"&gt;Лёгкое&lt;/LSTag&gt;. Ты не можешь использовать &lt;LSTag Tooltip="TwoHanded"&gt;Двуручное&lt;/LSTag&gt; оружие в обеих руках.&lt;br&gt;&lt;br&gt;Когда ты совершаешь действие Атаки в свой ход и атакуешь рукопашным оружием, ты можешь совершить одну Атаку второй рукой как Бонусное действие позже в этом же ходу. Если ты освоил свойство Nick и у тебя в другой руке экипировано оружие со свойством Nick, ты можешь совершить до двух Атак второй рукой за ход.</content>
-  <content contentuid="h720a62a8g5de9g9909gb1cagf61131cf2df9" version="1">Фит: Боец с двумя оружиями (Бонусная атака)</content>
+  <content contentuid="h720a62a8g5de9g9909gb1cagf61131cf2df9" version="1">Черта: Боец с двумя оружиями (Бонусная атака)</content>
   <content contentuid="h5cc813aagcb96gf7f3g42e4g17b7234b86eb" version="1">Ты можешь совершить одну атаку второй рукой, не тратя действие или бонусное действие. Ты можешь использовать это преимущество один раз за ход.</content>
-  <content contentuid="h7ed3574cg898aga3cage4bcg72bfa5e60a5c" version="1">Фит: Боец с двумя оружиями</content>
+  <content contentuid="h7ed3574cg898aga3cage4bcg72bfa5e60a5c" version="1">Черта: Боец с двумя оружиями</content>
   <content contentuid="hb2bf6fc5g6c41geefag4186g751dda5c0a20" version="1">Атака второй рукой (Боец с двумя оружиями)</content>
   <content contentuid="hfba39959g9b2dg1bffgffd6g069588fe122e" version="1">Исследователь подземелий</content>
   <content contentuid="h9dd8a551g9f01g98dbg64f1ga485e59f0e9d" version="2">Ты получаешь &lt;LSTag Tooltip="Advantage"&gt;Преимущество&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;Проверки&lt;/LSTag&gt; Восприятия для обнаружения скрытых объектов и на &lt;LSTag Tooltip="SavingThrow"&gt;Спасброски&lt;/LSTag&gt; для избежания или сопротивления ловушкам.
@@ -1071,34 +1071,34 @@
   <content contentuid="h00f044d5gf4edgc900g397bgca53d410bdad" version="2">Мастерство тяжёлого оружия. При попадании по существу оружием со свойством Тяжёлое как частью действия Атаки в свой ход ты можешь заставить оружие нанести цели дополнительный урон. Дополнительный урон равен твоему Бонусу мастерства.
 
 Размах. Сразу после Критического попадания рукопашным оружием или сведения существа к 0 очков здоровья с его помощью ты можешь совершить одну атаку тем же оружием как Бонусное действие.</content>
-  <content contentuid="h349877e7geb40gb92agf0ebg6d7a8824b88d" version="1">Фит: Мастер большого оружия</content>
+  <content contentuid="h349877e7geb40gb92agf0ebg6d7a8824b88d" version="1">Черта: Мастер большого оружия</content>
   <content contentuid="hf5c74f9cg9d34g5f2dgb774g506b6adf6782" version="1">Мастерство тяжёлого оружия. При попадании по существу оружием со свойством Тяжёлое как частью действия Атаки в свой ход ты можешь заставить оружие нанести цели дополнительный урон. Дополнительный урон равен твоему Бонусу мастерства.
 
 Размах. Сразу после Критического попадания рукопашным оружием или сведения существа к 0 очков здоровья с его помощью ты можешь совершить одну атаку тем же оружием как Бонусное действие.</content>
-  <content contentuid="h3b239dc5gf9c8g1abcgc84eg956c665ab218" version="1">Фит: Тяжёлый доспех</content>
+  <content contentuid="h3b239dc5gf9c8g1abcgc84eg956c665ab218" version="1">Черта: Тяжёлый доспех</content>
   <content contentuid="h8f67f4a8ga475g09e8gd009gab416f216b09" version="1">Ты имеешь &lt;LSTag Tooltip="ArmourProficiency"&gt;Владение доспехом&lt;/LSTag&gt; категории Тяжёлые доспехи.</content>
   <content contentuid="h9d48061fg5f17gd0d7gcc47g4d36f5a2b812" version="1">Тяжёлый доспех</content>
   <content contentuid="h514d8491g4149gd42dgac44g49eb428cfab7" version="1">Ты получаешь &lt;LSTag Tooltip="ArmourProficiency"&gt;Владение доспехом&lt;/LSTag&gt; категории Тяжёлые доспехи.</content>
   <content contentuid="h839231bbgeb1bg509bgdb9cge3286fb2cd64" version="1">Мастер тяжёлого доспеха</content>
   <content contentuid="h0266d9b6g2d5egdfa6g1bfag6db68cf5e3ff" version="1">Снижение урона. При попадании по тебе атакой, пока ты носишь Тяжёлые доспехи, любой Дробящий, Колющий и Рубящий урон, наносимый тебе этой атакой, уменьшается на величину, равную твоему Бонусу мастерства.</content>
-  <content contentuid="h05dbc595g938dgf8c5geb8ag232d7f8f255a" version="1">Фит: Мастер тяжёлого доспеха</content>
+  <content contentuid="h05dbc595g938dgf8c5geb8ag232d7f8f255a" version="1">Черта: Мастер тяжёлого доспеха</content>
   <content contentuid="h321dea39gd6d7g8505g1460ga4f1c96684b4" version="1">Снижение урона. При попадании по тебе атакой, пока ты носишь Тяжёлые доспехи, любой Дробящий, Колющий и Рубящий урон, наносимый тебе этой атакой, уменьшается на величину, равную твоему Бонусу мастерства.</content>
   <content contentuid="h494aa429g631cgf105g1994g4c64836d3f3d" version="1">Лёгкий доспех</content>
   <content contentuid="h1bf3ecc0g938dg39f4g8e16gfe946978878f" version="1">Обучение доспеху. Ты получаешь обучение владению Лёгкими доспехами и Щитами.</content>
-  <content contentuid="h97c3576bg651bg7e79g4da8g9dde54eb141f" version="1">Фит: Лёгкий доспех</content>
+  <content contentuid="h97c3576bg651bg7e79g4da8g9dde54eb141f" version="1">Черта: Лёгкий доспех</content>
   <content contentuid="hd9e3a2b4g854eg51fcg7859gb22843f1ee76" version="1">Обучение доспеху. Ты получаешь обучение владению Лёгкими доспехами и Щитами.</content>
   <content contentuid="heb622813gde8ag8560g8db8ga20dd3f55a1c" version="1">Убийца магов</content>
   <content contentuid="h97c2a4b1gf596g1516g285eg988549b0ed6f" version="1">Нарушитель концентрации. При нанесении урона существу, поддерживающему концентрацию, оно получает Помеху на спасбросок для поддержания Концентрации.
 
 Защищённый разум. При провале спасброска Интеллекта, Мудрости или Харизмы ты можешь заставить себя преуспеть вместо этого. После использования этого преимущества ты не можешь использовать его снова до завершения Короткого или Долгого отдыха.</content>
-  <content contentuid="h686b506cg3f99g1c96gdcfcgfd54e5d46f19" version="1">Фит: Убийца магов</content>
+  <content contentuid="h686b506cg3f99g1c96gdcfcgfd54e5d46f19" version="1">Черта: Убийца магов</content>
   <content contentuid="hfc9071adg34ddg859egdda4g444a72c4713f" version="1">Нарушитель концентрации. При нанесении урона существу, поддерживающему концентрацию, оно получает Помеху на спасбросок для поддержания Концентрации.
 
 Защищённый разум. При провале спасброска Интеллекта, Мудрости или Харизмы ты можешь заставить себя преуспеть вместо этого. После использования этого преимущества ты не можешь использовать его снова до завершения Короткого или Долгого отдыха.</content>
   <content contentuid="h64d74f86g3068g8d76g0cd1g2ed854b87962" version="1">Защищённый разум</content>
   <content contentuid="hd944c877g9f95g1749ge647gfe18b6b31562" version="1">При провале спасброска Интеллекта, Мудрости или Харизмы ты можешь заставить себя преуспеть вместо этого. После использования этого преимущества ты не можешь использовать его снова до завершения Короткого или Долгого отдыха.</content>
-  <content contentuid="hf3cb4188g698ag0e09ge5b7g7087f12e55e8" version="1">Фит: Воинский адепт</content>
-  <content contentuid="h8c96ebffgfa30ge6e9g2670ge4e2af8fb180" version="1">Фит: Мастер среднего доспеха</content>
+  <content contentuid="hf3cb4188g698ag0e09ge5b7g7087f12e55e8" version="1">Черта: Воинский адепт</content>
+  <content contentuid="h8c96ebffgfa30ge6e9g2670ge4e2af8fb180" version="1">Черта: Мастер среднего доспеха</content>
   <content contentuid="h9f345cf4g20e3g3adbg0568g4c6d7a467ed6" version="2">Стремительный</content>
   <content contentuid="h9aba9e0ag4af1g9f8fg922ag7e65e5b8a86b" version="2">Увеличение скорости. Твоя Скорость увеличивается на 10 футов.
 
@@ -1107,13 +1107,13 @@
 Ловкое перемещение. Атаки по возможности имеют Помеху против тебя.</content>
   <content contentuid="h8eacabe1gf4e0g46a9g32adg16f61a4b3530" version="1">Средний доспех</content>
   <content contentuid="h9683622cg2b30ga13egcae5g1c9525ef5014" version="1">Ты получаешь &lt;LSTag Tooltip="ArmourProficiency"&gt;Владение доспехом&lt;/LSTag&gt; категории Средние доспехи и щитами, а твоя &lt;LSTag Tooltip="Strength"&gt;Сила&lt;/LSTag&gt; или &lt;LSTag Tooltip="Dexterity"&gt;Ловкость&lt;/LSTag&gt; увеличивается на 1, до максимума 20.</content>
-  <content contentuid="h064d8f79g7d9eg262fg76e0g2d04ce1515a6" version="2">Фит: Стремительный</content>
+  <content contentuid="h064d8f79g7d9eg262fg76e0g2d04ce1515a6" version="2">Черта: Стремительный</content>
   <content contentuid="h1ea9a52fg1499gbdd8g9ab4g8e8ff63c7f3f" version="1">Увеличение скорости. Твоя Скорость увеличивается на 10 футов.
 
 Рывок по сложной местности. При совершении действия Рывок в свой ход Сложная местность не требует от тебя дополнительного перемещения до конца этого хода.
 
 Ловкое перемещение. Атаки по возможности имеют Помеху против тебя.</content>
-  <content contentuid="hcece8c3cgbda0g0cf1g3872g9d5fba9e3f61" version="1">Фит: Средний доспех</content>
+  <content contentuid="hcece8c3cgbda0g0cf1g3872g9d5fba9e3f61" version="1">Черта: Средний доспех</content>
   <content contentuid="hae25381bgef2fgb3e0ga319g98ed9f6981b8" version="1">Везучий</content>
   <content contentuid="h8708a627g8357g1f81g5bfdgc87a5b00b9fe" version="1">Ты получаешь количество &lt;LSTag Type="ActionResource" Tooltip="LuckPoint"&gt;Очков удачи&lt;/LSTag&gt;, равное твоему бонусу мастерства. Ты можешь использовать эти очки для получения &lt;LSTag Tooltip="Advantage"&gt;Преимущества&lt;/LSTag&gt; на &lt;LSTag Tooltip="AttackRoll"&gt;Броски атаки&lt;/LSTag&gt;, &lt;LSTag Tooltip="AbilityCheck"&gt;Проверки характеристики&lt;/LSTag&gt; или &lt;LSTag Tooltip="SavingThrow"&gt;Спасброски&lt;/LSTag&gt;, или чтобы заставить врага перебросить &lt;LSTag Tooltip="AttackRoll"&gt;Бросок атаки&lt;/LSTag&gt;.</content>
   <content contentuid="h03f42ae5g766bg7991gbcd3gacac23773d6c" version="1">Музыкант</content>
@@ -1128,31 +1128,31 @@
   <content contentuid="h215cfcadg8e38gf1d3g5cbfgf68a823d6955" version="1">Удар древком. Сразу после совершения действия Атаки и атаки Посохом, Копьём или оружием со свойствами Тяжёлое и С досягаемостью ты можешь использовать Бонусное действие для ближней атаки противоположным концом оружия. Оружие наносит Дробящий урон, а кость урона оружия для этой атаки — d4.
 
 Реактивная атака. Пока ты держишь Посох, Копьё или оружие со свойствами Тяжёлое и С досягаемостью, ты можешь использовать Реакцию для одной ближней атаки по существу, вошедшему в досягаемость этого оружия.</content>
-  <content contentuid="h0e159707gedcdgecceg7084geda7d6596f4b" version="1">Фит: Мастер древкового оружия</content>
+  <content contentuid="h0e159707gedcdgecceg7084geda7d6596f4b" version="1">Черта: Мастер древкового оружия</content>
   <content contentuid="h3dd5e7b4g4865gbd7bged74gd82f6e53d20d" version="1">Удар древком. Сразу после совершения действия Атаки и атаки Посохом, Копьём или оружием со свойствами Тяжёлое и С досягаемостью ты можешь использовать Бонусное действие для ближней атаки противоположным концом оружия. Оружие наносит Дробящий урон, а кость урона оружия для этой атаки — d4.
 
 Реактивная атака. Пока ты держишь Посох, Копьё или оружие со свойствами Тяжёлое и С досягаемостью, ты можешь использовать Реакцию для одной ближней атаки по существу, вошедшему в досягаемость этого оружия.</content>
-  <content contentuid="h8279b78cg9f64gf40egab20gf3b5ab80bc72" version="2">Фит: Стойкий (Харизма)</content>
-  <content contentuid="h5e27ad01ga610ga42cgc65dg1ce99d93cdf8" version="1">Фит предыстории: Маг-недоучка (Волшебник)</content>
-  <content contentuid="h264cac24g55adg2b42g5689g9ac57b287ff0" version="1">Фит: Стойкий (Телосложение)</content>
-  <content contentuid="h4d896d4bg38ffgb852ge9c4g321634de4a1d" version="1">Фит: Стойкий (Ловкость)</content>
-  <content contentuid="h28f453f2gecbagbf36g9580ga18155f4ed7c" version="1">Фит: Стойкий (Интеллект)</content>
-  <content contentuid="ha5d92735g8afdga8f3ge1c5g5b06d62a50e6" version="1">Фит: Стойкий (Сила)</content>
-  <content contentuid="he4365c80ga72cgc5ebg1ae0g6a84db454a82" version="1">Фит: Стойкий (Мудрость)</content>
+  <content contentuid="h8279b78cg9f64gf40egab20gf3b5ab80bc72" version="2">Черта: Стойкий (Харизма)</content>
+  <content contentuid="h5e27ad01ga610ga42cgc65dg1ce99d93cdf8" version="1">Черта предыстории: Посвященный в магию (Волшебник)</content>
+  <content contentuid="h264cac24g55adg2b42g5689g9ac57b287ff0" version="1">Черта: Стойкий (Телосложение)</content>
+  <content contentuid="h4d896d4bg38ffgb852ge9c4g321634de4a1d" version="1">Черта: Стойкий (Ловкость)</content>
+  <content contentuid="h28f453f2gecbagbf36g9580ga18155f4ed7c" version="1">Черта: Стойкий (Интеллект)</content>
+  <content contentuid="ha5d92735g8afdga8f3ge1c5g5b06d62a50e6" version="1">Черта: Стойкий (Сила)</content>
+  <content contentuid="he4365c80ga72cgc5ebg1ae0g6a84db454a82" version="1">Черта: Стойкий (Мудрость)</content>
   <content contentuid="h1015def7gafdbg59d8g86d2g26b83e1c4b9e" version="1">Дозорный</content>
-  <content contentuid="h531047f9gd6d4g5415g3f87gada7b4be2fa4" version="1">Когда враг в зоне ближнего боя атакует союзника, ты можешь использовать &lt;LSTag Type="ActionResource" Tooltip="ReactionActionPoint"&gt;реакцию&lt;/LSTag&gt; для атаки оружием по этому врагу. Союзник не должен иметь фит Дозорный.
+  <content contentuid="h531047f9gd6d4g5415g3f87gada7b4be2fa4" version="1">Когда враг в зоне ближнего боя атакует союзника, ты можешь использовать &lt;LSTag Type="ActionResource" Tooltip="ReactionActionPoint"&gt;реакцию&lt;/LSTag&gt; для атаки оружием по этому врагу. Союзник не должен иметь черты Дозорный.
 
 Ты получаешь &lt;LSTag Tooltip="Advantage"&gt;Преимущество&lt;/LSTag&gt; на &lt;LSTag Tooltip="OpportunityAttack"&gt;Атаки по возможности&lt;/LSTag&gt;, и при попадании по существу Атакой по возможности оно больше не может перемещаться до конца своего хода.</content>
-  <content contentuid="h7e48c498g5f4dgcd45g58fdgd35b898ea7df" version="1">Фит: Дозорный (Возмездие)</content>
-  <content contentuid="h23b78c62ge069ge2ccg2684g43996096895b" version="1">Фит: Дозорный (Преимущество возможности)</content>
-  <content contentuid="h5fb8bed9g9cd0g8557g68degf654e2c0ae58" version="1">Фит: Дозорный (Западня)</content>
+  <content contentuid="h7e48c498g5f4dgcd45g58fdgd35b898ea7df" version="1">Черта: Дозорный (Возмездие)</content>
+  <content contentuid="h23b78c62ge069ge2ccg2684g43996096895b" version="1">Черта: Дозорный (Преимущество возможности)</content>
+  <content contentuid="h5fb8bed9g9cd0g8557g68degf654e2c0ae58" version="1">Черта: Дозорный (Западня)</content>
   <content contentuid="h90887d29g0a12g4a4eg7f87ga23f7765f7dc" version="1">Меткий стрелок</content>
   <content contentuid="h5b4e785ag06afgf727gca99g7e0aa28facda" version="3">Игнорирование укрытия. Твои &lt;LSTag Tooltip="RangedWeaponAttack"&gt;дальнобойные атаки оружием&lt;/LSTag&gt; не получают штрафов от &lt;LSTag Tooltip="HighGroundRules"&gt;Правил превосходства по высоте&lt;/LSTag&gt;.
 
 Стрельба в ближнем бою. Нахождение в пределах 5 футов от врага не налагает Помеху на броски атаки из дальнобойного оружия.
 
 Дальние выстрелы. Атака двуручным дальнобойным оружием увеличивает его обычную дальность до 90 футов.</content>
-  <content contentuid="ha55fe95cgd504gfcc1gb585g1162cb7cffcc" version="1">Фит: Меткий стрелок</content>
+  <content contentuid="ha55fe95cgd504gfcc1gb585g1162cb7cffcc" version="1">Черта: Меткий стрелок</content>
   <content contentuid="hb219036fg4365gffedg71d5g938331069179" version="2">Игнорирование укрытия. Твои &lt;LSTag Tooltip="RangedWeaponAttack"&gt;дальнобойные атаки оружием&lt;/LSTag&gt; не получают штрафов от &lt;LSTag Tooltip="HighGroundRules"&gt;Правил превосходства по высоте&lt;/LSTag&gt;.
 
 Стрельба в ближнем бою. Нахождение в пределах 5 футов от врага не налагает Помеху на броски атаки из дальнобойного оружия.
@@ -1162,7 +1162,7 @@
   <content contentuid="he75553c3gd15ag322eg1dcega59ac6593319" version="4">Удар щитом. Если ты атакуешь существо в пределах 5 футов от тебя как частью действия Атаки и попадаешь рукопашным оружием, ты можешь немедленно ударить цель Щитом, если он экипирован, заставив цель совершить спасбросок Силы (СЛ 8 плюс модификатор Силы и Бонус мастерства). При провале ты либо отталкиваешь цель на 5 футов, либо переводишь её в состояние Распростёрт (на твой выбор). Ты можешь использовать это преимущество только один раз в каждый свой ход.
 
 Подставить щит. При подвержении эффекту, позволяющему совершить спасбросок Ловкости для получения только половины урона, ты можешь использовать Реакцию, чтобы не получить урона при успешном спасброске, если держишь Щит.</content>
-  <content contentuid="h99a1f866g5649g1e74gc90fgd29c50fa0426" version="1">Фит: Мастер щита</content>
+  <content contentuid="h99a1f866g5649g1e74gc90fgd29c50fa0426" version="1">Черта: Мастер щита</content>
   <content contentuid="h5752835cge17egb9e8g58cdgb5e2500ab72d" version="3">Удар щитом. Если ты атакуешь существо в пределах 5 футов от тебя как частью действия Атаки и попадаешь рукопашным оружием, ты можешь немедленно ударить цель Щитом, если он экипирован, заставив цель совершить спасбросок Силы (СЛ 8 плюс модификатор Силы и Бонус мастерства). При провале ты либо отталкиваешь цель на 5 футов, либо переводишь её в состояние Распростёрт (на твой выбор). Ты можешь использовать это преимущество только один раз в каждый свой ход.
 
 Подставить щит. При подвержении эффекту, позволяющему совершить спасбросок Ловкости для получения только половины урона, ты можешь использовать Реакцию, чтобы не получить урона при успешном спасброске, если держишь Щит.</content>
@@ -1176,7 +1176,7 @@
 Сотворение в ближнем бою. Нахождение в пределах 5 футов от врага не налагает Помеху на броски атаки заклинаниями.
 
 Увеличенная дальность. Увеличь дальность заклинаний на 50%.</content>
-  <content contentuid="h83a93112gc496g26f6g27f3ge5d63171ca0b" version="2">Фит: Магический снайпер (Дальний бой)</content>
+  <content contentuid="h83a93112gc496g26f6g27f3ge5d63171ca0b" version="2">Черта: Магический снайпер (Дальний бой)</content>
   <content contentuid="h14ab49cfg831ag83b9g1ddcgbadda155b2c0" version="2">Игнорирование укрытия. Твои дальнобойные атаки заклинаниями не получают штрафов от &lt;LSTag Tooltip="HighGroundRules"&gt;Правил превосходства по высоте&lt;/LSTag&gt;.
 
 Увеличенная дальность. Увеличь дальность заклинаний на 50%.</content>
@@ -1188,13 +1188,13 @@
   <content contentuid="h71ada843g58a3g712bgd82agc840de1595e5" version="2">Ты получаешь &lt;LSTag Tooltip="Proficiency"&gt;владение&lt;/LSTag&gt; воинским оружием.
 
 Ты получаешь два свойства мастерства оружия на свой выбор.</content>
-  <content contentuid="h70813330g91cdg841fgd506g43cca562e934" version="1">Фит: Снайпер заклинаний (ближний бой)</content>
+  <content contentuid="h70813330g91cdg841fgd506g43cca562e934" version="1">Черта: Снайпер заклинаний (ближний бой)</content>
   <content contentuid="hd8edfd84g6945ged2dg5a75gac1ea9cf87c7" version="1">Сотворение в ближнем бою. Нахождение в пределах 5 футов от врага не накладывает помеху на твои броски атаки заклинаниями.</content>
-  <content contentuid="he811ea2cg5f7ega90cgc208g301ddc5eb96c" version="1">Фит: Воинский заклинатель</content>
+  <content contentuid="he811ea2cg5f7ega90cgc208g301ddc5eb96c" version="1">Черта: Воинский заклинатель</content>
   <content contentuid="h2d86c838g5e8cg8763gdf9bgaeb1290ded87" version="1">Ты получаешь &lt;LSTag Tooltip="Advantage"&gt;преимущество&lt;/LSTag&gt; на &lt;LSTag Tooltip="SavingThrow"&gt;спасброски&lt;/LSTag&gt; для поддержания &lt;LSTag Tooltip="Concentration"&gt;концентрации&lt;/LSTag&gt; на заклинании.
 
 Ты можешь использовать &lt;LSTag Type="ActionResource" Tooltip="ReactionActionPoint"&gt;реакцию&lt;/LSTag&gt;, чтобы сотворить &lt;LSTag Type="Spell" Tooltip="Target_ShockingGrasp"&gt;Хватку молнии&lt;/LSTag&gt; по цели, выходящей из зоны ближнего боя.</content>
-  <content contentuid="h6f27cfe3g88f5geb3eg8790gd6ce157dfac9" version="1">Фит: Мастер оружия</content>
+  <content contentuid="h6f27cfe3g88f5geb3eg8790gd6ce157dfac9" version="1">Черта: Мастер оружия</content>
   <content contentuid="hba5a50e4g4e44gccaag18b0ga7d653029db5" version="3">Ты получаешь &lt;LSTag Tooltip="Proficiency"&gt;владение&lt;/LSTag&gt; воинским оружием.
 
 Ты получаешь два свойства мастерства оружия на свой выбор.</content>
@@ -1311,7 +1311,7 @@
   <content contentuid="hbb6b628eg2a57g6250g3b13g87d1d2155d94" version="1">Каждый раз, когда существо совершает бросок атаки против тебя до окончания заклинания, атакующий вычитает 1d4 из броска атаки.</content>
   <content contentuid="h9272c5c1g1dc9g193fg385dg4ccea106a7ad" version="1">Каждый раз, когда существо совершает бросок атаки против тебя до окончания заклинания, атакующий вычитает 1d4 из броска атаки.</content>
   <content contentuid="h4405cd9eg35f5g6fa4g01c6g020ed526c1e0" version="1">Каждый раз, когда существо совершает бросок атаки против тебя до окончания заклинания, атакующий вычитает 1d4 из броска атаки.</content>
-  <content contentuid="h6bbeea0cgfb9cg7197g9d87gc41ed5911b46" version="1">Оберег клинка</content>
+  <content contentuid="h6bbeea0cgfb9cg7197g9d87gc41ed5911b46" version="1">Защита от оружия</content>
   <content contentuid="h6ad2bdeag8e58g6b4fg3462g9aff44485001" version="1">Воплощение жнеца</content>
   <content contentuid="h8ccd7ec2g9ed6g29bdgcacfg269b2a087595" version="1">%%% EMPTY</content>
   <content contentuid="h2bed4266gaf46g07f6g40a0gfb3ed759c291" version="1">Непоколебимый</content>
@@ -1432,78 +1432,78 @@
   <content contentuid="hc704bd0ag2056geb75gf781g2a3b1ef159c5" version="1">Ты можешь пересотворить заклинание, не тратя ячейку заклинания и не используя действие.</content>
   <content contentuid="h272e8b3fg32bcg9272g86a0g32a43e6b7889" version="1">Пересотворение тьмы</content>
   <content contentuid="h191d3b3cg589agc29bg69e9g143e19f63834" version="1">Ты можешь пересотворить заклинание, не тратя ячейку заклинания и не используя действие.</content>
-  <content contentuid="hb302549egc54bg5a4dgbcedg1c098cc541f2" version="1">Порча</content>
+  <content contentuid="hb302549egc54bg5a4dgbcedg1c098cc541f2" version="1">Сглаз</content>
   <content contentuid="h15d4347egf4adg1955g7c5agb0611504409c" version="1">Заставь свои атаки наносить цели дополнительные [1] урона и дай ей &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="Abilities"&gt;характеристику&lt;/LSTag&gt; по твоему выбору.</content>
-  <content contentuid="h1468dc42g4e8bg6f7fg3c71g087f5298ce17" version="1">Если цель умрёт до окончания заклинания, ты можешь наложить порчу на новое существо, не тратя &lt;LSTag Tooltip="SpellSlot"&gt;ячейку заклинания&lt;/LSTag&gt;.</content>
-  <content contentuid="h94cfdb63g5f9bgb908ga1b4g49a999286692" version="1">Порча (Сила)</content>
+  <content contentuid="h1468dc42g4e8bg6f7fg3c71g087f5298ce17" version="1">Если цель умрёт до окончания заклинания, ты можешь наложить сглаз на новое существо, не тратя &lt;LSTag Tooltip="SpellSlot"&gt;ячейку заклинания&lt;/LSTag&gt;.</content>
+  <content contentuid="h94cfdb63g5f9bgb908ga1b4g49a999286692" version="1">Сглаз (Сила)</content>
   <content contentuid="h7a57f594g5b53g2b67g6e93g91c13a46a6ae" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Силы.</content>
-  <content contentuid="h987bc8d8gdf36gc7bcg7594gb66a908bf0c3" version="1">Порча (Ловкость)</content>
+  <content contentuid="h987bc8d8gdf36gc7bcg7594gb66a908bf0c3" version="1">Сглаз (Ловкость)</content>
   <content contentuid="h41db93b6g0ef1ge843g94a8ga0ab1175d337" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Ловкости.</content>
-  <content contentuid="h8ce4327cg50e9g7d5cgb46eg76e0ef7894c5" version="1">Порча (Телосложение)</content>
+  <content contentuid="h8ce4327cg50e9g7d5cgb46eg76e0ef7894c5" version="1">Сглаз (Телосложение)</content>
   <content contentuid="h357ee2f8gc6c0g20c2gb379gb5e5956b36c8" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Телосложения.</content>
-  <content contentuid="h4aac8b8dg3ce0g0e28g52dag466801c17de1" version="1">Порча (Интеллект)</content>
+  <content contentuid="h4aac8b8dg3ce0g0e28g52dag466801c17de1" version="1">Сглаз (Интеллект)</content>
   <content contentuid="hc349e53bg4534gfd44g5013g08f1ce806f4a" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Интеллекта.</content>
-  <content contentuid="h08459485g468fg19f8gdfa0gde729a573bdd" version="1">Порча (Мудрость)</content>
+  <content contentuid="h08459485g468fg19f8gdfa0gde729a573bdd" version="1">Сглаз (Мудрость)</content>
   <content contentuid="h99671ac5g1722g6772gd253gca4101371e65" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Мудрости.</content>
-  <content contentuid="hd84f5047g0e76gc836g35b5gbe6d305fb2a7" version="1">Порча (Харизма)</content>
+  <content contentuid="hd84f5047g0e76gc836g35b5gbe6d305fb2a7" version="1">Сглаз (Харизма)</content>
   <content contentuid="hdacc0f70g174fg1d6bgacb2ga2903b808996" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Харизмы.</content>
   <content contentuid="h996f221agacbcg6efeg993agc53fc989fb21" version="1">Заставь свои атаки наносить цели дополнительные [1] урона и дай ей &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="Abilities"&gt;характеристику&lt;/LSTag&gt; по твоему выбору.</content>
-  <content contentuid="hfea5f311gcf97g56f0g0870g033aad6ff8c4" version="1">Если цель умрёт до окончания заклинания, ты можешь наложить порчу на новое существо, не тратя &lt;LSTag Tooltip="SpellSlot"&gt;ячейку заклинания&lt;/LSTag&gt;.</content>
-  <content contentuid="hc1eccf67g50eag9cf5ga136gc2f32f4d87ca" version="1">Порча</content>
+  <content contentuid="hfea5f311gcf97g56f0g0870g033aad6ff8c4" version="1">Если цель умрёт до окончания заклинания, ты можешь наложить сглаз на новое существо, не тратя &lt;LSTag Tooltip="SpellSlot"&gt;ячейку заклинания&lt;/LSTag&gt;.</content>
+  <content contentuid="hc1eccf67g50eag9cf5ga136gc2f32f4d87ca" version="1">Сглаз</content>
   <content contentuid="h986ef392g7cedg2e71g03a9gf9c1687d9521" version="1">Заставь свои атаки наносить цели дополнительные [1] урона и дай ей &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="Abilities"&gt;характеристику&lt;/LSTag&gt; по твоему выбору.</content>
-  <content contentuid="hf92ba4c0g7544g31a6gfd25g199230d6f70e" version="1">Если цель умрёт до окончания заклинания, ты можешь наложить порчу на новое существо, не тратя &lt;LSTag Tooltip="SpellSlot"&gt;ячейку заклинания&lt;/LSTag&gt;.</content>
-  <content contentuid="hd19154f9g67bbga673gb1a8g0f17ebdb7005" version="1">Порча</content>
-  <content contentuid="h25a3dfe9g20e9gf9e2ge187g319f2447e505" version="1">Переналожить порчу</content>
+  <content contentuid="hf92ba4c0g7544g31a6gfd25g199230d6f70e" version="1">Если цель умрёт до окончания заклинания, ты можешь наложить сглаз на новое существо, не тратя &lt;LSTag Tooltip="SpellSlot"&gt;ячейку заклинания&lt;/LSTag&gt;.</content>
+  <content contentuid="hd19154f9g67bbga673gb1a8g0f17ebdb7005" version="1">Сглаз</content>
+  <content contentuid="h25a3dfe9g20e9gf9e2ge187g319f2447e505" version="1">Переналожить сглаз</content>
   <content contentuid="h31ca6f3dgf10dg95f5g40e3g89de00c36156" version="1">Прокляни новое существо, не тратя дополнительную &lt;LSTag Tooltip="SpellSlot"&gt;ячейку заклинания&lt;/LSTag&gt;.</content>
   <content contentuid="ha5a58153g6cc6g4715g75c2ge276ca741c83" version="1">Проклятое существо получает дополнительный урон при каждой твоей атаке и имеет &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки характеристики&lt;/LSTag&gt; с выбранной тобой &lt;LSTag Tooltip="Ability"&gt;характеристикой&lt;/LSTag&gt;.</content>
-  <content contentuid="h0ac3faf5gc801gba36g36e2ge50c0d3cbe3d" version="1">Переналожить порчу (Сила)</content>
+  <content contentuid="h0ac3faf5gc801gba36g36e2ge50c0d3cbe3d" version="1">Переналожить сглаз (Сила)</content>
   <content contentuid="h93b664f7ge625g3785ge62age99ab6de787e" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Силы.</content>
-  <content contentuid="hfe462b8cgfce2gf331g69a8gfd66b9d06b2c" version="1">Переналожить порчу (Ловкость)</content>
+  <content contentuid="hfe462b8cgfce2gf331g69a8gfd66b9d06b2c" version="1">Переналожить сглаз (Ловкость)</content>
   <content contentuid="h65fc6538g9b83gcdc4g67cfgc411ccba18fd" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Ловкости.</content>
-  <content contentuid="h4428d231g6bedg24dcg58d3g1a2c9a1125e7" version="1">Переналожить порчу (Телосложение)</content>
+  <content contentuid="h4428d231g6bedg24dcg58d3g1a2c9a1125e7" version="1">Переналожить сглаз (Телосложение)</content>
   <content contentuid="h703b6d99g4f19g3cfeg86abgacc9632e7471" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Телосложения.</content>
-  <content contentuid="h339ecf93g2f0ag416fge58ag903ed30bf51f" version="1">Переналожить порчу (Интеллект)</content>
+  <content contentuid="h339ecf93g2f0ag416fge58ag903ed30bf51f" version="1">Переналожить сглаз (Интеллект)</content>
   <content contentuid="ha4995955g8c54g2f20g60dfg3cbbd515279f" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Интеллекта.</content>
-  <content contentuid="h430a3b34g7f89g31cdg2b02ga2a3fbaf7812" version="1">Переналожить порчу (Мудрость)</content>
+  <content contentuid="h430a3b34g7f89g31cdg2b02ga2a3fbaf7812" version="1">Переналожить сглаз (Мудрость)</content>
   <content contentuid="hac9ec7f6g445ag9437ga0c4g1c9b0eeeaf71" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Мудрости.</content>
-  <content contentuid="h5aaf0080ge420g749fga2c5g922dd7ab9bc1" version="1">Переналожить порчу (Харизма)</content>
+  <content contentuid="h5aaf0080ge420g749fga2c5g922dd7ab9bc1" version="1">Переналожить сглаз (Харизма)</content>
   <content contentuid="h89057920g5fe6gc589g4d87ge015cd8a0c2b" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Харизмы.</content>
-  <content contentuid="h6f62ceafgc618g1146g5257g5408af5dab65" version="1">Переналожить порчу (Харизма)</content>
+  <content contentuid="h6f62ceafgc618g1146g5257g5408af5dab65" version="1">Переналожить сглаз (Харизма)</content>
   <content contentuid="hc1282babgcb3dge035g6100g9c90f22e8322" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Харизмы.</content>
-  <content contentuid="hfa7f6205ge320g224eg9c60g341254b00f5d" version="1">Переналожить порчу (Мудрость)</content>
+  <content contentuid="hfa7f6205ge320g224eg9c60g341254b00f5d" version="1">Переналожить сглаз (Мудрость)</content>
   <content contentuid="h43d4b358gb8f2ga4c7g6624g8428e6a2d7e0" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Мудрости.</content>
-  <content contentuid="h86c9143ega058g12f9g6c50ga755dfac9985" version="1">Переналожить порчу (Интеллект)</content>
+  <content contentuid="h86c9143ega058g12f9g6c50ga755dfac9985" version="1">Переналожить сглаз (Интеллект)</content>
   <content contentuid="h58e709b8gc090g659agd6b3g9e417bbbda73" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Интеллекта.</content>
-  <content contentuid="hc51bf50bg7affgbbefgf975ga57d608a8b19" version="1">Переналожить порчу (Телосложение)</content>
+  <content contentuid="hc51bf50bg7affgbbefgf975ga57d608a8b19" version="1">Переналожить сглаз (Телосложение)</content>
   <content contentuid="hd9a8ca0ag30cagfb8agbc55g0402f2d4ba55" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Телосложения.</content>
-  <content contentuid="h08115bbbgf0d0gd268g5ce9g6d73edc1f0dc" version="1">Переналожить порчу (Ловкость)</content>
+  <content contentuid="h08115bbbgf0d0gd268g5ce9g6d73edc1f0dc" version="1">Переналожить сглаз (Ловкость)</content>
   <content contentuid="h4d10531bg4d81g6ccegbf1bgda8710332c45" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Ловкости.</content>
-  <content contentuid="h365cad4egf41dg3be3g2556g60c4f94dca47" version="1">Переналожить порчу (Сила)</content>
+  <content contentuid="h365cad4egf41dg3be3g2556g60c4f94dca47" version="1">Переналожить сглаз (Сила)</content>
   <content contentuid="ha11a0af0gf1fdg6d14gc928g6c0b30819c32" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Силы.</content>
-  <content contentuid="hb33f8a62gdd36gf6d9gacb0ge5a98eab7ecd" version="1">Переналожить порчу</content>
+  <content contentuid="hb33f8a62gdd36gf6d9gacb0ge5a98eab7ecd" version="1">Переналожить сглаз</content>
   <content contentuid="h23e856a5g4d0ag528cgd0fag36230f54235f" version="1">Прокляни новое существо, не тратя дополнительную &lt;LSTag Tooltip="SpellSlot"&gt;ячейку заклинания&lt;/LSTag&gt;.</content>
   <content contentuid="hfda85d46g3626g88f8gecffg03e1abc1eb12" version="1">Проклятое существо получает дополнительный урон при каждой твоей атаке и имеет &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки характеристики&lt;/LSTag&gt; с выбранной тобой &lt;LSTag Tooltip="Ability"&gt;характеристикой&lt;/LSTag&gt;.</content>
   <content contentuid="hfd42c4cdg4002g1993ge98ag453cbbdf7684" version="1">Заставь свои атаки наносить цели дополнительные [1] урона и дай ей &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="Abilities"&gt;характеристику&lt;/LSTag&gt; по твоему выбору.</content>
-  <content contentuid="hd4782a03g4747ga790g93f8gb5ba22e3ba1a" version="1">Если цель умрёт до окончания заклинания, ты можешь наложить порчу на новое существо, не тратя &lt;LSTag Tooltip="SpellSlot"&gt;ячейку заклинания&lt;/LSTag&gt;.</content>
-  <content contentuid="h7416be09g20a9ga121g5136g174293a1df26" version="1">Порча</content>
+  <content contentuid="hd4782a03g4747ga790g93f8gb5ba22e3ba1a" version="1">Если цель умрёт до окончания заклинания, ты можешь наложить сглаз на новое существо, не тратя &lt;LSTag Tooltip="SpellSlot"&gt;ячейку заклинания&lt;/LSTag&gt;.</content>
+  <content contentuid="h7416be09g20a9ga121g5136g174293a1df26" version="1">Сглаз</content>
   <content contentuid="h4eb29c67ga49agd6e4g8d5ag46d694f80e9e" version="1">Заставь свои атаки наносить цели дополнительные [1] урона и дай ей &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="Abilities"&gt;характеристику&lt;/LSTag&gt; по твоему выбору.</content>
-  <content contentuid="h5fb3e9b6gc371g5c19g6943gfa3f460b2856" version="1">Если цель умрёт до окончания заклинания, ты можешь наложить порчу на новое существо, не тратя &lt;LSTag Tooltip="SpellSlot"&gt;ячейку заклинания&lt;/LSTag&gt;.</content>
-  <content contentuid="h315de182g2122gf2a7g83aagb2576755b5ee" version="1">Порча</content>
-  <content contentuid="hc904ec1agac4cgacb6g35dfg81038f9c3e4f" version="1">Порча (Харизма)</content>
+  <content contentuid="h5fb3e9b6gc371g5c19g6943gfa3f460b2856" version="1">Если цель умрёт до окончания заклинания, ты можешь наложить сглаз на новое существо, не тратя &lt;LSTag Tooltip="SpellSlot"&gt;ячейку заклинания&lt;/LSTag&gt;.</content>
+  <content contentuid="h315de182g2122gf2a7g83aagb2576755b5ee" version="1">Сглаз</content>
+  <content contentuid="hc904ec1agac4cgacb6g35dfg81038f9c3e4f" version="1">Сглаз (Харизма)</content>
   <content contentuid="h7362e90bg474ag92ddg105fg55c4d3f42ec4" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Харизмы.</content>
-  <content contentuid="h830830a0g7b58gd836gd2ceg2928e77472c1" version="1">Порча (Мудрость)</content>
+  <content contentuid="h830830a0g7b58gd836gd2ceg2928e77472c1" version="1">Сглаз (Мудрость)</content>
   <content contentuid="hd0159c36g4f28g7ca7g887dga2bf48ba4acd" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Мудрости.</content>
-  <content contentuid="hbea57063g0a4cg9437g0425g09d1d0f11ebd" version="1">Порча (Интеллект)</content>
+  <content contentuid="hbea57063g0a4cg9437g0425g09d1d0f11ebd" version="1">Сглаз (Интеллект)</content>
   <content contentuid="hba170a9fg16c5g2958gb01bg45ea03cb9d9d" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Интеллекта.</content>
-  <content contentuid="h5237054dgbd17gc3dagc39cg00fae637b62d" version="1">Порча (Телосложение)</content>
+  <content contentuid="h5237054dgbd17gc3dagc39cg00fae637b62d" version="1">Сглаз (Телосложение)</content>
   <content contentuid="h4cdd970cg98a9g8973ga41eg3a0152f76dc6" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Телосложения.</content>
-  <content contentuid="h4237c162g3b21g9ad5gbb24gfcac91a66def" version="1">Порча (Ловкость)</content>
+  <content contentuid="h4237c162g3b21g9ad5gbb24gfcac91a66def" version="1">Сглаз (Ловкость)</content>
   <content contentuid="h9de3bf52g05b5ge6b3g5e7fgcfe595cd5d02" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Ловкости.</content>
-  <content contentuid="h380fb49dg3e47g7b02gf89dge802681c350e" version="1">Порча (Сила)</content>
+  <content contentuid="h380fb49dg3e47g7b02gf89dge802681c350e" version="1">Сглаз (Сила)</content>
   <content contentuid="h2237238fg8d1fgafb3g32e9ge243c83acb05" version="1">Наноси дополнительные [1] при атаке цели и накладывай &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="AbilityCheck"&gt;проверки&lt;/LSTag&gt; Силы.</content>
-  <content contentuid="h5d17bbf7gb793g42b6gacefg8a899ba5c4ab" version="1">Порча</content>
+  <content contentuid="h5d17bbf7gb793g42b6gacefg8a899ba5c4ab" version="1">Сглаз</content>
   <content contentuid="h65f3ea14g5c79g6cdag91a8g8747542a090c" version="1">Заставь свои атаки наносить цели дополнительные [1] урона и дай ей &lt;LSTag Tooltip="Disadvantage"&gt;помеху&lt;/LSTag&gt; на &lt;LSTag Tooltip="Abilities"&gt;характеристику&lt;/LSTag&gt; по твоему выбору.</content>
-  <content contentuid="hce562dddgafdeg09c2gfcbfgfbdf120f983f" version="1">Если цель умрёт до окончания заклинания, ты можешь наложить порчу на новое существо, не тратя &lt;LSTag Tooltip="SpellSlot"&gt;ячейку заклинания&lt;/LSTag&gt;.</content>
+  <content contentuid="hce562dddgafdeg09c2gfcbfgfbdf120f983f" version="1">Если цель умрёт до окончания заклинания, ты можешь наложить сглаз на новое существо, не тратя &lt;LSTag Tooltip="SpellSlot"&gt;ячейку заклинания&lt;/LSTag&gt;.</content>
   <content contentuid="hc421c06eg7266g8444g3e70g03d5b5fcf166" version="2">При попадании или промахе по цели оружие или боеприпас, который ты используешь, превращается в молнию. Вместо получения урона или других эффектов от атаки цель получает 4d8 урона молнией при попадании или половину урона при промахе. Каждое существо в пределах 10 футов от цели получает 2d8 урона молнией.</content>
   <content contentuid="hbc4b3cdeg1f95g6b65gad88g180de678c0b5" version="1">При попадании или промахе по цели оружие или боеприпас, который ты используешь, превращается в молнию. Вместо получения урона или других эффектов от атаки цель получает 4d8 урона молнией при попадании или половину урона при промахе. Каждое существо в пределах 10 футов от цели получает 2d8 урона молнией.</content>
   <content contentuid="h13cf2c9bg80e6g0163g3e81g9d59cc051df8" version="1">При попадании или промахе по цели оружие или боеприпас, который ты используешь, превращается в молнию. Вместо получения урона или других эффектов от атаки цель получает 4d8 урона молнией при попадании или половину урона при промахе. Каждое существо в пределах 10 футов от цели получает 2d8 урона молнией.</content>
@@ -1613,15 +1613,15 @@
   <content contentuid="h61a4b68fgff5eg7169g07bfg95aab5c70a68" version="1">Ты взмахиваешь оружием, использованным при сотворении заклинания, и совершаешь им атаку ближнего боя по одному существу в пределах 5 футов от тебя. При попадании цель подвергается обычным эффектам атаки оружием, и ты можешь заставить зелёное пламя перепрыгнуть от цели к другому существу, которое ты видишь в пределах 5 футов от неё. Второе существо получает [1].</content>
   <content contentuid="h959cb550g10b0g1785ga0e3gd4203b55f7b8" version="1">Вспышка клинков</content>
   <content contentuid="h650ea344gc449g2751g4692g5f60cf3d64d3" version="1">Ты создаёшь мимолётный круг из призрачных клинков, которые вращаются вокруг тебя. Все остальные существа в пределах 5 футов от тебя должны преуспеть в спасброске Ловкости, иначе получат [1].</content>
-  <content contentuid="h8155116dgb434g017cg6396g666179cd6bbd" version="1">Фит: Творец ритуалов</content>
+  <content contentuid="h8155116dgb434g017cg6396g666179cd6bbd" version="1">Черта: Творец ритуалов</content>
   <content contentuid="h81682b22g3da3g86c5g11f5gbebe41d25951" version="1">Ты выучил три &lt;LSTag Tooltip="RitualSpell"&gt;ритуальных заклинания&lt;/LSTag&gt; на свой выбор.</content>
-  <content contentuid="hca029b39g4097g0379g6a74gd52bb5fd4a04" version="1">Фит: Подземный исследователь</content>
+  <content contentuid="hca029b39g4097g0379g6a74gd52bb5fd4a04" version="1">Черта: Подземный исследователь</content>
   <content contentuid="h5cc8709eg0974gcec1g323cg0a299d48a147" version="2">Ты получаешь &lt;LSTag Tooltip="Advantage"&gt;преимущество&lt;/LSTag&gt; на проверки Восприятия для обнаружения скрытых объектов.
 
 Ты получаешь &lt;LSTag Tooltip="Advantage"&gt;преимущество&lt;/LSTag&gt; на &lt;LSTag Tooltip="SavingThrow"&gt;спасброски&lt;/LSTag&gt; для избежания ловушек и &lt;LSTag Tooltip="Resistant"&gt;сопротивление&lt;/LSTag&gt; к урону от ловушек.
 
 Ты видишь в темноте на расстояние до [1].</content>
-  <content contentuid="h1e93417ag9497g58f3ge9aag2e54d8ba4076" version="1">Фит: Стойкий</content>
+  <content contentuid="h1e93417ag9497g58f3ge9aag2e54d8ba4076" version="1">Черта: Стойкий</content>
   <content contentuid="hf12dc8a9g3079g890agb1ffgdf7b91f3c03d" version="2">Обман смерти. Ты получаешь преимущество на спасброски от смерти.
 
 Быстрое восстановление. Ты восстанавливаешь максимально возможное количество &lt;LSTag Tooltip="HitPoints"&gt;очков здоровья&lt;/LSTag&gt; при лечении.</content>
@@ -1647,8 +1647,8 @@
   <content contentuid="hc14aec27g6210g39e2g3e06g4354d61fda0f" version="1">Когда ты попадаешь дальнобойным броском атаки с использованием оружия со свойством «Метательное», ты получаешь бонус +2 к броску урона.</content>
   <content contentuid="h50d829e8g75c2gf73cgee0fgb100f1e4a832" version="1">Стиль боя: Безоружный бой</content>
   <content contentuid="hb9ea2886ge218gb461g7d99gf5eea1cf55f9" version="2">Когда ты поражаешь безоружным ударом и наносишь урон, ты можешь нанести дробящий урон, равный 1d6 плюс твой модификатор Силы, вместо обычного урона безоружного удара.</content>
-  <content contentuid="h55628146g051fgf97agdef9g4359a2f1d8f0" version="1">Фит: Актёр</content>
-  <content contentuid="h662f011dg6d26gcaa0g9ddbg1bec71384d88" version="1">Начальный фит: Лекарь</content>
+  <content contentuid="h55628146g051fgf97agdef9g4359a2f1d8f0" version="1">Черта: Актёр</content>
+  <content contentuid="h662f011dg6d26gcaa0g9ddbg1bec71384d88" version="1">Начальная черта: Лекарь</content>
   <content contentuid="hb5fed628gc7a2g2040gd0adgb152d0d9aa4a" version="2">Боевой медик. Ты получаешь способность восстанавливать очки здоровья существу в количестве 1d8. Ты можешь использовать эту способность количество раз, равное твоему бонусу мастерства, и ты восстанавливаешь все потраченные применения после завершения долгого отдыха.
 
 Лечение. Каждый раз при восстановлении очков здоровья существу оно дополнительно восстанавливает очки здоровья, равные твоему бонусу мастерства.</content>
@@ -1659,17 +1659,17 @@
   <content contentuid="hf4670cedg622ag16adgd7fbgf472400d198b" version="1">Боевой медик. Ты получаешь способность восстанавливать очки здоровья существу в количестве 1d8. Ты можешь использовать эту способность количество раз, равное твоему бонусу мастерства, и ты восстанавливаешь все потраченные применения после завершения долгого отдыха.
 
 Лечение. Каждый раз при восстановлении очков здоровья существу оно дополнительно восстанавливает очки здоровья, равные твоему бонусу мастерства.</content>
-  <content contentuid="h871f4affg0f96gce2fg8f99g76c6d4b04da1" version="2">Книга игрока: Начальные фиты</content>
-  <content contentuid="hc54d8cd4g6034g8a1ag1af3g0f14cef04940" version="2">Книга игрока: Общие фиты</content>
-  <content contentuid="hd28472dcg3ccag8ba5g3424g645e17f370db" version="1">Фит: Дробитель</content>
+  <content contentuid="h871f4affg0f96gce2fg8f99g76c6d4b04da1" version="2">Книга игрока: Начальные черты</content>
+  <content contentuid="hc54d8cd4g6034g8a1ag1af3g0f14cef04940" version="2">Книга игрока: Общие черты</content>
+  <content contentuid="hd28472dcg3ccag8ba5g3424g645e17f370db" version="1">Черта: Дробитель</content>
   <content contentuid="h9ac2c1d5gd0dcga37bgf4d5gb17546182f77" version="3">Отталкивание. Когда ты поражаешь существо атакой, наносящей дробящий урон, ты можешь сдвинуть его на 5 футов на незанятое пространство, если цель не более чем на одну категорию размера больше тебя.
 
 Улучшенное критическое попадание. Когда ты наносишь критическое попадание дробящим уроном по существу, броски атаки против этого существа имеют преимущество до начала твоего следующего хода.</content>
-  <content contentuid="h0f24fc73ge6b5g8e1fg0b3eg4216fa3191e9" version="1">Фит: Пронзитель</content>
+  <content contentuid="h0f24fc73ge6b5g8e1fg0b3eg4216fa3191e9" version="1">Черта: Пронзитель</content>
   <content contentuid="h5f23ece1gd28eg37b5gb2f7g57554d7c8da9" version="2">Прокалывание. Когда ты поражаешь существо атакой, наносящей колющий урон, ты можешь перебросить один из кубиков урона атаки, и ты должен использовать новый результат.
 
 Улучшенное критическое попадание. Когда ты наносишь критическое попадание колющим уроном по существу, ты можешь бросить один дополнительный кубик урона при определении дополнительного колющего урона, который получает цель.</content>
-  <content contentuid="h540810fdg8dc8g2211g0121gd8e6f4397c51" version="1">Фит: Рассекатель</content>
+  <content contentuid="h540810fdg8dc8g2211g0121gd8e6f4397c51" version="1">Черта: Рассекатель</content>
   <content contentuid="hfd222472gd8acg6b69g6068g2840b34f0315" version="4">Подсечка. Когда ты поражаешь существо атакой, наносящей рубящий урон, ты можешь уменьшить скорость этого существа на 10 футов до начала твоего следующего хода.
 
 Улучшенное критическое попадание. Когда ты наносишь критическое попадание рубящим уроном по существу, оно получает помеху на броски атаки до начала твоего следующего хода.</content>
@@ -1685,12 +1685,12 @@
   <content contentuid="he322b215g4b74g107eg1abfg1d7e848abd23" version="2">Подсечка. Один раз за ход, когда ты поражаешь существо атакой, наносящей рубящий урон, ты можешь уменьшить скорость этого существа на 10 футов до начала твоего следующего хода.
 
 Улучшенное критическое попадание. Когда ты наносишь критическое попадание рубящим уроном по существу, оно получает помеху на броски атаки до начала твоего следующего хода.</content>
-  <content contentuid="h2bcebb1fgce9aga6edgfb96gb1208491f0c1" version="1">Фит: Конный воин</content>
+  <content contentuid="h2bcebb1fgce9aga6edgfb96gb1208491f0c1" version="1">Черта: Конный воин</content>
   <content contentuid="h3242d16eg8787g1d4cg8a1ag1ed7c22edd47" version="2">Пока ты верхом на скакуне, ты получаешь преимущество на броски атаки ближнего боя по существам Малого размера или меньше. Кроме того, верхом ты не можешь быть выбит из седла или опрокинут в результате получения урона.</content>
   <content contentuid="hadc251cegfa83ge72dgb40fg8799ee8d6cfe" version="1">Атака скакуна</content>
   <content contentuid="h6abe2717g78bdgfbc5g2d30g1cc22e96ca24" version="1">Помчись вперёд и атакуй первого врага на твоём пути.</content>
-  <content contentuid="h6f880a83gf538g3473g56f7g616ba93a3e5b" version="1">Фит: Отравитель</content>
-  <content contentuid="h9e96b030g4a5fgfbd9g8d73g10831d134be3" version="3">Мощный яд. Заклинания, которые ты сотворяешь, и атаки, которые ты совершаешь, игнорируют &lt;LSTag Tooltip="Resistant"&gt;сопротивление&lt;/LSTag&gt; к урону ядом. Кроме того, когда ты наносишь урон ядом с помощью заклинания, ты не можешь выбросить 1. 
+  <content contentuid="h6f880a83gf538g3473g56f7g616ba93a3e5b" version="1">Черта: Отравитель</content>
+  <content contentuid="h9e96b030g4a5fgfbd9g8d73g10831d134be3" version="3">Мощный яд. Заклинания, которые ты сотворяешь, и атаки, которые ты совершаешь, игнорируют &lt;LSTag Tooltip="Resistant"&gt;сопротивление&lt;/LSTag&gt; к урону ядом. Кроме того, когда ты наносишь урон ядом с помощью заклинания, ты не можешь выбросить 1.
 
 Варка яда. Ты получаешь набор отравителя и владение им. Когда ты наносишь урон ядом существу, оно должно преуспеть в спасброске Телосложения, иначе будет отравлено.</content>
   <content contentuid="h98f7bf60g0be6g2f80g7ff8g89648f02353b" version="2">Конный воин</content>
@@ -1704,11 +1704,11 @@
   <content contentuid="h1c64e7ffg27dfg1336g4d10g922cd9e93f4f" version="1">Использовать набор отравителя: Токсин</content>
   <content contentuid="hbe9f2752g8f47geea4gedcfg417ece6cb1bd" version="1">Намажь токсин на текущий оснащённый набор оружия.</content>
   <content contentuid="h32a854e4gba0ag03e3g6c4agac345edd3b25" version="1">Отравитель</content>
-  <content contentuid="he05ad460g276fg1990g8fccg4bd00b5d035a" version="1">Мощный яд. Заклинания, которые ты сотворяешь, и атаки, которые ты совершаешь, игнорируют &lt;LSTag Tooltip="Resistant"&gt;сопротивление&lt;/LSTag&gt; к урону ядом. Кроме того, когда ты наносишь урон ядом с помощью заклинания, ты не можешь выбросить 1. 
+  <content contentuid="he05ad460g276fg1990g8fccg4bd00b5d035a" version="1">Мощный яд. Заклинания, которые ты сотворяешь, и атаки, которые ты совершаешь, игнорируют &lt;LSTag Tooltip="Resistant"&gt;сопротивление&lt;/LSTag&gt; к урону ядом. Кроме того, когда ты наносишь урон ядом с помощью заклинания, ты не можешь выбросить 1.
 
 Варка яда. Ты получаешь набор отравителя и владение им. Когда ты наносишь урон ядом существу, оно должно преуспеть в спасброске Телосложения, иначе будет отравлено.</content>
-  <content contentuid="hc782e27cga896ge43ag0c4agb3058242abbb" version="1">Книга игрока: Начальные фиты</content>
-  <content contentuid="hc7971da0g5d1bgf514g6294gfba09c9f94ab" version="1">Книга игрока: Общие фиты</content>
+  <content contentuid="hc782e27cga896ge43ag0c4agb3058242abbb" version="1">Книга игрока: Начальные черты</content>
+  <content contentuid="hc7971da0g5d1bgf514g6294gfba09c9f94ab" version="1">Книга игрока: Общие черты</content>
   <content contentuid="hcbf50aebge043ge664g7bbegc0c0e3941aef" version="1">Уровень 3: Заклинания Круга земли</content>
   <content contentuid="hc63ea14cgb031g53b1ge9c5gd05f610e629c" version="1">Всякий раз после завершения долгого отдыха ты выбираешь один тип земли: засушливая, полярная, умеренная или тропическая. На основе твоего выбора ты сверяешься с соответствующей таблицей и имеешь подготовленными все перечисленные заклинания для твоего уровня друида и ниже.
 
@@ -1978,7 +1978,7 @@
   <content contentuid="h22e041e9g38f5g44c4ga023g152c8451beae" version="2">Бернард</content>
   <content contentuid="hbc769f65g2e00g4787gb697gd955581a5567" version="2">Страж Заколдованной Башни</content>
   <content contentuid="hb352a2d9g2b29g035bgcae6ge065a7ef8fe8" version="1">Уровень 3: Заклинания Архифеи</content>
-  <content contentuid="hd7701b33g6b2fg2417gbd20g2eb61af61f00" version="1">Магия твоего покровителя гарантирует, что у тебя всегда наготове определённые заклинания. При достижении определённых уровней Колдуна ты получаешь дополнительные заклинания, как показано в таблице Заклинаний Архифеи, и впредь они всегда у тебя подготовлены. 
+  <content contentuid="hd7701b33g6b2fg2417gbd20g2eb61af61f00" version="1">Магия твоего покровителя гарантирует, что у тебя всегда наготове определённые заклинания. При достижении определённых уровней Колдуна ты получаешь дополнительные заклинания, как показано в таблице Заклинаний Архифеи, и впредь они всегда у тебя подготовлены.
 
 На 3-м уровне ты получаешь Успокоение эмоций, Волшебный огонь, Туманный шаг, Фантомную силу и Сон. На 5-м уровне ты получаешь Скачок и Рост растений. На 7-м — Подчинение зверя и Большую невидимость. На 9-м — Подчинение личности и Подобие.</content>
   <content contentuid="h46177747g5549g5775gad78g65fbcd1fc3a6" version="1">Уровень 3: Шаги фей</content>
@@ -2132,15 +2132,15 @@
   <content contentuid="h1cf67618gcdc1g9bf0g352egd9e5052a34ad" version="1">Заклинание заканчивается, если твои очки здоровья опустятся до 0. Оно также заканчивается, если заклинание будет сотворено снова на любое из связанных существ. Заклинание продолжает действовать, только пока ты и цель находитесь в пределах 60 футов друг от друга.</content>
   <content contentuid="hd3e9c567g2905g672bg0224gf1c8ec229255" version="1">Заклинание заканчивается, если твои очки здоровья опустятся до 0. Оно также заканчивается, если заклинание будет сотворено снова на любое из связанных существ. Заклинание продолжает действовать, только пока ты и цель находитесь в пределах 60 футов друг от друга.</content>
   <content contentuid="h917f9908g4fcbge66dgb997gdac87ffc4aff" version="1">Заклинание заканчивается, если твои очки здоровья опустятся до 0. Оно также заканчивается, если заклинание будет сотворено снова на любое из связанных существ. Заклинание продолжает действовать, только пока ты и цель находитесь в пределах 60 футов друг от друга.</content>
-  <content contentuid="h90381d36g6a66g678dgc622g940db553e2a2" version="1">Фит: Отмеченный феями</content>
+  <content contentuid="h90381d36g6a66g678dgc622g940db553e2a2" version="1">Черта: Отмеченный феями</content>
   <content contentuid="hfaef3824g8845gb735gf4dfgd86da7822941" version="1">Выбери одно заклинание 1-го круга из школы Прорицания или Очарования. У тебя всегда подготовлены это заклинание и Туманный шаг. Ты также получаешь одну ячейку заклинания 1-го круга и одну ячейку 2-го круга.</content>
-  <content contentuid="h373ea885g4542g96b0g1626g9afe46582637" version="1">Фит: Отмеченный тенями</content>
+  <content contentuid="h373ea885g4542g96b0g1626g9afe46582637" version="1">Черта: Отмеченный тенями</content>
   <content contentuid="h0c8f8629gcdb5g21d2g6ba3g68301d16a9ea" version="1">Выбери одно заклинание 1-го круга из школы Иллюзии или Некромантии. У тебя всегда подготовлены это заклинание и Невидимость. Ты также получаешь одну ячейку заклинания 1-го круга и одну ячейку 2-го круга.</content>
   <content contentuid="h3e078741g3071gaa98ga931g651f9cac58d8" version="1">Отмеченный феями</content>
   <content contentuid="h9dd19073g7262gabe8g561dga56e7269712b" version="1">Выбери одно заклинание 1-го круга из школы Прорицания или Очарования. У тебя всегда подготовлены это заклинание и Туманный шаг. Ты также получаешь одну ячейку заклинания 1-го круга и одну ячейку 2-го круга.</content>
   <content contentuid="h45c39024gdfe0g1fbeg74d2g67115110174b" version="1">Отмеченный тенями</content>
   <content contentuid="hbd7f0193ge427g3d75gc0adgfdba8212fb8b" version="1">Выбери одно заклинание 1-го круга из школы Иллюзии или Некромантии. У тебя всегда подготовлены это заклинание и Невидимость. Ты также получаешь одну ячейку заклинания 1-го круга и одну ячейку 2-го круга.</content>
-  <content contentuid="h217127dag7542g9cacg618cg5aa51ecced4b" version="1">Фит: Вдохновляющий лидер</content>
+  <content contentuid="h217127dag7542g9cacg618cg5aa51ecced4b" version="1">Черта: Вдохновляющий лидер</content>
   <content contentuid="h008b1355g9855gf610g8c06gec5ceab5ab6f" version="1">Когда ты завершаешь Короткий или Долгий отдых, ты можешь выступить с вдохновляющим исполнением: речью, песней или танцем. Ты можешь использовать эту способность один раз за Короткий отдых. При этом каждый союзник в пределах 30 футов от тебя получает Временные очки здоровья, равные твоему уровню персонажа плюс твой Бонус мастерства.</content>
   <content contentuid="h38de6e70g3483gb2a8gf232gce6933397614" version="1">Вдохновляющий лидер</content>
   <content contentuid="ha3aeca2ag84a7g9aa2gc23cg0d41a7036cc2" version="1">Когда ты завершаешь Короткий или Долгий отдых, ты можешь выступить с вдохновляющим исполнением: речью, песней или танцем. Ты можешь использовать эту способность один раз за Короткий отдых. При этом каждый союзник в пределах 30 футов от тебя получает Временные очки здоровья, равные твоему уровню персонажа плюс твой Бонус мастерства.</content>
@@ -2148,7 +2148,7 @@
   <content contentuid="hd28c4d74gd3aag5aa9g12b2g628e33edb9c9" version="1">Получить Временные очки здоровья, равные уровню заклинателя плюс его Бонус мастерства.</content>
   <content contentuid="hea65502fg6391g1f02gf466g3d9d8f544c0b" version="1">Вдохновляющий лидер</content>
   <content contentuid="hfe85ad95g8cb3g8eecg7ca9g7f8ee3255f42" version="1">Когда ты завершаешь Короткий или Долгий отдых, ты можешь выступить с вдохновляющим исполнением: речью, песней или танцем. Ты можешь использовать эту способность один раз за Короткий отдых. При этом каждый союзник в пределах 30 футов от тебя получает Временные очки здоровья, равные твоему уровню персонажа плюс твой Бонус мастерства.</content>
-  <content contentuid="h722f5cc4g1b03ga262gffdfg044c2f2f2f85" version="1">Фит: Эксперт навыков</content>
+  <content contentuid="h722f5cc4g1b03ga262gffdfg044c2f2f2f85" version="1">Черта: Эксперт навыков</content>
   <content contentuid="h07dde1d7g4173g2970g8a5fgd318f17b9b5f" version="1">Владение навыком. Ты получаешь владение одним навыком на свой выбор.
 
 Экспертиза. Выбери один навык, которым ты владеешь, но не имеешь Экспертизы. Ты получаешь Экспертизу в этом навыке.</content>
@@ -2156,7 +2156,7 @@
   <content contentuid="he4358e65g244dg1eb4g4922g6f5157e7df61" version="1">Владение навыком. Ты получаешь владение одним навыком на свой выбор.
 
 Экспертиза. Выбери один навык, которым ты владеешь, но не имеешь Экспертизы. Ты получаешь Экспертизу в этом навыке.</content>
-  <content contentuid="h0c144373g63c1g842bg99b7g472028280932" version="1">Фит: Скрытник</content>
+  <content contentuid="h0c144373g63c1g842bg99b7g472028280932" version="1">Черта: Скрытник</content>
   <content contentuid="h355c781dg7ea0g31c3g7904g5e09dcd7d24d" version="1">Слепое чутьё. Ты обладаешь Слепым чутьём с радиусом 10 футов.
 
 Туман войны. Сложность стать Невидимым при использовании действия Скрыться равна 15 вместо 20.</content>
@@ -2172,7 +2172,7 @@
   <content contentuid="h8d8901f6g2e5cg9e63gccfag9986aa35774d" version="1">Получить преимущества Короткого отдыха.</content>
   <content contentuid="h29b83689gfd3bg5f53g17f0g9a9d6b677256" version="1">Получить преимущества Короткого отдыха.</content>
   <content contentuid="h9e1946a3g463agb8b7g75e7gd94f9c36f9f7" version="1">Когда ты используешь заклинания Кары, ты получаешь &lt;LSTag Tooltip="TemporaryHitPoints"&gt;временные очки здоровья&lt;/LSTag&gt;, равные твоему &lt;LSTag Tooltip="AbilityModifier"&gt;Модификатору&lt;/LSTag&gt; Харизмы.</content>
-  <content contentuid="h49c4cec7gb617g6a1eg491fgb75829e376fa" version="1">Фит: Драконий страх</content>
+  <content contentuid="h49c4cec7gb617g6a1eg491fgb75829e376fa" version="1">Черта: Драконий страх</content>
   <content contentuid="h1e4b1002g6774g3698g6495gb47ef39af956" version="2">Ты получаешь одно использование своего Дыхания.
 
 Ты можешь потратить одно использование своего Дыхания, чтобы зареветь, заставив каждое выбранное тобой существо в пределах 30 футов от тебя совершить спасбросок Мудрости. При провале цель становится испуганной тобой на 1 минуту.</content>
@@ -2196,12 +2196,12 @@
 Твоя чешуя твердеет. Пока ты не носишь доспех, ты можешь рассчитывать свой Класс доспеха как 13 + твой модификатор Ловкости. Ты можешь использовать щит и при этом получать этот бонус.
 
 Ты отращиваешь убирающиеся когти на кончиках пальцев. Выдвижение или втягивание когтей не требует действия. Когти — это естественное оружие, которым ты можешь наносить Безоружные удары. Когда ты попадаешь Безоружным ударом этими когтями, атака наносит дополнительный 1d4 рубящего урона.</content>
-  <content contentuid="h15c9cd37ga045g7431ge7e7g0c7fa387fb99" version="1">Фит: Драконья шкура</content>
+  <content contentuid="h15c9cd37ga045g7431ge7e7g0c7fa387fb99" version="1">Черта: Драконья шкура</content>
   <content contentuid="hb434eaecg1425g3722gfd51g5065b8b2a915" version="1">Твоя чешуя твердеет. Пока ты не носишь доспех, ты можешь рассчитывать свой Класс доспеха как 13 + твой модификатор Ловкости. Ты можешь использовать щит и при этом получать этот бонус.
 
 Ты отращиваешь убирающиеся когти на кончиках пальцев. Выдвижение или втягивание когтей не требует действия. Когти — это естественное оружие, которым ты можешь наносить Безоружные удары. Когда ты попадаешь Безоружным ударом этими когтями, атака наносит дополнительный 1d4 рубящего урона.</content>
-  <content contentuid="hff5fa241g78c2g2414gf5caga9f8235efc8d" version="1">Фит: Драконья шкура</content>
-  <content contentuid="h2f58c2a0g1fd8gcbc6g65e4g15015618e4f6" version="1">Фит: Дворфийская стойкость</content>
+  <content contentuid="hff5fa241g78c2g2414gf5caga9f8235efc8d" version="1">Черта: Драконья шкура</content>
+  <content contentuid="h2f58c2a0g1fd8gcbc6g65e4g15015618e4f6" version="1">Черта: Дворфийская стойкость</content>
   <content contentuid="haa8d3917gd15fg261dg5b19g07a62de6a88f" version="1">Каждый раз, когда ты используешь действие Уклонение в бою, ты можешь потратить одну Кость здоровья, чтобы исцелить себя. Брось кубик, прибавь свой модификатор Телосложения и восстанови количество очков здоровья, равное сумме (минимум 1).</content>
   <content contentuid="h399266afg5858g5079g1067g6fd5b17e38ef" version="1">Дворфийская стойкость</content>
   <content contentuid="h5d6d057fg00c7g16f2g3e29g4815f812225a" version="3">Предварительное требование: Дворф
@@ -2209,7 +2209,7 @@
 В твоих жилах течёт кровь дворфийских героев.
 
 Каждый раз, когда ты используешь действие Уклонение в бою, ты можешь потратить одну Кость здоровья, чтобы исцелить себя. Брось кубик, прибавь свой модификатор Телосложения и восстанови количество очков здоровья, равное сумме (минимум 1).</content>
-  <content contentuid="h59ec731bg946dg1c9eg2b5fg04fb49032eb0" version="1">Фит: Эльфийская точность</content>
+  <content contentuid="h59ec731bg946dg1c9eg2b5fg04fb49032eb0" version="1">Черта: Эльфийская точность</content>
   <content contentuid="h7568c386gf212ga40dg691eg69b66c143ccb" version="1">Каждый раз, когда ты имеешь преимущество на бросок атаки с использованием Ловкости, Интеллекта, Мудрости или Харизмы, ты можешь перебросить один из кубиков один раз.</content>
   <content contentuid="h871574cdg815eg20feg9c4bg90c69f23267f" version="1">Эльфийская точность</content>
   <content contentuid="h9859bb44g3e14g4995geac2ga0aad82d5174" version="3">Предварительное требование: Эльф или полуэльф
@@ -2217,7 +2217,7 @@
 Точность эльфов легендарна, особенно эльфийских лучников и заклинателей. Ты обладаешь невероятным прицелом при атаках, требующих точности, а не грубой силы.
 
 Каждый раз, когда ты имеешь преимущество на бросок атаки с использованием Ловкости, Интеллекта, Мудрости или Харизмы, ты можешь перебросить один из кубиков один раз.</content>
-  <content contentuid="h9e85d1b6g9ae7gbd03g0979g143f269618f6" version="1">Фит: Растворение</content>
+  <content contentuid="h9e85d1b6g9ae7gbd03g0979g143f269618f6" version="1">Черта: Растворение</content>
   <content contentuid="hf3c081c9gfff8gde1bg3dfdg9efec07a99db" version="1">Сразу после получения урона ты можешь использовать реакцию, чтобы магическим образом стать невидимым до конца своего следующего хода или пока ты не атакуешь, нанесёшь урон или заставишь кого-то совершить спасбросок. Использовав эту способность, ты не сможешь сделать это снова, пока не завершишь короткий или долгий отдых.</content>
   <content contentuid="he5681483gc147g2847g3d00g9d1fbf8ceb55" version="1">Растворение</content>
   <content contentuid="h77e7a483ged12gb338gf5e8g19d2932eb5ca" version="1">Сразу после получения урона ты можешь использовать реакцию, чтобы магическим образом стать невидимым до конца своего следующего хода или пока ты не атакуешь, нанесёшь урон или заставишь кого-то совершить спасбросок. Использовав эту способность, ты не сможешь сделать это снова, пока не завершишь короткий или долгий отдых.</content>
@@ -2229,7 +2229,7 @@
 Твой народ хитёр и имеет склонность к магии иллюзий. Ты научился магическому трюку растворения, когда тебе причиняют вред.
 
 Сразу после получения урона ты можешь использовать реакцию, чтобы магическим образом стать невидимым до конца своего следующего хода или пока ты не атакуешь, нанесёшь урон или заставишь кого-то совершить спасбросок. Использовав эту способность, ты не сможешь сделать это снова, пока не завершишь короткий или долгий отдых.</content>
-  <content contentuid="h9f87a9d2g9d12g4c2cg64e6g15737cbc6441" version="1">Фит: Пламя Флегетона</content>
+  <content contentuid="h9f87a9d2g9d12g4c2cg64e6g15737cbc6441" version="1">Черта: Пламя Флегетона</content>
   <content contentuid="hc35093b5g5ceag870eg966fg55e93a47c7ca" version="1">Когда ты бросаешь урон огнём за сотворённое тобой заклинание, ты можешь перебросить любую единицу на кубиках урона огнём.
 
 Каждый раз, когда ты сотворяешь заклинание, наносящее урон огнём, ты можешь окутать себя пламенем до конца своего следующего хода. Пока это пламя присутствует, любое существо, попадающее по тебе атакой ближнего боя, получает 1d4 урона огнём.</content>
@@ -2244,7 +2244,7 @@
 Когда ты бросаешь урон огнём за сотворённое тобой заклинание, ты можешь перебросить любую единицу на кубиках урона огнём.
 
 Каждый раз, когда ты сотворяешь заклинание, наносящее урон огнём, ты можешь окутать себя пламенем до конца своего следующего хода. Пока это пламя присутствует, любое существо, попадающее по тебе атакой ближнего боя, получает 1d4 урона огнём.</content>
-  <content contentuid="h8da0ffe6gfac9g6966g9355g3d3ff1aeff52" version="1">Фит: Инфернальное телосложение</content>
+  <content contentuid="h8da0ffe6gfac9g6966g9355g3d3ff1aeff52" version="1">Черта: Инфернальное телосложение</content>
   <content contentuid="h8a863439g286bg8971g8df1g7a3cb3edc5c6" version="1">Ты обладаешь сопротивлением к урону холодом и ядом.
 Ты имеешь преимущество на спасброски против отравления.</content>
   <content contentuid="h9870add4g87a1g306fg4d11g7626059e8997" version="1">Инфернальное телосложение</content>
@@ -2254,7 +2254,7 @@
 
 Ты обладаешь сопротивлением к урону холодом и ядом.
 Ты имеешь преимущество на спасброски против отравления.</content>
-  <content contentuid="he3cdc39cg8e39gb2e3gc628g38d8698d6dfb" version="1">Фит: Орчья ярость</content>
+  <content contentuid="he3cdc39cg8e39gb2e3gc628g38d8698d6dfb" version="1">Черта: Орчья ярость</content>
   <content contentuid="h4b0f1e63g20c9gcc05ga203g340139e843f1" version="1">Когда ты наносишь &lt;LSTag Tooltip="CriticalHit"&gt;Критическое попадание&lt;/LSTag&gt; атакой оружием ближнего боя, ты наносишь дополнительный кубик урона оружием. </content>
   <content contentuid="h09b6e651g8c58gb250g73d8gf855f2d9b768" version="1">Орчья ярость</content>
   <content contentuid="h505c9691gb92dg0066g1bd8gee8dbadfa730" version="1">Предварительное требование: Полуорк
@@ -2268,7 +2268,7 @@
 Увеличь свою скорость ходьбы на 5 футов.
 Ты получаешь владение навыком Акробатика или Атлетика (на твой выбор).
 Ты имеешь преимущество на любую проверку Силы (Атлетика) или Ловкости (Акробатика), которую ты совершаешь, чтобы вырваться из связывания.</content>
-  <content contentuid="h1dbe3f90g3d47gc1cagd861g317e83891368" version="1">Фит: Приземистая ловкость</content>
+  <content contentuid="h1dbe3f90g3d47gc1cagd861g317e83891368" version="1">Черта: Приземистая ловкость</content>
   <content contentuid="h40770da0g7507g2a0eg4c0dgbab4e296bc1d" version="1">Увеличь свою скорость ходьбы на 5 футов.
 Ты получаешь владение навыком Акробатика или Атлетика (на твой выбор).
 Ты имеешь преимущество на любую проверку Силы (Атлетика) или Ловкости (Акробатика), которую ты совершаешь, чтобы вырваться из связывания.</content>
@@ -2283,19 +2283,19 @@
   <content contentuid="hce732cf1g4e06ge110g8d34g08c428a3b974" version="1">Котёл Ташас со всем</content>
   <content contentuid="h0cb1e09cg436bgc901g0c7cg06f2eb6a1066" version="1">Драконий ужас</content>
   <content contentuid="h7859cbddgc1d2g2fb6g37e8ge9fff27abfce" version="1">Ты можешь использовать магическое действие, чтобы вселить ужас в существо, которое ты видишь в пределах 30 футов от себя. Цель должна преуспеть в спасброске Мудрости, иначе получит состояние «Испуган» до конца твоего следующего хода.</content>
-  <content contentuid="h0d2663e7ga6eag1b82g8e4bg4351babc6226" version="2">Корневой фит: Посвящённый Культа Дракона</content>
+  <content contentuid="h0d2663e7ga6eag1b82g8e4bg4351babc6226" version="2">Корневая черта: Посвящённый Культа Дракона</content>
   <content contentuid="h5648b3eag0325g46d8g5cd1g0463117aab6a" version="4">Драконий ужас. Ты можешь использовать магическое действие, чтобы вселить ужас в существо, которое ты видишь в пределах 30 футов от себя. Цель должна преуспеть в спасброске Мудрости, иначе получит состояние «Испуган» до конца твоего следующего хода.
 
 Вдохновлённый страхом. Когда ты заставляешь существо получить состояние «Испуган» и являешься источником его страха, ты получаешь Героическое вдохновение. Использовав этот бонус, ты не можешь сделать это снова, пока не завершишь Короткий или Долгий отдых.</content>
   <content contentuid="hee930e39g569egbf9bgf8d4gce1dcff3b5cd" version="1">Героическое вдохновение</content>
   <content contentuid="hd9193a10g8e78g28bagc22eg90d1be20c4d7" version="1">Ты получаешь Героическое вдохновение каждый раз, когда завершаешь Долгий отдых. Если у тебя есть Героическое вдохновение, ты можешь потратить его, чтобы перебросить любой кубик сразу после его броска.</content>
-  <content contentuid="h07d286f6gc9ceg419dgb13dg7480d479c810" version="3">Забытые Королевства: Герои Фэйруна: Корневые фиты</content>
+  <content contentuid="h07d286f6gc9ceg419dgb13dg7480d479c810" version="3">Забытые Королевства: Герои Фэйруна: Корневые черты</content>
   <content contentuid="hab576294g3e47gcbbeg44c0g9dc38a2a3ab6" version="2">Забытые Королевства: Герои Фэйруна</content>
   <content contentuid="hc477acf9gaec4g36b5g7d0bg06d04d9b41f4" version="2">Драконий ужас. Ты можешь использовать магическое действие, чтобы вселить ужас в существо, которое ты видишь в пределах 30 футов от себя. Цель должна преуспеть в спасброске Мудрости, иначе получит состояние «Испуган» до конца твоего следующего хода.
 
 Вдохновлённый страхом. Когда ты заставляешь существо получить состояние «Испуган» и являешься источником его страха, ты получаешь Героическое вдохновение. Использовав этот бонус, ты не можешь сделать это снова, пока не завершишь Короткий или Долгий отдых.</content>
   <content contentuid="h131adc06g9cd1g7b27g9571g87157dc4b980" version="2">Посвящённый Культа Дракона</content>
-  <content contentuid="h9882b9efg772bg815eg465bg5671d559ae9f" version="2">Корневой фит: Птенец Изумрудного Анклава</content>
+  <content contentuid="h9882b9efg772bg815eg465bg5671d559ae9f" version="2">Корневая черта: Птенец Изумрудного Анклава</content>
   <content contentuid="ha908486dgac97g5080g2fcdg248197559140" version="1">Разговор с животными. У тебя всегда подготовлено заклинание Разговор с животными, и ты можешь сотворять его с помощью любых имеющихся ячеек заклинаний.
 
 Командная работа. Когда ты используешь действие Помощь, ты можешь поменяться местами с добровольным союзником в пределах 5 футов от себя в рамках того же действия. Это перемещение не провоцирует Атаки по возможности.</content>
@@ -2314,8 +2314,8 @@
   <content contentuid="h4ee892fdg07d1g3e46ga80bg74e493bcf181" version="1">Вдохновляющий удар. Один раз за ход, когда ты наносишь Критическое попадание по существу, ты получаешь Героическое вдохновение.
 
 Отстоять честь. Когда враг, которого ты видишь, наносит тебе урон, ты получаешь Преимущество на свой следующий бросок атаки против этого врага до конца твоего следующего хода.</content>
-  <content contentuid="h32098dd3g6f72g92eag10cbg76fc72c357c4" version="2">Корневой фит: Агент Арфистов</content>
-  <content contentuid="hb61939ecg2158g4da3gadf9g7aace51ea588" version="2">Корневой фит: Агент Альянса Лордов</content>
+  <content contentuid="h32098dd3g6f72g92eag10cbg76fc72c357c4" version="2">Корневая черта: Агент Арфистов</content>
+  <content contentuid="hb61939ecg2158g4da3gadf9g7aace51ea588" version="2">Корневая черта: Агент Альянса Лордов</content>
   <content contentuid="h6c140161ge881g7f60g8a89gbf47719d5f66" version="1">Вдохновляющий удар. Один раз за ход, когда ты наносишь Критическое попадание по существу, ты получаешь Героическое вдохновение.
 
 Отстоять честь. Когда враг, которого ты видишь, наносит тебе урон, ты получаешь Преимущество на свой следующий бросок атаки против этого врага до конца твоего следующего хода.</content>
@@ -2325,7 +2325,7 @@
 
 Воодушевляющий клич. Ты можешь выбрать количество существ, равное твоему Бонусу мастерства, которых ты видишь в пределах 30 футов от себя. Эти существа получают Героическое вдохновение. Использовав этот бонус, ты не можешь сделать это снова, пока не завершишь Долгий отдых.</content>
   <content contentuid="ha118d2a1gbbb4gcfd3g1676g37accfee78d4" version="1">Ладья Пурпурного Дракона</content>
-  <content contentuid="h460435aaga1b3g7abbg15e5g3ca6334b18ec" version="2">Корневой фит: Ладья Пурпурного Дракона</content>
+  <content contentuid="h460435aaga1b3g7abbg15e5g3ca6334b18ec" version="2">Корневая черта: Ладья Пурпурного Дракона</content>
   <content contentuid="h76a090b6gcb17g375dg822fgdf79bae4b00a" version="1">Убеждение. Ты получаешь владение навыком Убеждение.
 
 Воодушевляющий клич. Ты можешь выбрать количество существ, равное твоему Бонусу мастерства, которых ты видишь в пределах 30 футов от себя. Эти существа получают Героическое вдохновение. Использовав этот бонус, ты не можешь сделать это снова, пока не завершишь Долгий отдых.</content>
@@ -2335,7 +2335,7 @@
   <content contentuid="hdefd07e9gac32g3227g03d6g27116876f808" version="1">Магическое поглощение. Один раз за ход, когда ты получаешь урон от заклинания или магического эффекта, ты уменьшаешь общий полученный урон на 1d4.
 
 Заклинанное пламя. Ты изучаешь заговор Священное пламя. Ты также можешь сотворять этот заговор в качестве бонусного действия количество раз, равное твоему Бонусу мастерства, и ты восстанавливаешь все потраченные использования, когда завершаешь Долгий отдых.</content>
-  <content contentuid="hd178e099gb659g6341ga121g62c3fe95197b" version="2">Корневой фит: Искра заклинанного пламени</content>
+  <content contentuid="hd178e099gb659g6341ga121g62c3fe95197b" version="2">Корневая черта: Искра заклинанного пламени</content>
   <content contentuid="h5b07f997g2114g17b3gd384gcaa505b50750" version="1">Магическое поглощение. Один раз за ход, когда ты получаешь урон от заклинания или магического эффекта, ты уменьшаешь общий полученный урон на 1d4.
 
 Заклинанное пламя. Ты изучаешь заговор Священное пламя. Ты также можешь сотворять этот заговор в качестве бонусного действия количество раз, равное твоему Бонусу мастерства, и ты восстанавливаешь все потраченные использования, когда завершаешь Долгий отдых.</content>
@@ -2351,9 +2351,9 @@
   <content contentuid="h35e74b0fg788bg373bg7feag7976ce468738" version="2">Использовать брешь. Когда ты бросаешь урон за Атаку по возможности, ты можешь бросить кубики урона дважды и использовать любой результат против цели.
 
 Семья прежде всего. Один раз за Долгий отдых ты даруешь себе и союзникам в пределах 30 футов от тебя Преимущество на броски Инициативы.</content>
-  <content contentuid="hcdc555cfg9d57g4360g3b62gca191ef8dbeb" version="2">Корневой фит: Новичок Перчатки</content>
+  <content contentuid="hcdc555cfg9d57g4360g3b62gca191ef8dbeb" version="2">Корневая черта: Новичок Перчатки</content>
   <content contentuid="hae5d214ag6792g7325g5146gf48dfd5f7239" version="1">Стоять как один. Когда союзник в пределах 5 футов от тебя подвергается эффекту, который оттолкнул бы или притянул бы его, ты можешь использовать Реакцию, чтобы помешать союзнику быть оттолкнутым или притянутым. Чтобы получить этот бонус, союзник не должен иметь состояние «Недееспособен».</content>
-  <content contentuid="hc035112fg126ag11d6gfb7dg336a2c68d5d8" version="2">Корневой фит: Жентаримский головорез</content>
+  <content contentuid="hc035112fg126ag11d6gfb7dg336a2c68d5d8" version="2">Корневая черта: Жентаримский головорез</content>
   <content contentuid="hb6c99f09gddf8gda0ag3134gfda7f384b17d" version="2">Использовать брешь. Когда ты бросаешь урон за Атаку по возможности, ты можешь бросить кубики урона дважды и использовать любой результат против цели.
 
 Семья прежде всего. Один раз за Долгий отдых ты даруешь себе и союзникам в пределах 30 футов от тебя Преимущество на броски Инициативы.</content>
@@ -2366,7 +2366,7 @@
   <content contentuid="hdc0c151fgfe8egbcabge68cg685831c227f1" version="1">Наносит на [1] больше урона оружием ближнего боя, импровизированным оружием и метанием.</content>
   <content contentuid="hbba7650bg2c8bga26fga741g9eb4b22d5870" version="1">Твои заговоры, наносящие урон, воздействуют даже на тех существ, которые избегают основной силы эффекта. Когда ты сотворяешь заговор по существу и промахиваешься по броску атаки или цель преуспевает в спасброске против заговора, цель получает половину урона заговора (если он есть), но не страдает от дополнительных эффектов заговора.</content>
   <content contentuid="h97952f3cg6278g1f14ge37fg872fa1c84f63" version="1">Фермер</content>
-  <content contentuid="h15dc29ceg8c9cg6290g5aa9gcfb5242e5617" version="2">Фит: Стойкий
+  <content contentuid="h15dc29ceg8c9cg6290g5aa9gcfb5242e5617" version="2">Черта: Стойкий
 
 Ты вырос близко к земле. Годы ухода за животными и возделывания почвы наделили тебя терпением и крепким здоровьем. Ты глубоко ценишь щедрость природы и испытываешь здоровое уважение к её гневу.</content>
   <content contentuid="h2ab2a67bgf459gef48gcc42g14876f553c65" version="1">Вдохновение от предыстории</content>
@@ -2374,39 +2374,39 @@
   <content contentuid="hb07fe333g4275g1c07gea70g9c7c1eced411" version="1">Вдохновение от предыстории</content>
   <content contentuid="hd5c61c76gdec1g8787g7cc4g876ca085fd07" version="2">Пока ты проводишь ночь в отдыхе, в твоём сознании оседают воспоминания о дневных испытаниях и триумфах. Из этих размышлений произрастает вдохновение, сопровождающее тебя в грядущий день.</content>
   <content contentuid="hfb98470dgc1a0gda55g59fbgedacd498ecb1" version="1">Проводник</content>
-  <content contentuid="h49166a1eg4322g9138gf1d7g4a5a791dc1d6" version="2">Фит: Маг-послушник (Друид)
+  <content contentuid="h49166a1eg4322g9138gf1d7g4a5a791dc1d6" version="2">Черта: Маг-послушник (Друид)
 
 Ты вырос на открытом воздухе, вдали от обжитых земель. Твоим домом было любое место, где ты решал расстелить свой спальник. В глуши таится множество чудес — странные чудовища, нетронутые леса и ручьи, заросшие руины некогда великих чертогов, по которым ступали великаны, — и ты научился обходиться собственными силами, исследуя их. Время от времени ты сопровождал дружелюбных жрецов природы, которые обучали тебя основам направления дикой магии.</content>
   <content contentuid="h0fa8ec83g19fag6182gb455g1d2c24eddba3" version="1">Отшельник</content>
-  <content contentuid="ha5ec425bg430dg6de7ge56ag7b5f719afc8e" version="2">Фит: Целитель
+  <content contentuid="ha5ec425bg430dg6de7ge56ag7b5f719afc8e" version="2">Черта: Целитель
 
 Ты провёл свои ранние годы в уединении в хижине или монастыре, расположенном далеко за окраинами ближайшего поселения. В те дни твоими единственными спутниками были лесные твари да редкие гости, приносившие вести из внешнего мира и припасы. Уединение позволило тебе провести множество часов в размышлениях над тайнами мироздания.</content>
   <content contentuid="h1696d2f4g7bc6gd4a6gfafbg09abc3a4acdc" version="1">Купец</content>
-  <content contentuid="h1de6d67bgeb49gcb85gfb65g06babeedf8df" version="2">Фит: Удачливый
+  <content contentuid="h1de6d67bgeb49gcb85gfb65g06babeedf8df" version="2">Черта: Удачливый
 
 Ты был в подмастерьях у торговца, караванщика или лавочника, постигая основы коммерции. Ты много путешествовал и зарабатывал на жизнь, покупая и продавая сырьё, необходимое ремесленникам для их мастерства, либо готовые изделия таких мастеров. Возможно, ты перевозил товары с места на место (на корабле, в повозке или с караваном) либо скупал их у заезжих торговцев и продавал в собственной лавке.</content>
   <content contentuid="h75361877g462ag56f8g1373ge76df7dda28e" version="1">Моряк</content>
-  <content contentuid="h7187b090g05a9g4c6fgefa0g22b1e8de0294" version="2">Фит: Трактирный драчун
+  <content contentuid="h7187b090g05a9g4c6fgefa0g22b1e8de0294" version="2">Черта: Трактирный драчун
 
 Ты жил как мореплаватель, с ветром в спине и палубой, качающейся под ногами. Ты сиживал на барных стульях в большем количестве портов, чем можешь вспомнить, выдерживал свирепые штормы и обменивался историями с теми, кто живёт под волнами.</content>
   <content contentuid="h27dc6fe0gecf0gbd0fg3e2eg5238adc0ffe1" version="1">Писец</content>
-  <content contentuid="h196d3642g2b8eg0c5ag525dg06fde33550c2" version="2">Фит: Искусный
+  <content contentuid="h196d3642g2b8eg0c5ag525dg06fde33550c2" version="2">Черта: Искусный
 
 Ты провёл свои становые годы в скриптории, монастыре, посвящённом сохранению знаний, или в государственном учреждении, где научился писать разборчиво и создавать искусно написанные тексты. Возможно, ты переписывал государственные документы или копировал тома литературы. Возможно, ты владеешь пером как поэт, рассказчик или учёный. Прежде всего, ты отличаешься тщательным вниманием к деталям, что помогает тебе избегать ошибок в документах, которые ты копируешь и создаёшь.</content>
   <content contentuid="h1f45de0dg88e1g0733gfc1fg831305fea871" version="1">Странник</content>
-  <content contentuid="h906ec4f3gc82ag542bgde14g6bc7078122ad" version="2">Фит: Удачливый
+  <content contentuid="h906ec4f3gc82ag542bgde14g6bc7078122ad" version="2">Черта: Удачливый
 
 Ты вырос на улицах в окружении таких же обречённых изгоев — кое-кто из них стал твоими друзьями, а кое-кто — соперниками. Ты спал, где придётся, и перебивался случайными подработками ради пропитания. Порой, когда голод становился невыносимым, ты прибегал к воровству. Но ты никогда не терял гордость и не оставлял надежду. Судьба ещё не закончила с тобой.</content>
   <content contentuid="he12b9f94g6f02gff63gc972g8305903353f4" version="1">Хондатский флибустьер</content>
-  <content contentuid="he504b2a7g6a08gdabfgb8a9g1df72a68f86c" version="2">Фит: Искусный
+  <content contentuid="he504b2a7g6a08gdabfgb8a9g1df72a68f86c" version="2">Черта: Искусный
 
 Хотя большинство юношей в Хондате покорно отбывают четырёхлетний срок обязательной военной службы, ты возмутился этой авторитарной попыткой управлять твоей жизнью. Ты отрёкся от подданства, выбросил своё данное при рождении имя и нанялся вольным флибустьером на первый корабль, который тебя принял. С тех пор ты странствуешь по Вилхонскому пределу. И хотя ты никогда не отходил от берега больше, чем на несколько десятков лиг, ты с лихвой компенсируешь это глубокими местными связями и богатством накопленного опыта.</content>
   <content contentuid="ha0d25efeg81cagb1eag57a7gc306ed49c4ed" version="1">Обитатель зоны мёртвой магии</content>
-  <content contentuid="h0026be6dg10c9g0f95gcab2g7474991939fb" version="2">Фит: Целитель
+  <content contentuid="h0026be6dg10c9g0f95gcab2g7474991939fb" version="2">Черта: Целитель
 
 Зоны мёртвой магии в пустыне Анаурок — проклятие для заклинателей и чудовищ, полагающихся на магию, и именно поэтому ты избрал это место своим домом. Возможно, ты бежишь от Красных волшебников, или же ты перешёл дорогу могущественному джинну в Калимшане. Как бы то ни было, ты решил, что жизнь в Анауроке — твой лучший выход. После долгих месяцев или лет ты стал сильнее, мудрее и овладел с трудом добытыми знаниями пустынной медицины и выживания в пустошах.</content>
   <content contentuid="h0bf7e770g96a0g3f97g6ab1g8d7f9041630c" version="1">Культист Дракона</content>
-  <content contentuid="h9ce67cb6ga5b0ga13bg7785g0b5aae8510f3" version="3">Фит: Послушник Культа Дракона
+  <content contentuid="h9ce67cb6ga5b0ga13bg7785g0b5aae8510f3" version="3">Черта: Послушник Культа Дракона
 
 Ты — послушник Культа Дракона. Ты сам обнаружил или был приведён в ячейку культа, где проявил качества, чтимые культистами Дракона: коварство, скрытность и решимость. В обмен на клятву служения культу тебе предложили общество единомышленников-почитателей драконов, а также доступ к ресурсам, способным помочь в твоих занятиях арканой и оккультизмом.
 
@@ -2414,7 +2414,7 @@
 
 Вдохновлён страхом. Когда ты заставляешь существо получить состояние «Испуган», и ты являешься источником этого страха, ты получаешь Героическое вдохновение. Воспользовавшись этой способностью, ты не сможешь сделать это снова, пока не закончишь короткий или долгий отдых.</content>
   <content contentuid="h90ac0b94ga91cg1944g4476gd94460ac409f" version="1">Опекун Изумрудного Анклава</content>
-  <content contentuid="h3ab69a8agd42agbda7g29dbgb432d976003a" version="2">Фит: Птенец Изумрудного Анклава
+  <content contentuid="h3ab69a8agd42agbda7g29dbgb432d976003a" version="2">Черта: Птенец Изумрудного Анклава
 
 Как опекун Изумрудного Анклава, ты заботишься о тех, кто заботится о мире. Вместе с другими членами Изумрудного Анклава или в одиночку ты освоил важнейшие навыки жизни в гармонии с землёй: как выслеживать дичь, где искать полезные травы и даже как предсказывать погоду. Ты используешь эти таланты, чтобы поддерживать равновесие между цивилизацией и дикой природой, а также избавлять мир от неестественных существ.
 
@@ -2422,15 +2422,15 @@
 
 Слаженная команда. Когда ты используешь действие «Помощь», ты можешь поменяться местами с добровольным союзником в радиусе 5 футов от себя в рамках того же действия. Это перемещение не провоцирует атаки по возможности.</content>
   <content contentuid="hdca03596gcde4g4b29g8a36g81f8496c69a4" version="1">Наёмник Пылающего Кулака</content>
-  <content contentuid="he09a0c77g31aeg7362g892bg7bdd827aa73e" version="2">Фит: Стойкий
+  <content contentuid="he09a0c77g31aeg7362g892bg7bdd827aa73e" version="2">Черта: Стойкий
 
 Главным органом охраны порядка во Вратах Бальдура является Пылающий Кулак — могучая гильдия наёмников, которую возглавляет великий герцог города. Ты некогда служил в Пылающем Кулаке, где научился предотвращать неприятности своим устрашающим взглядом и, при необходимости, принимать на себя смертоносные удары. Наёмники Пылающего Кулака, действующие или отставные, слывут одними из самых стойких и выносливых воинов на Побережье Мечей, и ты стремишься поддерживать эту репутацию.</content>
   <content contentuid="h105bb9d9g609ag49cfg2111g5249b2b04f14" version="1">Отмеченный джинном</content>
-  <content contentuid="h44bec492ga13fg76e5gfab8g3f1ba78481ca" version="2">Фит: Маг-послушник (Волшебник)
+  <content contentuid="h44bec492ga13fg76e5gfab8g3f1ba78481ca" version="2">Черта: Маг-послушник (Волшебник)
 
 Хотя джинны больше не правят Калимшаном, магия джиннов по-прежнему обычна в твоей родной земле. Возможно, ты случайно вызвал джинна из волшебной лампы, или же наткнулся на оазис, охраняемый маридом. Может быть, дао спас тебя от оползня, или ты сторговался с ифритом ради мимолётного богатства. Как бы ни пересеклись твои пути с путями джинна, этот опыт одарил тебя острым взором, сладкими речами и изрядной долей магии.</content>
   <content contentuid="h9cef8d1ag8ca9gc531gcb6fg4f3bce89a4a8" version="1">Арфист</content>
-  <content contentuid="he00a4a5dg14ebg9a5cg87e7ga940f48f405e" version="2">Фит: Агент Арфистов
+  <content contentuid="he00a4a5dg14ebg9a5cg87e7ga940f48f405e" version="2">Черта: Агент Арфистов
 
 Ты принял приглашение вступить в Арфисты, поклявшись соблюдать кодекс Арфистов и служить на общее благо. Как и все Арфисты, ты понимаешь ценность командной работы, а также то, когда лучше действовать в одиночку. Ветераны Арфистов обучили тебя тайнам ордена — волшебным мелодиям, особым паролям и ловкости рук — и доверили тебе использовать эти знания для слежки за силами зла и подрыва их могущества.
 
@@ -2438,17 +2438,17 @@
 
 Отвлекающая мелодия. Когда ты используешь действие «Отвлечь», чтобы помочь союзнику в его броске атаки, враг, которого ты отвлекаешь, может находиться в радиусе 30 футов от тебя, а не 5 футов, при условии, что враг может тебя видеть или слышать.</content>
   <content contentuid="h3da2c0c2ge282gffe0g4fc2gbb39fdf2759a" version="1">Ледяной рыбак</content>
-  <content contentuid="h0326e7b1g8c73g586agce87gedf968fe63ea" version="2">Фит: Бдительный
+  <content contentuid="h0326e7b1g8c73g586agce87gedf968fe63ea" version="2">Черта: Бдительный
 
 Ты происходишь из гордой династии ледяных рыбаков из Десяти Городов Долины Ледяного Ветра. Ловля рыбы-костеголова — не самое славное ремесло на Севере, но честное. Ты натренировал свои чувства замечать малейший рывок лески, вываживал крупную форель из покрытых льдом озёр и выпотрошил столько рыбы-костеголова, что мог бы прокормить свою деревню много раз подряд. Эти опыты закалили твоё тело и разум для жизни искателя приключений.
 
 Стоим вместе. Когда союзник в радиусе 5 футов от тебя подвергается эффекту, который оттолкнул бы или притянул его, ты можешь реакцией помешать тому, чтобы союзника оттолкнули или притянули. Чтобы получить эту пользу, союзник не должен иметь состояние «Недееспособен».</content>
   <content contentuid="hc067f1degeab6gcb46ge111g828cec427e50" version="1">Рыцарь Перчатки</content>
-  <content contentuid="hc3c055e8g4d69gee62gad8cg75de8ea0fec1" version="1">Фит: Новичок Перчатки
+  <content contentuid="hc3c055e8g4d69gee62gad8cg75de8ea0fec1" version="1">Черта: Новичок Перчатки
 
 Не все, кто отвечает на зов высшей силы, довольствуются тем, что корпят над писаниями в душном храме. Ты избрал путь священного воина, вступив в Орден Перчатки. Как рыцарь Перчатки, ты проявляешь праведный гнев к силам зла, непоколебимую братскую преданность к соратникам по оружию и искреннее сострадание к выжившим в войнах. С оружием и священным символом в руках ты поклялся не успокоиться, пока свет справедливости не развеет тень хаоса по всему Фэйруну.</content>
   <content contentuid="h1ec0a941gc588ga341g98c0g61f235c0bedd" version="2">Вассал Альянса Лордов</content>
-  <content contentuid="hfabda183g7436g881egc8e9gf6ec8a6a8cb3" version="1">Фит: Агент Альянса Лордов
+  <content contentuid="hfabda183g7436g881egc8e9gf6ec8a6a8cb3" version="1">Черта: Агент Альянса Лордов
 
 Ты принёс клятву верности городу-члену Альянса Лордов. Как агент Альянса, ты должен блюсти принципы Альянса и стремиться к укреплению безопасности и процветания на Побережье Мечей. Ты поклялся принести честь и славу дому своего лорда, будь то обеспечение безопасности торговых дорог для купца-лорда Глубоководья или истребление чудовищ вверх по течению от Даггерфорда. Ты обучался искусству фехтования и государственной деятельности и владеешь клинком так же ловко, как и пером.
 
@@ -2456,19 +2456,19 @@
 
 Возвращённая честь. Когда враг, которого ты видишь, наносит тебе урон, ты получаешь преимущество на свой следующий бросок атаки против этого врага до конца твоего следующего хода.</content>
   <content contentuid="ha3b66239g0fceg1dd7gf543g116ada2a1fc1" version="1">Паломник лунного колодца</content>
-  <content contentuid="h38b188b6g2fc2g8138g725agd0f6fbca254c" version="1">Фит: Маг-послушник (Друид)
+  <content contentuid="h38b188b6g2fc2g8138g725agd0f6fbca254c" version="1">Черта: Маг-послушник (Друид)
 
 Как и многие выходцы с Муншаэских островов, ты вырос, почитая благословенную землю, её особых богов и таинственные святилища, именуемые лунными колодцами. Будучи паломником лунных колодцев, ты предпринял странствие, чтобы посетить каждый лунный колодец на карте (и за её пределами) и слиться с ним духом. В этих идиллических странствиях ты собрал коллекцию муншаэских народных песен, писал пейзажи очаровательных видов и даже научился обращаться с крупицей первобытной магии.</content>
   <content contentuid="h2b4ab32dg3157gd5f2g6219g187c4cdef9f7" version="1">Мульхорандский расхититель гробниц</content>
-  <content contentuid="h96aa51dag6fb2gf3a9g321fged3d699fde79" version="1">Фит: Удачливый
+  <content contentuid="h96aa51dag6fb2gf3a9g321fged3d699fde79" version="1">Черта: Удачливый
 
 Ты вырос в земле живых богов-царей, и в детстве тебе рассказывали бесчисленные истории о древних империях и погребённых городах. В этих сказаниях Мульхоранд был страной, изобилующей забытыми богатствами — бесценными сокровищами, ожидающими того, кто окажется достаточно хитёр и смел, чтобы отыскать их. Ты взял на себя задачу исследовать склепы, гробницы и пирамиды своей родины, чтобы вернуть реликвии своего народа.</content>
   <content contentuid="h21f658cdg376fg2dd1gdeaeg3ea987213e26" version="1">Хранитель миталя</content>
-  <content contentuid="hc52cd33bg7738g4b5eg085dgfcbe54464a64" version="1">Фит: Удачливый
+  <content contentuid="hc52cd33bg7738g4b5eg085dgfcbe54464a64" version="1">Черта: Удачливый
 
 Митали — источники великой магической мощи, способные изменять Ткань или даже саму природу реальности. Большинство из них были созданы в древности, и многие с тех пор повреждены или бездействуют. Как хранитель миталя из Долин, твоё первое знакомство с миталем, вероятно, произошло в руинах Миф Драннора. Ты странствуешь по Фэйруну в поисках других разрушенных мест силы, надеясь узнать больше об истории и возможностях миталей — а может, и восстановить повреждённый.</content>
   <content contentuid="h099b8c13g6adeg4d63g45deg207f06214cb4" version="1">Оруженосец Пурпурного Дракона</content>
-  <content contentuid="h07cec1a0g7220ge9ebg9676gffd755fa50d0" version="1">Фит: Ладья Пурпурного Дракона
+  <content contentuid="h07cec1a0g7220ge9ebg9676gffd755fa50d0" version="1">Черта: Ладья Пурпурного Дракона
 
 Ты посвятил свою жизнь безопасности Кормира и добивался приёма в орден элитных воинов этого королевства — Рыцарей Пурпурного Дракона. Но прежде чем получить шанс официально вступить в их ряды, ты должен послужить оруженосцем у рыцаря. Ты нашёл сеньора, готового взять тебя под свою опеку и обучить обычаям ордена. Сможешь ли ты придерживаться идеалов Рыцарей Пурпурного Дракона — славы, чести и силы — и доказать свою достойность рыцарского звания?
 
@@ -2476,15 +2476,15 @@
 
 Воодушевляющий клич. Ты можешь выбрать количество существ, равное твоему бонусу мастерства, которых ты видишь в радиусе 30 футов от себя. Эти существа получают Героическое вдохновение. Воспользовавшись этой способностью, ты не сможешь сделать это снова, пока не закончишь долгий отдых.</content>
   <content contentuid="h625450b8g42bdgc0cag5d94g932492b64ed0" version="1">Рашемийский странник</content>
-  <content contentuid="h75277cafgfc31g7483g2ad8gfd91011a85cc" version="1">Фит: Стойкий
+  <content contentuid="h75277cafgfc31g7483g2ad8gfd91011a85cc" version="1">Черта: Стойкий
 
 Ты провёл годы, странствуя по нагорью Рашемена — опасной продуваемой ветрами пустоши, усеянной древними обелисками, зачарованными пленять исчадий, и служащей домом драконам, гноллам и другим смертоносным существам. В такой глухой земле трудно найти друзей, и ты научился держать чужаков на расстоянии.</content>
   <content contentuid="h02a4f737g934ag8c5fg60d4gbe36054837ed" version="1">Изгнанник Теневладык</content>
-  <content contentuid="he15395feg34cbgfdbbgc738g75da56bca5d6" version="1">Фит: Свирепый атакующий
+  <content contentuid="he15395feg34cbgfdbbgc738g75da56bca5d6" version="1">Черта: Свирепый атакующий
 
 Ты всю жизнь тренировался, чтобы стать членом Теневладык — таинственной гильдии воров, управляющей королевством Теск из-за кулис. Скрытность и быстрые рефлексы были лишь началом твоего обучения у Теневладык; тебе также нужно было отточить свою беспощадность, чтобы обеспечить безопасность тайн гильдии. Но одна ошибка привела к твоему изгнанию из ордена. Теперь тебе предстоит идти собственным путём.</content>
   <content contentuid="hbefddbd1g977eg0ac2g94b5g9fadf9b4b0ba" version="1">Послушник пламени заклинаний</content>
-  <content contentuid="he8c36bc0g70c8g1d48g6d88g25469ebb3fda" version="1">Фит: Искра пламени заклинаний
+  <content contentuid="he8c36bc0g70c8g1d48g6d88g25469ebb3fda" version="1">Черта: Искра пламени заклинаний
 
 Ты носишь в себе дар пламени заклинаний: редкую форму магии, направляющую сырую мощь Ткани. Владение пламенем заклинаний тяжело сказывается на теле. Ты тренировал и разум, и тело, чтобы эффективно обращаться с этой священной силой.
 
@@ -2492,56 +2492,56 @@
 
 Пламя заклинаний. Ты осваиваешь заговор «Священное пламя». Ты также можешь накладывать этот заговор как бонусное действие количество раз, равное твоему бонусу мастерства, и восстанавливаешь все потраченные использования, когда заканчиваешь долгий отдых.</content>
   <content contentuid="h502820d0g8b37g078bg65f7g4a80446379d8" version="1">Наёмник Жентарима</content>
-  <content contentuid="hdeab958dge913gf95bg123dg27338a365d6d" version="2">Фит: Жентаримский головорез
+  <content contentuid="hdeab958dge913gf95bg123dg27338a365d6d" version="2">Черта: Жентаримский головорез
 
 Возможно, тебе нужны были деньги. Возможно, ты тосковал по семье, какой бы сомнительной она ни была. Или, может быть, ты просто умеешь доводить дело до конца любыми средствами. Какова бы ни была причина, ты завербовался в Жентарим — самую печально известную гильдию наёмников в Королевствах. Хотя лидеры Жентарима утверждают, что их организация скорее похожа на семью, чем на теневой синдикат, немногие семьи демонстрируют столько же бесчестия, непотизма и коррупции, сколько эта. Ты отточил свою хитрость, рефлексы и клинок, чтобы продвигаться по рангам гильдии.
 
 Использование бреши. Когда ты бросаешь урон за атаку по возможности, ты можешь бросить кубики урона дважды и использовать любой из результатов против цели.
 
 Семья прежде всего. Один раз за долгий отдых ты даруешь себе и союзникам в радиусе 30 футов от тебя преимущество на броски инициативы.</content>
-  <content contentuid="h6c0d30c6gd6bagd6f9g6ed0g7d30fcd174dd" version="1">Фит: Ледяной заклинатель</content>
+  <content contentuid="h6c0d30c6gd6bagd6f9g6ed0g7d30fcd174dd" version="1">Черта: Ледяной заклинатель</content>
   <content contentuid="he5401f43ga2cfgcd9dgcb25g6ce8548e686a" version="1">Заговор. Ты осваиваешь заговор «Луч холода».
 
 Морозный укус. Один раз за ход, когда ты попадаешь по существу броском атаки и наносишь урон Холодом, ты можешь временно подавить защиты существа. Существо вычитает 1d4 из своего следующего спасброска, совершаемого до конца твоего следующего хода.</content>
-  <content contentuid="h046e98e9gd6d2gf0ecga207gad73de421d8c" version="1">Фит: Отмеченный драконом</content>
-  <content contentuid="h1b40d160ge647gb336gde38g35a23097c13b" version="1">Сопротивление урону. Когда ты получаешь этот фит, выбери Кислоту, Холод, Огонь, Молнию или Яд. Ты обладаешь сопротивлением к выбранному типу урона.
+  <content contentuid="h046e98e9gd6d2gf0ecga207gad73de421d8c" version="1">Черта: Отмеченный драконом</content>
+  <content contentuid="h1b40d160ge647gb336gde38g35a23097c13b" version="1">Сопротивление урону. Когда ты получаешь эту черту, выбери Кислоту, Холод, Огонь, Молнию или Яд. Ты обладаешь сопротивлением к выбранному типу урона.
 
-Внушающая страх мощь. Когда ты наносишь урон существу в рамках действия «Атака» или «Магия» в свой ход, ты можешь использовать способность «Драконий ужас» из фита «Послушник Культа Дракона» как бонусное действие в этом ходу.</content>
-  <content contentuid="h956022bdge5c5g1d50gfb23ga2e9b937150f" version="1">Фит: Магия Анклава</content>
+Внушающая страх мощь. Когда ты наносишь урон существу в рамках действия «Атака» или «Магия» в свой ход, ты можешь использовать способность «Драконий ужас» из черты «Послушник Культа Дракона» как бонусное действие в этом ходу.</content>
+  <content contentuid="h956022bdge5c5g1d50gfb23ga2e9b937150f" version="1">Черта: Магия Анклава</content>
   <content contentuid="h99dd2a82gb360g8747g2eafg30d4b056f72d" version="1">У тебя всегда подготовлено заклинание «Шипастый рост». Ты можешь наложить его один раз, не расходуя ячейку заклинания, и восстанавливаешь эту способность, когда заканчиваешь короткий отдых. При наложении заклинания таким образом оно не требует концентрации.</content>
-  <content contentuid="h7330e7c6gc771g8abbg45f0g15512946f998" version="1">Фит: Фейский проказник</content>
+  <content contentuid="h7330e7c6gc771g8abbg45f0g15512946f998" version="1">Черта: Фейский проказник</content>
   <content contentuid="h7e916fa3g95c4g0367g8918g7dd56be199a8" version="1">Скачущий по фейским тропам. Когда ты используешь действие «Отход» в свой ход, сложная местность не требует от тебя дополнительного перемещения до конца этого хода.
 
-Смущающий удар. Когда ты попадаешь по существу броском атаки, ты можешь попытаться смутить цель. Цель должна преуспеть в спасброске Мудрости (СЛ 8 плюс модификатор характеристики, увеличенной этим фитом, и твой бонус мастерства), иначе получит помеху на спасброски до конца твоего следующего хода.
+Смущающий удар. Когда ты попадаешь по существу броском атаки, ты можешь попытаться смутить цель. Цель должна преуспеть в спасброске Мудрости (СЛ 8 плюс модификатор характеристики, увеличенной этой чертой, и твой бонус мастерства), иначе получит помеху на спасброски до конца твоего следующего хода.
 
 Ты можешь использовать эту способность количество раз, равное твоему бонусу мастерства, и восстанавливаешь все потраченные использования, когда заканчиваешь долгий отдых.</content>
-  <content contentuid="h077c85ecg890cg792bg6840gee3051f5be3e" version="1">Фит: Магия джиннов</content>
+  <content contentuid="h077c85ecg890cg792bg6840gee3051f5be3e" version="1">Черта: Магия джиннов</content>
   <content contentuid="h0ef080f7gca72g7669g8b06g981e2feedb49" version="2">Ты получаешь две ячейки заклинания 1-го круга и одну ячейку заклинания 2-го круга.</content>
-  <content contentuid="h8ee570adg0fe2g0097g40e1g8134e53943ad" version="1">Фит: Командная работа Арфистов</content>
+  <content contentuid="h8ee570adg0fe2g0097g40e1g8134e53943ad" version="1">Черта: Командная работа Арфистов</content>
   <content contentuid="h9e8fefadgbcc7g10f5ga4aage45ad3d82e96" version="2">Иссушающая игра слов. Когда ты используешь действие «Отвлечь», чтобы помочь союзнику в его броске атаки против врага, этот враг также получает помеху на первый спасбросок, совершаемый им до начала твоего следующего хода.
 
 Вдохновляющая сила воли. Ты получаешь преимущество на спасброски против состояний «Испуган» и «Парализован».</content>
-  <content contentuid="h4aee3eacgaf72gc757g8d80g048d0a64e805" version="1">Фит: Лордовская решимость</content>
+  <content contentuid="h4aee3eacgaf72gc757g8d80g048d0a64e805" version="1">Черта: Лордовская решимость</content>
   <content contentuid="h86fbc975g75b4gcf4cg3416geb64d948c1e4" version="1">Знаменосец. Ты невосприимчив к состояниям «Распростёрт», «Очарован» и «Испуган».</content>
-  <content contentuid="h75370f04gff6egfa29g73e5g4e8d6739e8fa" version="1">Фит: Отмеченный миталем</content>
+  <content contentuid="h75370f04gff6egfa29g73e5g4e8d6739e8fa" version="1">Черта: Отмеченный миталем</content>
   <content contentuid="h81877b18gdacfg553cge0c9g65813ccf4557" version="1">Твоё заклинание может высвободить всплески необузданной магии. Один раз за ход ты можешь бросить 1d20 сразу после того, как наложишь заклинание с использованием ячейки заклинания. Если выпадает 20, брось по таблице всплесков дикой магии, чтобы создать магический эффект.</content>
-  <content contentuid="h3860f913g1f6fg4b18g9ecfgabcab0169949" version="1">Фит: Стойкость Ордена</content>
+  <content contentuid="h3860f913g1f6fg4b18g9ecfgabcab0169949" version="1">Черта: Стойкость Ордена</content>
   <content contentuid="hddb981a7g0a29gd059gf634g1b2d20e1a8fd" version="1">Пока ты используешь «Стоим вместе» (Новичок Перчатки), союзники в радиусе 5 футов от тебя невосприимчивы к состоянию «Распростёрт» и имеют преимущество на спасброски Силы.</content>
-  <content contentuid="h9c38c422gaf7bg5622gf3baga2123af217ab" version="1">Фит: Командант Пурпурного Дракона</content>
+  <content contentuid="h9c38c422gaf7bg5622gf3baga2123af217ab" version="1">Черта: Командант Пурпурного Дракона</content>
   <content contentuid="hf790b35fg5b7ege376ge7e5gfdcf78fcbf35" version="2">Воодушевление союзника. Бонусным действием ты укрепляешь одного союзника, которого видишь в радиусе 30 футов. Этот союзник получает временные очки здоровья в количестве 2d6 плюс твой бонус мастерства. Ты можешь использовать это бонусное действие количество раз, равное твоему бонусу мастерства, и восстанавливаешь все потраченные использования, когда заканчиваешь долгий отдых.
 
 Последний рубеж. Ты получаешь преимущество на броски атаки, пока ты истекаешь кровью.</content>
-  <content contentuid="h9de5f3bdgd036g8fc7gc000g9f162c3acfc6" version="1">Фит: Адепт пламени заклинаний</content>
+  <content contentuid="h9de5f3bdgd036g8fc7gc000g9f162c3acfc6" version="1">Черта: Адепт пламени заклинаний</content>
   <content contentuid="h94e22d9cg05ceg0802gc712g372cd3b8f030" version="1">Заклинания, которые ты накладываешь, и атаки, которые ты совершаешь, игнорируют &lt;LSTag Tooltip="Resistant"&gt;сопротивление&lt;/LSTag&gt; лучистому урону. Кроме того, когда ты наносишь лучистый урон заклинанием, ты не можешь выбросить 1. </content>
-  <content contentuid="h2d5b87b6g1172g67b5gcfefg0bf170e5aaef" version="1">Фит: Жентаримская тактика</content>
+  <content contentuid="h2d5b87b6g1172g67b5gcfefg0bf170e5aaef" version="1">Черта: Жентаримская тактика</content>
   <content contentuid="h06b8380ag7f73g106agdf63g8dabbadb964c" version="1">Возмездие. Сразу после того, как существо в радиусе 5 футов от тебя попадает по тебе атакой ближнего боя, ты можешь совершить атаку по возможности против этого существа.
 
 Универсальный наёмник. Выбери навык, которым ты владеешь. Ты обладаешь экспертизой в этом навыке.</content>
-  <content contentuid="h32fd92c5gd42cg926fgb1adg572674b52c38" version="1">Фит: Отмеченный драконом (Сопротивление кислоте)</content>
-  <content contentuid="hca54a12agc1f9g2a70g2257g737e96e7df9b" version="1">Фит: Отмеченный драконом (Сопротивление холоду)</content>
-  <content contentuid="h0a63962age9c8g7392g84a8g55d4962d5732" version="1">Фит: Отмеченный драконом (Сопротивление огню)</content>
-  <content contentuid="h7dded34cg6b05gddbbg76fcg1c9672c5bb9f" version="1">Фит: Отмеченный драконом (Сопротивление молнии)</content>
-  <content contentuid="h8e3378b3gc69bgb63dgcd15gad7e31607dfd" version="1">Фит: Отмеченный драконом (Сопротивление яду)</content>
+  <content contentuid="h32fd92c5gd42cg926fgb1adg572674b52c38" version="1">Черта: Отмеченный драконом (Сопротивление кислоте)</content>
+  <content contentuid="hca54a12agc1f9g2a70g2257g737e96e7df9b" version="1">Черта: Отмеченный драконом (Сопротивление холоду)</content>
+  <content contentuid="h0a63962age9c8g7392g84a8g55d4962d5732" version="1">Черта: Отмеченный драконом (Сопротивление огню)</content>
+  <content contentuid="h7dded34cg6b05gddbbg76fcg1c9672c5bb9f" version="1">Черта: Отмеченный драконом (Сопротивление молнии)</content>
+  <content contentuid="h8e3378b3gc69bgb63dgcd15gad7e31607dfd" version="1">Черта: Отмеченный драконом (Сопротивление яду)</content>
   <content contentuid="h8b2a4760g816bg9df8ge286g6fbe1c2b0bcd" version="1">Помеха на все спасброски.</content>
   <content contentuid="h6546b917g1c6dg4ca0g0808g9c4689c5032e" version="1">Смущающий удар</content>
   <content contentuid="h1d522e3cgc9dcg916bgfa58g5cd59e1f7ebd" version="1">Когда ты попадаешь по существу броском атаки, ты можешь попытаться смутить цель. Цель должна преуспеть в спасброске Мудрости, иначе получит помеху на спасброски до конца твоего следующего хода.</content>
@@ -2555,22 +2555,22 @@
   <content contentuid="h2287dbd5gd1ffga56ag677eg771e23ed7f4c" version="1">Получает временные очки здоровья в количестве 2d6 плюс бонус мастерства заклинателя.</content>
   <content contentuid="h1bca3b80g61b0g1241gad6dg59a5b944962e" version="1">Возмездие</content>
   <content contentuid="h3b19c28cg80dcg38e9gc853g0c674ef3b5e5" version="1">Сразу после того, как существо в радиусе 5 футов от тебя попадает по тебе атакой ближнего боя, ты можешь совершить атаку по возможности против этого существа.</content>
-  <content contentuid="h7266774agddd3g954ag8493g86532999d2ae" version="1">Забытые Королевства: Герои Фэйруна: Общие фит</content>
-  <content contentuid="hb3bd7f59g0610g8deag20d1ga4bb317c1e9b" version="1">Забытые Королевства: Герои Фэйруна: Общие фит</content>
+  <content contentuid="h7266774agddd3g954ag8493g86532999d2ae" version="1">Забытые Королевства: Герои Фэйруна: Общие черты</content>
+  <content contentuid="hb3bd7f59g0610g8deag20d1ga4bb317c1e9b" version="1">Забытые Королевства: Герои Фэйруна: Общие черты</content>
   <content contentuid="h29ab3531g02fbgac9egf6b3g45f445778cb6" version="1">Ледяной заклинатель</content>
   <content contentuid="hc43fd16fgcee0g3229g6eaeg057f44917b4e" version="1">Заговор. Ты осваиваешь заговор «Луч холода».
 
 Морозный укус. Один раз за ход, когда ты попадаешь по существу броском атаки и наносишь урон Холодом, ты можешь временно подавить защиты существа. Существо вычитает 1d4 из своего следующего спасброска, совершаемого до конца твоего следующего хода.</content>
   <content contentuid="h1c19b94dg0f16g1ad9ge5e7g35a02c85c163" version="1">Отмеченный драконом</content>
-  <content contentuid="hb1847b98g2cc5gbe94g49f1gc11efdbfb5a5" version="1">Сопротивление урону. Когда ты получаешь этот фит, выбери Кислоту, Холод, Огонь, Молнию или Яд. Ты обладаешь сопротивлением к выбранному типу урона.
+  <content contentuid="hb1847b98g2cc5gbe94g49f1gc11efdbfb5a5" version="1">Сопротивление урону. Когда ты получаешь эту черту, выбери Кислоту, Холод, Огонь, Молнию или Яд. Ты обладаешь сопротивлением к выбранному типу урона.
 
-Внушающая страх мощь. Когда ты наносишь урон существу в рамках действия «Атака» или «Магия» в свой ход, ты можешь использовать способность «Драконий ужас» из фита «Послушник Культа Дракона» как бонусное действие в этом ходу.</content>
+Внушающая страх мощь. Когда ты наносишь урон существу в рамках действия «Атака» или «Магия» в свой ход, ты можешь использовать способность «Драконий ужас» из черты «Послушник Культа Дракона» как бонусное действие в этом ходу.</content>
   <content contentuid="h2fc939d2gdb2egc680g11d6gd7ecee244590" version="1">Магия Анклава</content>
   <content contentuid="hd23656cfg57f8g9378gb515g69eaf09ae893" version="1">У тебя всегда подготовлено заклинание «Шипастый рост». Ты можешь наложить его один раз, не расходуя ячейку заклинания, и восстанавливаешь эту способность, когда заканчиваешь короткий отдых. При наложении заклинания таким образом оно не требует концентрации.</content>
   <content contentuid="hb79bd3d9g613dg22a6gdf89ged7bb1cc5f1d" version="1">Фейский проказник</content>
   <content contentuid="h978a3ea0g73c2gc59cgc52eg4aecbaa53dae" version="1">Скачущий по фейским тропам. Когда ты используешь действие «Отход» в свой ход, сложная местность не требует от тебя дополнительного перемещения до конца этого хода.
 
-Смущающий удар. Когда ты попадаешь по существу броском атаки, ты можешь попытаться смутить цель. Цель должна преуспеть в спасброске Мудрости (СЛ 8 плюс модификатор характеристики, увеличенной этим фитом, и твой бонус мастерства), иначе получит помеху на спасброски до конца твоего следующего хода.
+Смущающий удар. Когда ты попадаешь по существу броском атаки, ты можешь попытаться смутить цель. Цель должна преуспеть в спасброске Мудрости (СЛ 8 плюс модификатор характеристики, увеличенной этой чертой, и твой бонус мастерства), иначе получит помеху на спасброски до конца твоего следующего хода.
 
 Ты можешь использовать эту способность количество раз, равное твоему бонусу мастерства, и восстанавливаешь все потраченные использования, когда заканчиваешь долгий отдых.</content>
   <content contentuid="h2aff44fbga1d3g84a9g91cege594afc8805c" version="1">Магия джиннов</content>
@@ -2595,18 +2595,18 @@
   <content contentuid="he09232a3g8429ge28bga994gd171ef3f3292" version="1">Возмездие. Сразу после того, как существо в радиусе 5 футов от тебя попадает по тебе атакой ближнего боя, ты можешь совершить атаку по возможности против этого существа.
 
 Универсальный наёмник. Выбери навык, которым ты владеешь. Ты обладаешь экспертизой в этом навыке.</content>
-  <content contentuid="h3566bf7ege17bg0f56g4fbdgfac65706f1a2" version="1">При создании персонажа или пересборе выбирай только один фит происхождения «Маг-послушник». Выбор более одного может привести к непредвиденным проблемам.</content>
-  <content contentuid="hca895012gaf5dg78a6g7a2eg37692b43b104" version="2">Фит: Смертельная стрельба</content>
+  <content contentuid="h3566bf7ege17bg0f56g4fbdgfac65706f1a2" version="1">При создании персонажа или пересборе выбирай только одну черту происхождения «Маг-послушник». Выбор более одного может привести к непредвиденным проблемам.</content>
+  <content contentuid="hca895012gaf5dg78a6g7a2eg37692b43b104" version="2">Черта: Смертельная стрельба</content>
   <content contentuid="hc67a4df3gcd8bgf957g4d35gee2424c14472" version="2">Бонусным действием ты можешь получить преимущество на бросок атаки дальнобойным оружием в текущем ходу. Ты можешь использовать это бонусное действие, только если не перемещался в этом ходу, и после его использования твоя скорость становится 0 до конца текущего хода.</content>
-  <content contentuid="h1f3d47b6gbc1fgf224g07d7g6347072349e6" version="2">Фит: Драконоборец</content>
+  <content contentuid="h1f3d47b6gbc1fgf224g07d7g6347072349e6" version="2">Черта: Драконоборец</content>
   <content contentuid="h2407b839gbdcdg7a29gb1ceg77ebf305424f" version="2">Ты получаешь преимущество на броски атаки против существ Большого размера и крупнее. Кроме того, ты наносишь дополнительный урон, равный твоему модификатору Силы, когда попадаешь по таким существам.</content>
-  <content contentuid="hedc33adbg89b5ge699g0a6bgf060748fb8bb" version="2">Фит: Блеск гнева</content>
+  <content contentuid="hedc33adbg89b5ge699g0a6bgf060748fb8bb" version="2">Черта: Блеск гнева</content>
   <content contentuid="h1fa402eeg7070g07b2gbfbaga67c4ad37e78" version="3">Бонусным действием ты можешь заставить оружие ближнего боя, которым ты вооружён, испускать тусклый свет в радиусе 10 футов в течение 10 ходов. Этот свет является солнечным. Пока оружие сияет, оно наносит лучистый урон вместо своего обычного типа урона.
 
 Когда ты наносишь критическое попадание атакой оружия ближнего боя, ты можешь бросить один из кубиков урона оружия ещё один раз и добавить результат.</content>
-  <content contentuid="h12c8377bg73a7g1523gd2f7gce9b3dfd5731" version="2">Фит: Проворство</content>
+  <content contentuid="h12c8377bg73a7g1523gd2f7gce9b3dfd5731" version="2">Черта: Проворство</content>
   <content contentuid="had1170f7ga4c6gba7cg3bc3gbf03f398ce3a" version="1">Ты получаешь +1 к КД. Ты теряешь этот бонус, если становишься недееспособным или берёшь щит.</content>
-  <content contentuid="h4796f67cg2656g7e4fg0832gdc67d0ccef8e" version="2">Фит: Свирепый выстрел</content>
+  <content contentuid="h4796f67cg2656g7e4fg0832gdc67d0ccef8e" version="2">Черта: Свирепый выстрел</content>
   <content contentuid="h06a155bfgfa73g3924g9442gc7875f6aba6d" version="1">При совершении атаки дальнобойным оружием ты используешь свой модификатор Силы для бросков атаки и урона. Ты должен использовать один и тот же модификатор для обоих бросков.</content>
   <content contentuid="hef1660acg903fg1237g99f8g6b9c3a3e042b" version="1">Смертельная стрельба</content>
   <content contentuid="hd4674709g7d30gba4fgad6cg17adc9b95a51" version="2">Бонусным действием ты получаешь преимущество на бросок атаки дальнобойным оружием в текущем ходу. Ты можешь использовать эту способность, только если не перемещался в этом ходу, и после её использования твоя скорость становится 0 до конца текущего хода.</content>
@@ -2674,7 +2674,7 @@
 
 Лунная живительность. Один раз за ход, когда ты восстанавливаешь очки здоровья существа заклинанием, ты можешь потратить кубик бардовского вдохновения и увеличить количество восстанавливаемых очков здоровья на число, равное выпавшему значению кубика бардовского вдохновения. Скорость существа также увеличивается на 10 футов до конца его следующего хода.</content>
   <content contentuid="haca3aef8ga626gc323g22acg746bfa4a9426" version="1">Уровень 3: Первобытные знания</content>
-  <content contentuid="h16bfd443g2ac4gcdcegaa91gcadfccb20761" version="1">Ты осваиваешь друидический язык и один заговор из списка заклинаний друида. Для тебя он считается заклинанием барда, но не учитывается в количестве известных тебе заговоров. 
+  <content contentuid="h16bfd443g2ac4gcdcegaa91gcadfccb20761" version="1">Ты осваиваешь друидический язык и один заговор из списка заклинаний друида. Для тебя он считается заклинанием барда, но не учитывается в количестве известных тебе заговоров.
 
 Кроме того, выбери один из следующих навыков: «Уход за животными», «Проницательность», «Медицина», «Природа», «Восприятие» или «Выживание». Ты получаешь владение этим навыком.</content>
   <content contentuid="h3911c437g16cagdddcgede4gaa0c643aec8c" version="1">Уровень 6: Благословения лунного света</content>
@@ -2829,7 +2829,7 @@
 
 Если ты выбираешь Бейна, ты получаешь сопротивление к психическому урону и можешь накладывать «Малую иллюзию».
 
-Если ты выбираешь Баала, ты получаешь сопротивление к урону ядом и можешь накладывать «Оберег клинка».
+Если ты выбираешь Баала, ты получаешь сопротивление к урону ядом и можешь накладывать «Защита от оружия».
 
 Если ты выбираешь Миркула, ты получаешь сопротивление к некротическому урону и можешь накладывать «Леденящее касание».
 
@@ -2853,13 +2853,13 @@
   <content contentuid="h6d6ec091g6782g7736g3633g063bf2cee187" version="1">Зловещая присяга: Бейн</content>
   <content contentuid="h7601f4ccg5ecfg89a8gf4d4gc425820bf2a2" version="1">Если ты выбираешь Бейна, ты получаешь сопротивление к психическому урону и можешь накладывать «Малую иллюзию».</content>
   <content contentuid="h51a11419g7905g3848gd5bfgf6d72fd1a609" version="1">Зловещая присяга: Баал</content>
-  <content contentuid="hb4a3c0b4g39f9g3519g8885g8624730cfa75" version="1">Если ты выбираешь Баала, ты получаешь сопротивление к урону ядом и можешь накладывать «Оберег клинка».</content>
+  <content contentuid="hb4a3c0b4g39f9g3519g8885g8624730cfa75" version="1">Если ты выбираешь Баала, ты получаешь сопротивление к урону ядом и можешь накладывать «Защита от оружия».</content>
   <content contentuid="h23fa8e89g70f4g44b2g3bceg2ab0350c9dde" version="1">Зловещая присяга: Миркул</content>
   <content contentuid="h6523df3dgbad7g0fafg867dg13134c55e3c3" version="1">Если ты выбираешь Миркула, ты получаешь сопротивление к некротическому урону и можешь накладывать «Леденящее касание».</content>
   <content contentuid="h9a96305agf2f9g7267gdc69g37c278977066" version="1">Зловещая присяга: Бейн</content>
   <content contentuid="haa7b4b2bga3d4g5493g0cd0g0d1480ede8e3" version="1">Ты получаешь сопротивление к психическому урону и можешь накладывать «Малую иллюзию».</content>
   <content contentuid="h3d0aa39dg266bg7c47g97e8g8d257554171a" version="1">Зловещая присяга: Баал</content>
-  <content contentuid="h58ee4755g4d7eg3830g0e23g9eeb9de00bf1" version="1">Ты получаешь сопротивление к урону ядом и можешь накладывать «Оберег клинка».</content>
+  <content contentuid="h58ee4755g4d7eg3830g0e23g9eeb9de00bf1" version="1">Ты получаешь сопротивление к урону ядом и можешь накладывать «Защита от оружия».</content>
   <content contentuid="hb44a03abgc118ge0f2g55eegf877db7779de" version="1">Зловещая присяга: Миркул</content>
   <content contentuid="h6e38ab81gffdegf60dgddc7gdd71c617d269" version="1">Ты получаешь сопротивление к некротическому урону и можешь накладывать «Леденящее касание».</content>
   <content contentuid="h4d43ff27g7af4g7c74gd48dg5f5bf9706659" version="1">1</content>
@@ -3114,9 +3114,14 @@
   <content contentuid="h6c75a711gccb2g34c5g5489gfbaf6012200e" version="2">Договорное оружие: Некротический урон</content>
   <content contentuid="hcd88f337g7b53g35deg791bgf37bf6314ed5" version="2">Договорное оружие: Психический урон</content>
   <content contentuid="ha2a934dbg1420gf4c4g7431gcf508603657a" version="2">Договорное оружие: Лучистый урон</content>
-  <content contentuid="h93c42699gb5efg50eeg700ag91b482874bb9" version="1">Связать договорное оружие (Некротический урон)</content>
-  <content contentuid="hbe8ae593g19c8gc31cg51cdg845945c5b41b" version="1">Связать договорное оружие (Психический урон)</content>
-  <content contentuid="h8697b53cg246dg4397g9db8gc35b4035bc5b" version="1">Связать договорное оружие (Лучистый урон)</content>
+  <content contentuid="h2eeadc40g0ba4g1146g9408g3a7f972a8ba4" version="1">Бонусным действием ты можешь призвать в свою руку оружие договора — простое или воинское оружие на твой выбор, с которым ты связываешься, — либо установить связь с магическим оружием, к которому ты прикасаешься; ты не можешь связаться с магическим оружием, если к нему настроен кто-то другой или с ним связан другой чернокнижник. Пока связь не прекратится, ты владеешь этим оружием и можешь использовать его как магический фокус.
+
+Каждый раз, когда ты атакуешь связанным оружием, ты можешь использовать свой модификатор Харизмы для бросков атаки и урона вместо Силы или Ловкости; кроме того, ты можешь заставить оружие наносить некротический, психический или лучистый урон вместо его обычного типа урона.
+
+Твоя связь с оружием прекращается, если ты снова используешь бонусное действие этой способности, если оружие находится на расстоянии более 5 футов от тебя в течение 1 минуты или дольше, либо если ты умираешь. Призванное оружие исчезает, когда связь прекращается.</content>
+  <content contentuid="h93c42699gb5efg50eeg700ag91b482874bb9" version="1">Привязать оружие договора (Некротический урон)</content>
+  <content contentuid="hbe8ae593g19c8gc31cg51cdg845945c5b41b" version="1">Привязать оружие договора (Психический урон)</content>
+  <content contentuid="h8697b53cg246dg4397g9db8gc35b4035bc5b" version="1">Привязать оружие договора (Лучистый урон)</content>
   <content contentuid="h672e82feg2734g7895ga227gd76ffbfded41" version="1">Прими облик гигантского барсука, который может &lt;LSTag Type="Spell" Tooltip="Target_Burrow_GiantBadger"&gt;закапываться&lt;/LSTag&gt; под землю.</content>
   <content contentuid="h3d2a0062g8a04g4942g776fg8389d4b68f1b" version="1">Прими облик белого медведя, который может &lt;LSTag Type="Spell" Tooltip="Shout_GoadingRoar_Bear_Summon"&gt;провоцировать&lt;/LSTag&gt; врагов на атаку.</content>
   <content contentuid="he8e15200g5d16g3cfag9fd3g57eec75fb43b" version="1">Прими облик кошки, которая может избегать внимания и &lt;LSTag Type="Spell" Tooltip="Shout_Distract_Cat_Summon"&gt;мяукать&lt;/LSTag&gt;, отвлекая врагов.</content>
@@ -3506,15 +3511,15 @@
   <content contentuid="h3e91d02cg9178geb72g919bgd2f45a5bb6ea" version="1">Аксиоматические печати: Некротический урон</content>
   <content contentuid="h4272602ag3fa1g398bgb969g13be228622d0" version="1">Устаревший</content>
   <content contentuid="h1fb22109gb584g03f6g66f8g5a967386d305" version="1">Устаревший</content>
-  <content contentuid="hd9a3ce8dg39a9gb357gf766g5a7a8e8a2b47" version="1">Посвящение в магию: Жрец</content>
+  <content contentuid="hd9a3ce8dg39a9gb357gf766g5a7a8e8a2b47" version="1">Посвященный в магию: Жрец</content>
   <content contentuid="h0df39a9dg1cfag178cg75f0g6adabe0323af" version="1">Ты изучаешь 2 &lt;LSTag Tooltip="Cantrip"&gt;заговора&lt;/LSTag&gt; и одно заклинание 1-го круга из списка заклинаний жреца.</content>
-  <content contentuid="hafe8b652g4e6agf0fdg68cdgfa9f15790432" version="1">Посвящение в магию: Друид</content>
+  <content contentuid="hafe8b652g4e6agf0fdg68cdgfa9f15790432" version="1">Посвященный в магию: Друид</content>
   <content contentuid="h65af80fagec9bg5351g2f9agc30e65db33e7" version="1">Ты изучаешь 2 &lt;LSTag Tooltip="Cantrip"&gt;заговора&lt;/LSTag&gt; и одно заклинание 1-го круга из списка заклинаний друида.</content>
   <content contentuid="hc0b48f30g3f17g3a7fg830dgd6bcb23043d6" version="1">Устаревший</content>
   <content contentuid="h3199ad9dg3293g80a6g74adg1bf55e642821" version="1">Устаревший</content>
   <content contentuid="h14abb3cdgc934g76a7g47aeg2111983c2f7a" version="1">Устаревший</content>
   <content contentuid="hd8bfa253g9a70g0b3dga7f3g8b52b646dc9a" version="1">Устаревший</content>
-  <content contentuid="h01e4f65cg7f45g4509g7911g655523dbfc23" version="1">Посвящение в магию: Волшебник</content>
+  <content contentuid="h01e4f65cg7f45g4509g7911g655523dbfc23" version="1">Посвященный в магию: Волшебник</content>
   <content contentuid="hf53d0a43g624eg7762g6910g0264f0ae7c73" version="1">Ты изучаешь 2 &lt;LSTag Tooltip="Cantrip"&gt;заговора&lt;/LSTag&gt; и одно заклинание 1-го круга из списка заклинаний волшебника.</content>
   <content contentuid="hb45ab210g4dfeg44aage273g11ab2c83f7b8" version="1">Оберегающие печати</content>
   <content contentuid="hd8757627g198cg4659gbdcbgf8c916e4b023" version="1">Когда ты бонусным действием накладываешь печать иллриггера на существо или когда ты сжигаешь печать, наложенную на существо, ты получаешь эффект «Защиты клинка» на 2 хода.</content>
@@ -3560,7 +3565,7 @@
   <content contentuid="h32ce3bc3gbd08g5553gcc7dga7ed37159c2b" version="1">Призыв фей: Красный колпак (иллюзия)</content>
   <content contentuid="h5e364771gbbf3gcea4gc521g7ebe73137887" version="1">Иллюзионист</content>
   <content contentuid="hd2b280acgffccg1945g84d8g178fda0ac2df" version="1">Ты специализируешься на магии, которая ослепляет чувства и обманывает разум, а создаваемые тобой иллюзии заставляют невозможное казаться реальным.</content>
-  <content contentuid="hf232e287g63a4g3aa2g6f5fg25aabe4d8c7e" version="2">Фит: Изменённый</content>
+  <content contentuid="hf232e287g63a4g3aa2g6f5fg25aabe4d8c7e" version="2">Черта: Изменённый</content>
   <content contentuid="h1844772eg802eg78e4g4c43g59d82d32b9d4" version="2">Ты был изменён магией, наукой или нестабильной смесью того и другого. У тебя есть явное физическое дополнение на твой выбор из приведённых ниже вариантов. Это дополнение очевидно — например, швы, привитые части тел других существ или имплантаты — если только оно не скрыто.
 
 Естественный доспех. У тебя есть чешуя, пластины или толстая шкура, дающие тебе КД 10 + твои модификаторы Ловкости и Телосложения.
@@ -3568,34 +3573,34 @@
 Естественное оружие. У тебя есть когти, клыки, рога или иное естественное оружие, которым ты можешь наносить безоружные удары, наносящие 1d6 урона при попадании.
 
 Ночное зрение. У тебя есть тёмное зрение с дальностью 60 футов. Если у тебя уже есть тёмное зрение, его дальность увеличивается на 30 футов.</content>
-  <content contentuid="ha288579eg93c9g19b4gd809gcbf44c5b3b6b" version="1">Фит: Плетущий обереги</content>
+  <content contentuid="ha288579eg93c9g19b4gd809gcbf44c5b3b6b" version="1">Черта: Плетущий обереги</content>
   <content contentuid="h02d99bfegfef1g8e2dg60b7g277ac219dbc2" version="1">Тебе известны деревенские снадобья и проклятия, передаваемые через учение Старых путей, и ты можешь заключать их в маленькие плетёные обереги. Ты получаешь следующие преимущества.
 
 У тебя всегда подготовлены заклинания «Благословение» и «Дурное знамение». Кроме того, ты получаешь одну ячейку заклинания 1-го круга, которую можно использовать для их сотворения.</content>
-  <content contentuid="h62e3caedgde0fgd173g13ddg989c09ea72d8" version="1">Фит: Могильщик</content>
+  <content contentuid="h62e3caedgde0fgd173g13ddg989c09ea72d8" version="1">Черта: Могильщик</content>
   <content contentuid="he41177dagaf29g13c8gc756g66414bcb409d" version="1">Изучение погребальных обрядов и забота о покое мёртвых сделали тебя проводником между мирами живых и мёртвых. Ты получаешь следующие преимущества.
 
 Божественный канал. Ты получаешь одно использование свойства «Божественная сила» от класса Жреца и можешь создавать с его помощью эффект «Изгнание нежити». Если у тебя уже есть «Божественная сила», ты добавляешь это использование к свойству одного класса на твой выбор.</content>
   <content contentuid="h5edcd5f5g2597g4cb6g5ebcg6f37e6b6f496" version="1">Эксперимент</content>
-  <content contentuid="h2ba4fa20gb5a4gcf6fg0c48g86e73cad2928" version="1">Фит: Изменённый
+  <content contentuid="h2ba4fa20gb5a4gcf6fg0c48g86e73cad2928" version="1">Черта: Изменённый
 
 Ты навсегда изменён неким радикальным, физическим образом, возможно, даже сделан чудовищным. Богохульное слияние науки, алхимии и магии изменило тебя — возможно, чтобы исцелить какую-то неисцелимую болезнь или чтобы проверить пределы твоей биологии. Процесс удался, по крайней мере частично, но изменение оставило на тебе свой след. Неизгладимое искажение твоей формы может вызывать страх у тех, кто не понимает, что видит.
 
 Изменённый. Ты получаешь естественный доспех (КД 10 + модификаторы Ловкости и Телосложения), естественное оружие (безоружные удары 1d6) и тёмное зрение до 60 футов (или +30 футов, если оно у тебя уже есть).</content>
   <content contentuid="h8de8eb2bg4b97gfd23gf17fg132f6e2c9157" version="1">Страж покоя</content>
-  <content contentuid="h7d405f4ag1770gee29gfd7egc0479b1be286" version="1">Фит: Могильщик
+  <content contentuid="h7d405f4ag1770gee29gfd7egc0479b1be286" version="1">Черта: Могильщик
 
 В месте, что ближе к землям мёртвых, нежели живых, тех, кто заботится о вечном покое и упокоении усопших, почитают со смесью уважения и опасения. Ты занимался ремеслом могильщика, гробовщика и бальзамировщика. Порой ты был единственным, кто говорил доброе слово в честь ушедших. Притеснения нежити хорошо тебе известны, и ты не терпишь её вмешательства в покой тех, кто вверен твоей заботе.
 
 Могильщик. Ты получаешь одно использование свойства «Божественная сила» от класса Жреца и можешь создавать с его помощью эффект «Изгнание нежити». Если у тебя уже есть «Божественная сила», ты добавляешь это использование к свойству одного класса на твой выбор.</content>
-  <content contentuid="h49b1f4ebg0b80g1cbbg3266g01728d057db5" version="1">Фит: Стремительное чародейство</content>
-  <content contentuid="h485ec73fg065ag11a4g6c56g26237d4aa777" version="1">Фит: Презирающий смерть</content>
+  <content contentuid="h49b1f4ebg0b80g1cbbg3266g01728d057db5" version="1">Черта: Стремительное чародейство</content>
+  <content contentuid="h485ec73fg065ag11a4g6c56g26237d4aa777" version="1">Черта: Презирающий смерть</content>
   <content contentuid="h04a42f0bg5327gaeb5gd711g78bbff1f0780" version="1">Если эффект убил бы тебя мгновенно без спасбросков от смерти или уменьшил бы твои очки здоровья прямо до 0 без нанесения урона, твои очки здоровья вместо этого уменьшаются до значения, равного твоему уровню. Ты не сможешь использовать это преимущество снова, пока не завершишь долгий отдых.</content>
   <content contentuid="hbf7fe4b1g71e7g88d5g300dgca4d09fd7f60" version="1">Презирающий смерть</content>
   <content contentuid="hc19ea2ecg9a08gebf9gd8dbg264ac39f1d4e" version="1">Презирающий смерть</content>
   <content contentuid="hf825d6a4g01fbg9069gd8b6gd7c305318fc8" version="1">Ты можешь сотворить более одного заклинания, использующего ячейку заклинания, за свой ход.</content>
   <content contentuid="h6b9942c5g3516g176fg224dg36bf0a71d821" version="1">Лозоплетельщик</content>
-  <content contentuid="hdb90b6a2g422eg0fbeg786dgb67c50e37043" version="1">Фит: Плетущий обереги
+  <content contentuid="hdb90b6a2g422eg0fbeg786dgb67c50e37043" version="1">Черта: Плетущий обереги
 
 Тебе известны древние обряды, хранимые тайными друидами и деревенскими практиками в тенистых рощах первозданных лесов. Снадобья и проклятия, вплетённые в обереги из лозы, могут отводить беду и отпугивать зло. Но они с такой же лёгкостью могут навлечь мрак и гнев древних духов.
 
@@ -3642,20 +3647,20 @@
   <content contentuid="h7620f19ag43c9g05a4g36acg0cd45d849578" version="1">Круг Несломленных — это орден Друидов, которые оставили терпеливые учения своих предшественников, решив вместо этого взяться за оружие в защиту дикой природы. Эти воинственные Друиды формируют ополчения и используют ярость самой природы, чтобы силой изгнать любое надвигающееся зло, угрожающее их священным землям.
 
 Хотя хаотичный нрав природы и присущ этим Друидам, их тела и порывы укрощены тренировками и дисциплиной. Изначально родом из безжалостного Гнилого леса, учения этого круга столь же суровы, как и сам лес, сочетая наступление и защиту, чтобы противостоять всем вызовам мира.</content>
-  <content contentuid="h6b046ff8ga327gdc59g8f4fgebc351482d81" version="1">Уровень 3: Улучшенный Шиллелаг</content>
-  <content contentuid="hb033a976g4cccgdbedg5c40ge3ee8016bca2" version="1">Сотворяя «Шиллелаг», ты можешь наделить силой природы любое оружие ближнего боя, которое ты держишь; ты можешь выбрать, чтобы оружие сохранило свой обычный кубик урона вместо d8. Кроме того, ты можешь использовать любое оружие, которым ты владеешь, в качестве магического фокуса для своих заклинаний Друида.</content>
+  <content contentuid="h6b046ff8ga327gdc59g8f4fgebc351482d81" version="1">Уровень 3: Улучшенный Дубинка</content>
+  <content contentuid="hb033a976g4cccgdbedg5c40ge3ee8016bca2" version="1">Сотворяя «Дубинка», ты можешь наделить силой природы любое оружие ближнего боя, которое ты держишь; ты можешь выбрать, чтобы оружие сохранило свой обычный кубик урона вместо d8. Кроме того, ты можешь использовать любое оружие, которым ты владеешь, в качестве магического фокуса для своих заклинаний Друида.</content>
   <content contentuid="he9c252edgc46cg4450gfb88g57508151df65" version="1">Уровень 3: Заклинания Круга Несломленных</content>
   <content contentuid="head50b7eg3179gbc89g1334gbee0de9d925c" version="1">Твоя связь с Кругом Несломленных гарантирует, что у тебя всегда подготовлены определённые заклинания. Достигнув уровня Друида, указанного в таблице «Заклинания Круга Несломленных», ты впредь всегда имеешь перечисленные заклинания подготовленными.
 
-На 3-м уровне у тебя всегда подготовлены «Опутывающий удар», «Шиллелаг», «Сияющий удар» и «Верный удар». На 5-м уровне у тебя всегда подготовлено «Ускорение». На 7-м уровне у тебя всегда подготовлен «Огненный щит». На 9-м уровне у тебя всегда подготовлен «Огненный удар».
+На 3-м уровне у тебя всегда подготовлены «Опутывающий удар», «Дубинка», «Сияющий удар» и «Меткий удар». На 5-м уровне у тебя всегда подготовлено «Ускорение». На 7-м уровне у тебя всегда подготовлен «Огненный щит». На 9-м уровне у тебя всегда подготовлен «Огненный удар».
 </content>
   <content contentuid="h8ed0d8e9g85baga28cg5d7eg2778cf1bbf0a" version="1">Уровень 3: Дикое восстановление</content>
   <content contentuid="heb2a7f7ag521bg6a02g5dffg52cdf49a9788" version="2">Ты получаешь способность восстанавливаться с помощью дикой, звериной магии, текущей сквозь тебя. Бонусным действием ты можешь потратить одно использование «Дикого облика», чтобы восстановить количество очков здоровья, равное 2d6 плюс твой уровень Друида. Это исцеление увеличивается на 1d6 на 5-м (3d6 плюс твой уровень Друида) и 10-м (4d6 плюс твой уровень Друида) уровнях Друида.</content>
-  <content contentuid="h7fe6e3e8gb94ag15c5g406eg227fcfa3c807" version="1">Уровень 6: Мастерство Шиллелага</content>
+  <content contentuid="h7fe6e3e8gb94ag15c5g406eg227fcfa3c807" version="1">Уровень 6: Мастерство Дубинкаа</content>
   <content contentuid="h7e8ca440g858fg8122g6567g8dbda7a1b2f0" version="1">Всякий раз, когда ты выполняешь действие «Атака» в свой ход, ты можешь атаковать оружием дважды вместо одного раза.</content>
   <content contentuid="hd5f1b8cag18ffgb6f6g47ffg3b8c0b38f590" version="1">Уровень 10: Друид-воин</content>
   <content contentuid="hf86fda08gd41fg7378gec9bg99ec11e5214f" version="1">Когда ты выполняешь действие «Атака» в свой ход, ты можешь заменить одну из атак сотворением одного из твоих заговоров Друида с временем сотворения, равным действию.</content>
-  <content contentuid="h33d907d8gd0a0gaee7g061fg578448183f33" version="1">Улучшенный Шиллелаг</content>
+  <content contentuid="h33d907d8gd0a0gaee7g061fg578448183f33" version="1">Улучшенный Дубинка</content>
   <content contentuid="h698d6323ge92fg1fd9g8d8bg36d7db994d94" version="1">Дикое восстановление</content>
   <content contentuid="hc24409fagede8g0aaag1ad3g32c2949bb667" version="2">Бонусным действием ты можешь потратить одно использование «Дикого облика», чтобы восстановить количество очков здоровья, равное 2d6 плюс твой уровень Друида. Это исцеление увеличивается на 1d6 на 5-м (3d6 плюс твой уровень Друида) и 10-м (4d6 плюс твой уровень Друида) уровнях Друида.</content>
   <content contentuid="hc064fa21ge684g65c0g9633g796b118177b3" version="1">Разъедающий удар</content>
@@ -3983,7 +3988,7 @@
   <content contentuid="h0152f209g939bg4575g22f7g26ad677352b5" version="1">Отрезанный от снов: Мудрость</content>
   <content contentuid="hb641ddd6g0950g5b50gf483g681c68224f61" version="1">Отрезанный от снов: Харизма</content>
   <content contentuid="h387fbbd8g1993g3f29gb171ge2f1a3b1e7cd" version="1">Универсальное</content>
-  <content contentuid="h0f6ded08gcd3bgf273gc080g6c03b3f1633b" version="1">Ты получаешь фит происхождения на свой выбор или можешь выбрать черту нечеловеческой расы.</content>
+  <content contentuid="h0f6ded08gcd3bgf273gc080g6c03b3f1633b" version="1">Ты получаешь черту происхождения на свой выбор или можешь выбрать черту нечеловеческой расы.</content>
   <content contentuid="h325e735fg2b3bg04e3g4111g0c40750b7fbe" version="1">Мастер умений</content>
   <content contentuid="h621fd279gebdag777dg35cdge79dc6dc09a3" version="1">Ты получаешь владение одним навыком на свой выбор.</content>
   <content contentuid="hffb15f0dg8d46g8ce2g4665g6ab0e628d277" version="1">Острые чувства</content>
@@ -4091,7 +4096,7 @@
   <content contentuid="he571e586gc384gf9bbg0231g7c7be2144adc" version="1">Растворись во тьме и стань &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;невидимым&lt;/LSTag&gt;.</content>
   <content contentuid="h87d3e26ag5e53gdf92g801cg4e8c26aac78e" version="1">Боевой заклинатель: Громовой клинок</content>
   <content contentuid="ha738254bg5dbag724ag511ag8d59cf1fed09" version="1">Боевой заклинатель: Зелёное пламя</content>
-  <content contentuid="h7e0866bbgdec1g07c2g7725gef3c6eb68247" version="1">Боевой заклинатель: Верный удар</content>
+  <content contentuid="h7e0866bbgdec1g07c2g7725gef3c6eb68247" version="1">Боевой заклинатель: Меткий удар</content>
   <content contentuid="h664f7fdag1793g4256gd73cga50bae7c538a" version="1">Боевой заклинатель: Мстительный клинок</content>
   <content contentuid="h67a39d88g2da4ga80bg2675g4c2a3e61a8ce" version="1">Боевой заклинатель: Шокирующее касание</content>
   <content contentuid="h58d3ea5cg20f9gc47cg638cg148f2229c69f" version="1">Сотвори заклинание по существу, выходящему из зоны досягаемости.</content>
@@ -4340,7 +4345,7 @@
 
 Тайный некроз. Некротический урон от твоих атак, заклинаний Колдуна и особенностей Колдуна игнорирует Сопротивление Некротическому урону.
 
-Ужасающий некроз. Сотворяемые тобой заклинания и совершаемые атаки игнорируют &lt;LSTag Tooltip="Resistant"&gt;Сопротивление&lt;/LSTag&gt; Некротическому урону. Кроме того, при нанесении Некротического урона заклинанием ты не можешь выбросить [1]. 
+Ужасающий некроз. Сотворяемые тобой заклинания и совершаемые атаки игнорируют &lt;LSTag Tooltip="Resistant"&gt;Сопротивление&lt;/LSTag&gt; Некротическому урону. Кроме того, при нанесении Некротического урона заклинанием ты не можешь выбросить [1].
 
 Выносливость нежити. Тебе не нужно спать, и магия не может усыпить тебя.</content>
   <content contentuid="he206cdceg59e4gfa8cg4328gf3d7938622de" version="1">Уровень 10: Некротическая оболочка</content>
@@ -4406,24 +4411,24 @@
   <content contentuid="ha989ddfeg14aege15egc09fgf298fc8f086e" version="1">Покровитель — Древнее зло</content>
   <content contentuid="h3504f51eg1ac0gd563g881eg515b53b1f37b" version="1">Выбирая этот подкласс, ты можешь связать себя с невообразимым существом из Дальнего края или старшим богом — таким как Тариздун, Скованный бог; Заргон, Возвращающийся; Хадар, Тёмный голод; или Великий Ктулху. Либо ты можешь взывать к нескольким сущностям, не подчиняясь одной из них. Мотивы этих существ непостижимы, и Древнее зло может быть безразлично к твоему существованию. Но изученные тобой тайны тем не менее позволяют черпать из него странную магию.</content>
   <content contentuid="h68dcfb27g52ddg20aag7977g147e317f34ce" version="1">Уровень 3: Заклинания Гексблейда</content>
-  <content contentuid="h4336900ag6e5egc73bgadb8g0a8300eeb536" version="1">Магия твоего покровителя гарантирует, что у тебя всегда подготовлены определённые заклинания. Когда ты достигаешь уровня Колдуна, указанного в таблице «Заклинания Гексблейда», с этого момента у тебя всегда подготовлены перечисленные заклинания. На 3-м уровне ты изучаешь Тайную бодрость, Порчу, Магическое оружие, Щит и Грозовое сокрушение. На 5-м уровне — Навести проклятие и Ливень стрел. На 7-м уровне — Свободу перемещения и Сокрушительное сокрушение. На 9-м уровне — Стальной ветровой удар.</content>
-  <content contentuid="h6b8ec4b1g6350g0a0ag1d7dgc74d66ad8dd7" version="1">На 3-м уровне ты изучаешь Тайную бодрость, Порчу, Магическое оружие, Щит и Грозовое сокрушение. На 5-м уровне — Навести проклятие и Ливень стрел. На 7-м уровне — Свободу перемещения и Сокрушительное сокрушение. На 9-м уровне — Стальной ветровой удар.</content>
+  <content contentuid="h4336900ag6e5egc73bgadb8g0a8300eeb536" version="1">Магия твоего покровителя гарантирует, что у тебя всегда подготовлены определённые заклинания. Когда ты достигаешь уровня Колдуна, указанного в таблице «Заклинания Гексблейда», с этого момента у тебя всегда подготовлены перечисленные заклинания. На 3-м уровне ты изучаешь Тайную бодрость, Сглаз, Магическое оружие, Щит и Грозовое сокрушение. На 5-м уровне — Навести проклятие и Ливень стрел. На 7-м уровне — Свободу перемещения и Сокрушительное сокрушение. На 9-м уровне — Стальной ветровой удар.</content>
+  <content contentuid="h6b8ec4b1g6350g0a0ag1d7dgc74d66ad8dd7" version="1">На 3-м уровне ты изучаешь Тайную бодрость, Сглаз, Магическое оружие, Щит и Грозовое сокрушение. На 5-м уровне — Навести проклятие и Ливень стрел. На 7-м уровне — Свободу перемещения и Сокрушительное сокрушение. На 9-м уровне — Стальной ветровой удар.</content>
   <content contentuid="hfa17cac1gac88g9d72gf29eg0946ab8c0bb4" version="1">Уровень 3: Проявление Гексблейда</content>
-  <content contentuid="ha92a78f3ge96agd47egb8ddg6ad716d3cc56" version="3">Проклятие Гексблейда. Ты можешь сотворять Порчу без затрат ячейки заклинания количество раз, равное твоему модификатору Харизмы (минимум один раз), и восстанавливаешь все потраченные использования, когда заканчиваешь Долгий отдых. При сотворении Порчи призрачное оружие, напоминающее твоего покровителя, вращается вокруг проклятой цели.
+  <content contentuid="ha92a78f3ge96agd47egb8ddg6ad716d3cc56" version="3">Проклятие Гексблейда. Ты можешь сотворять Сглаз без затрат ячейки заклинания количество раз, равное твоему модификатору Харизмы (минимум один раз), и восстанавливаешь все потраченные использования, когда заканчиваешь Долгий отдых. При сотворении Сглаза призрачное оружие, напоминающее твоего покровителя, вращается вокруг проклятой цели.
 
-Манёвры Гексблейда. Один раз за ход, когда ты попадаешь по цели, проклятой твоей Порчей, броском атаки, ты можешь вызвать один из следующих дополнительных эффектов:
+Манёвры Гексблейда. Один раз за ход, когда ты попадаешь по цели, проклятой твоим Сглазом, броском атаки, ты можешь вызвать один из следующих дополнительных эффектов:
 
 Истощающий удар, Мучительный клинок, Сдерживающая метка</content>
   <content contentuid="h1aa8b9e4g53d3g8ae5gbb29g4fe1ab6952bb" version="1">Уровень 6: Похититель жизни</content>
   <content contentuid="h83838ad6gee6dg6e8fg5d57g389e936516fb" version="3">Мощь твоего покровителя позволяет тебе вытягивать жизненную силу из тех, кого ты проклинаешь, даруя тебе следующие преимущества.
 
-Голодная порча. Всякий раз, когда цель, проклятая твоей Порчей, опускается до 0 Очков здоровья в результате твоих действий, ты восстанавливаешь Очки здоровья в размере 1d8 плюс твой модификатор Харизмы.
+Голодный сглаз. Всякий раз, когда цель, проклятая твоим Сглазом, опускается до 0 Очков здоровья в результате твоих действий, ты восстанавливаешь Очки здоровья в размере 1d8 плюс твой модификатор Харизмы.
 
-Неотвратимый клинок. Один раз за ход, когда ты совершаешь бросок атаки по цели, проклятой твоей Порчей, и промахиваешься, ты можешь нанести 1d6 Некротического урона.</content>
+Неотвратимый клинок. Один раз за ход, когда ты совершаешь бросок атаки по цели, проклятой твоим Сглазом, и промахиваешься, ты можешь нанести 1d6 Некротического урона.</content>
   <content contentuid="h6dea9c47g93a0g6397g3d9eg04b5e5b83704" version="1">Уровень 10: Броня гексов</content>
-  <content contentuid="h49e72c1cg2d7bgc3fbg7e56gdbf9203830ad" version="1">Когда ты получаешь урон от цели, проклятой твоей Порчей, ты можешь Реакцией уменьшить этот урон на 2d8 плюс твой модификатор Харизмы. Ты можешь использовать эту способность количество раз, равное твоему модификатору Харизмы, и восстанавливаешь все потраченные использования, когда заканчиваешь Долгий отдых.</content>
+  <content contentuid="h49e72c1cg2d7bgc3fbg7e56gdbf9203830ad" version="1">Когда ты получаешь урон от цели, проклятой твоим Сглазом, ты можешь Реакцией уменьшить этот урон на 2d8 плюс твой модификатор Харизмы. Ты можешь использовать эту способность количество раз, равное твоему модификатору Харизмы, и восстанавливаешь все потраченные использования, когда заканчиваешь Долгий отдых.</content>
   <content contentuid="h8a44a18ag2f79g5f22ga66dgf9d14502995b" version="1">Проявление Гексблейда</content>
-  <content contentuid="hbc1ef353geeb2g5ddeg7ab9gd396c0474ea5" version="1">Ты можешь сотворять Порчу без затрат ячейки заклинания количество раз, равное твоему модификатору Харизмы (минимум один раз), и восстанавливаешь все потраченные использования, когда заканчиваешь Долгий отдых.</content>
+  <content contentuid="hbc1ef353geeb2g5ddeg7ab9gd396c0474ea5" version="1">Ты можешь сотворять Сглаз без затрат ячейки заклинания количество раз, равное твоему модификатору Харизмы (минимум один раз), и восстанавливаешь все потраченные использования, когда заканчиваешь Долгий отдых.</content>
   <content contentuid="h26188b0bg7517gb0f4g956fg7f3316d5dd96" version="1">Истощающий удар</content>
   <content contentuid="hc89adc48gff23ge491g6563g134f3a4d1c41" version="1">Цель совершает спасбросок Телосложения против Сложности спасброска от твоих заклинаний. При провале она не может совершать Атаки по возможности, а её Скорость уменьшается вдвое до начала твоего следующего хода.</content>
   <content contentuid="hc7b0f28egb110gffacg5c7egb0143bdd1014" version="1">Мучительный клинок</content>
@@ -4431,21 +4436,21 @@
   <content contentuid="hd36755d1g9403g81dbgf4efg2fb565b73a1f" version="1">Сдерживающая метка</content>
   <content contentuid="h1e510414g6658gde2bgccc5g70c12902a1fb" version="1">Цель получает Помеху на следующий спасбросок, совершаемый ею до начала твоего следующего хода.</content>
   <content contentuid="h338cdd4dg57cdg382agd382g6e2930e3713f" version="1">Броня гексов</content>
-  <content contentuid="h16aa8ef8g9057g8804g10e3g6c754af3589d" version="1">Когда ты получаешь урон от цели, проклятой твоей Порчей, ты можешь Реакцией уменьшить этот урон на 2d8 плюс твой модификатор Харизмы. Ты можешь использовать эту способность количество раз, равное твоему модификатору Харизмы, и восстанавливаешь все потраченные использования, когда заканчиваешь Долгий отдых.</content>
+  <content contentuid="h16aa8ef8g9057g8804g10e3g6c754af3589d" version="1">Когда ты получаешь урон от цели, проклятой твоим Сглазом, ты можешь Реакцией уменьшить этот урон на 2d8 плюс твой модификатор Харизмы. Ты можешь использовать эту способность количество раз, равное твоему модификатору Харизмы, и восстанавливаешь все потраченные использования, когда заканчиваешь Долгий отдых.</content>
   <content contentuid="h352f1d01g9b89ge024gdb8cg7b67da12f0e0" version="1">Истощающий удар</content>
   <content contentuid="h9a19d8f9g6000gec74g2e00g5462feeee031" version="2">Цель совершает спасбросок Телосложения против Сложности спасброска от твоих заклинаний. При провале она не может совершать Атаки по возможности, а её Скорость уменьшается вдвое до начала твоего следующего хода.</content>
   <content contentuid="ha104f4d6gd9eeg1862g7452g73819c4c7c2f" version="1">Мучительный клинок</content>
   <content contentuid="h61d275d7g23e9gcb80g1af5g7d1bceb17545" version="2">Цель совершает спасбросок Мудрости против Сложности спасброска от твоих заклинаний. При провале, следующий раз, когда она совершает бросок атаки против существа, отличного от тебя, до начала твоего следующего хода, она получает 1d6 Некротического урона.</content>
   <content contentuid="h8af79815gc7d3gf37ag99eage18bc75980e0" version="1">Сдерживающая метка</content>
   <content contentuid="hca3e32abg4341g51e2ga8f4gba89522cb18f" version="1">Цель получает Помеху на следующий спасбросок, совершаемый ею до начала твоего следующего хода.</content>
-  <content contentuid="h8dcb95d2ga517g32ebg6912g7069289dcf67" version="1">Голодная порча</content>
-  <content contentuid="h7ab53afeg6536g6c48g43eagddb5bf8b087e" version="1">Всякий раз, когда цель, проклятая твоей Порчей, опускается до 0 Очков здоровья, ты восстанавливаешь Очки здоровья в размере 1d8 плюс твой модификатор Харизмы.</content>
-  <content contentuid="hf03aeb95g5dbbg3147g324cg388502cbfe2e" version="1">Когда ты получаешь урон от цели, проклятой твоей Порчей, ты можешь Реакцией уменьшить этот урон на 2d8 плюс твой модификатор Харизмы. Ты можешь использовать эту способность количество раз, равное твоему модификатору Харизмы, и восстанавливаешь все потраченные использования, когда заканчиваешь Долгий отдых.</content>
-  <content contentuid="hca29dcb5g220cg55c3g2c6dgb8a635486d83" version="1">Голодная порча</content>
-  <content contentuid="h10cb65eeg6a98g7720g30f1g78e524e4746c" version="2">Фит: Повелитель рун</content>
+  <content contentuid="h8dcb95d2ga517g32ebg6912g7069289dcf67" version="1">Голодный сглаз</content>
+  <content contentuid="h7ab53afeg6536g6c48g43eagddb5bf8b087e" version="1">Всякий раз, когда цель, проклятая твоим Сглазом, опускается до 0 Очков здоровья, ты восстанавливаешь Очки здоровья в размере 1d8 плюс твой модификатор Харизмы.</content>
+  <content contentuid="hf03aeb95g5dbbg3147g324cg388502cbfe2e" version="1">Когда ты получаешь урон от цели, проклятой твоим Сглазом, ты можешь Реакцией уменьшить этот урон на 2d8 плюс твой модификатор Харизмы. Ты можешь использовать эту способность количество раз, равное твоему модификатору Харизмы, и восстанавливаешь все потраченные использования, когда заканчиваешь Долгий отдых.</content>
+  <content contentuid="hca29dcb5g220cg55c3g2c6dgb8a635486d83" version="1">Голодный сглаз</content>
+  <content contentuid="h10cb65eeg6a98g7720g30f1g78e524e4746c" version="2">Черта: Повелитель рун</content>
   <content contentuid="h39e6f66dgb9c7g82d9ge759gc88241418c54" version="1">Рунная магия. Ты знаешь две руны на свой выбор из таблицы «Рунные заклинания». Ты изучаешь заклинания 1-го уровня, связанные с этими рунами, как указано в таблице «Рунные заклинания». Ты получаешь одну ячейку заклинания 1-го уровня, которую можно использовать только для сотворения этих заклинаний. Ты также можешь сотворять заклинания, связанные с твоими рунами, используя любые другие имеющиеся у тебя ячейки заклинаний.</content>
-  <content contentuid="h7161b496g15eeg82f5gd23agbcddcc7ddb56" version="1">Родовой фит: Удар великанов</content>
-  <content contentuid="h603f364eg76f2g4896gd3eeg723e7e1e85a7" version="2">Ты впитал первобытную магию, дающую тебе отголосок мощи великанов. Один раз за ход, когда ты попадаешь по цели ближней оружейной атакой или дальнобойной оружейной атакой с использованием метательного оружия, ты можешь наделить атаку дополнительным эффектом в зависимости от выбранного преимущества. Ты можешь использовать этот фит количество раз, равное твоему бонусу мастерства, и восстанавливаешь все потраченные использования, когда заканчиваешь долгий отдых.</content>
+  <content contentuid="h7161b496g15eeg82f5gd23agbcddcc7ddb56" version="1">Родовая черта: Удар великанов</content>
+  <content contentuid="h603f364eg76f2g4896gd3eeg723e7e1e85a7" version="2">Ты впитал первобытную магию, дающую тебе отголосок мощи великанов. Один раз за ход, когда ты попадаешь по цели ближней оружейной атакой или дальнобойной оружейной атакой с использованием метательного оружия, ты можешь наделить атаку дополнительным эффектом в зависимости от выбранного преимущества. Ты можешь использовать эту черту количество раз, равное твоему бонусу мастерства, и восстанавливаешь все потраченные использования, когда заканчиваешь долгий отдых.</content>
   <content contentuid="hae3fe0d8g977dg32d2g8d96g1076ec054f12" version="1">Повелитель рун: Облако</content>
   <content contentuid="hf833f73bg69acga9f0ge44cgf4535aeb7eb0" version="1">Рунная магия: Затуманивание</content>
   <content contentuid="h7e25491bgcdfcgd62fg64efg5de054df9a4b" version="1">Повелитель рун: Смерть</content>
@@ -5352,10 +5357,10 @@
   <content contentuid="h23f50accgc0b8gb376gbc26g1fff227eb3f5" version="1">Заклинание поглощает часть входящей энергии, уменьшая её воздействие на тебя и сохраняя её для твоей следующей атаки ближнего боя. Ты получаешь сопротивление к типу урона, вызвавшему срабатывание, до начала твоего следующего хода. Кроме того, при первом попадании атакой ближнего боя в твоём следующем ходу цель получает дополнительные [1] урона того же типа, и заклинание заканчивается.</content>
   <content contentuid="h0d100dc2gb2a7ge09fg624dga1554d1a009c" version="1">Поглощение стихий</content>
   <content contentuid="hab392145gc890gaa18g04cag5b0b653d9632" version="1">Заклинание поглощает часть входящей энергии, уменьшая её воздействие на тебя и сохраняя её для твоей следующей атаки ближнего боя. Ты получаешь сопротивление к типу урона, вызвавшему срабатывание, до начала твоего следующего хода. Кроме того, при первом попадании атакой ближнего боя в твоём следующем ходу цель получает дополнительные [1] урона того же типа, и заклинание заканчивается.</content>
-  <content contentuid="h93909048gc250g4ba0g8188g2450b9be939f" version="1">Магический ученик: Поглощение стихий</content>
+  <content contentuid="h93909048gc250g4ba0g8188g2450b9be939f" version="1">Посвященный в магию: Поглощение стихий</content>
   <content contentuid="hc53cf966gb23fg281eg72e3g7fee38b6dede" version="1">Волна тьмы</content>
   <content contentuid="h029cddf2gf1b9g86a2g45e7g18bf046b40f1" version="3">Ты выпускаешь волну клубящихся теней, заполняющую пространство рядом с тобой. Каждое существо в 10-футовом Кубе тьмы, исходящем от тебя при сотворении заклинания, совершает спасбросок Мудрости. При провале существо получает 2d8 психического урона и Ослеплено до начала твоего следующего хода. При успехе оно получает половину урона и не Ослеплено.</content>
-  <content contentuid="hde134590g10deg4df4g9d4age5320c74f0fb" version="1">Магический ученик: Волна тьмы</content>
+  <content contentuid="hde134590g10deg4df4g9d4age5320c74f0fb" version="1">Посвященный в магию: Волна тьмы</content>
   <content contentuid="h74c27673g4c1bga1beg5a49ga7aec2022773" version="1">Теневой усик</content>
   <content contentuid="h347e6fe4g42a8g22ecgdb29gefc97f004483" version="1">Ты создаёшь длинный, крадущий жизнь теневой усик, который хлещет по существу, которое ты видишь в пределах дальности.
 
@@ -5363,7 +5368,7 @@
 </content>
   <content contentuid="ha3d984fag9166g3a51gbc9fg45fc0d47e563" version="1">Теневой усик</content>
   <content contentuid="h243a5f49gc364g1981gbc7fge75041c302f9" version="1">Получи временные очки здоровья.</content>
-  <content contentuid="h6c91c1d0geff6g49ddg9fd0gd5d83740ee64" version="1">Магический ученик: Теневой усик</content>
+  <content contentuid="h6c91c1d0geff6g49ddg9fd0gd5d83740ee64" version="1">Посвященный в магию: Теневой усик</content>
   <content contentuid="h28992689gab7eg0bcega955gb5ee06d7deaf" version="1">Ты можешь тратить кости хитов во время короткого отдыха, чтобы восстановить очки здоровья.</content>
   <content contentuid="hbd79e588g85a8ga317gab92g1dc3ec782773" version="1">Связанное оружие: основное</content>
   <content contentuid="h6193eaa0gbef3g3810gc2ffg05099e13d0ea" version="1">Связанное оружие: вторичное</content>
@@ -5410,10 +5415,10 @@
   <content contentuid="h68cc0961gb6ceg3e67g1ae5g31162e46016b" version="1">Телесное искажение Горгорота</content>
   <content contentuid="h2ee464d4g6606g2b85g7008gfc6f4aaa15b0" version="1">Выбери гуманоида твоего размера, которого ты видишь в пределах дальности. Ты физически трансформируешься, становясь точной копией этого существа на время действия. Даже тщательный физический осмотр не выявит никаких различий между тобой и целью.</content>
   <content contentuid="h35b9b915g3bf7g0d1dg728fg2be8d9ced715" version="1">Телесное искажение Горгорота</content>
-  <content contentuid="hfb5ff22bgbb91g4598ga3acg629a9bc0bbf5" version="1">Магический ученик: Телесное искажение Горгорота</content>
+  <content contentuid="hfb5ff22bgbb91g4598ga3acg629a9bc0bbf5" version="1">Посвященный в магию: Телесное искажение Горгорота</content>
   <content contentuid="hff8c3953ga42fgb3bfgdad0g52582466fdd5" version="1">Катапульта</content>
   <content contentuid="h33322b0egd4a5g9e80gdabdg3abd5d4b2ddc" version="1">Выбери один предмет весом от 1 до 5 фунтов в пределах дальности, который не надет и не несом. Предмет летит по прямой до 60 футов в выбранном тобой направлении, прежде чем упасть на землю, останавливаясь раньше, если столкнётся с твёрдой поверхностью. Если предмет столкнётся с существом, это существо должно совершить спасбросок Ловкости. При провале предмет поражает цель и останавливается. Когда предмет во что-то попадает, и предмет, и то, во что он попал, получают дробящий урон.</content>
-  <content contentuid="h531eb181g2185g4a8eg9a93g7866406491b2" version="1">Магический ученик: Катапульта</content>
+  <content contentuid="h531eb181g2185g4a8eg9a93g7866406491b2" version="1">Посвященный в магию: Катапульта</content>
   <content contentuid="hcee9d863gb64eg2f43gf305g608bc4aa5061" version="1">Жаждущий клинок</content>
   <content contentuid="h0f617ea9g5fc5gff42gae8ag41a6861d59c0" version="1">Ты наделяешь удерживаемое оружие или свои безоружные удары ненасытной негативной энергией. На время действия, когда ты впервые за ход попадаешь по существу атакой усиленным оружием или безоружным ударом, цель получает некротический урон, равный модификатору твоей магической характеристики, и ты получаешь количество временных очков здоровья, равное нанесённому некротическому урону.</content>
   <content contentuid="h700ed84bg957fg2a5dg1d50g4d69487d7001" version="1">Жаждущий клинок</content>
@@ -5426,7 +5431,7 @@
   <content contentuid="h73991020g32ffg9f15g55bcgd13afd4a160b" version="1">Шипованный доспех</content>
   <content contentuid="hf4db5d55g3f59g3137gd662g4504298dce7d" version="1">Получает [1] временных очков здоровья. Если существо попадает по цели броском атаки ближнего боя до окончания заклинания, это существо получает колющий урон, равный количеству потерянных временных очков здоровья в результате атаки. Заклинание заканчивается раньше, если у цели не останется временных очков здоровья, дарованных этим заклинанием.</content>
   <content contentuid="h56d01007g7639g76b3g6944ge9e37780bfa3" version="1">Шипованный доспех</content>
-  <content contentuid="h5aaf459egc2f8g443cgbd6cgea65032712ea" version="1">Магический ученик: Шипованный доспех</content>
+  <content contentuid="h5aaf459egc2f8g443cgbd6cgea65032712ea" version="1">Посвященный в магию: Шипованный доспех</content>
   <content contentuid="h090fc065geb1dge3e6g22b1g1d5d2fa91c92" version="1">Серебряное копьё Лаэраль</content>
   <content contentuid="h55dbf30agbd12g301dga596g935c9cd3ab5e" version="1">Серебряная энергия вырывается из тебя линией длиной 120 футов и шириной 5 футов. Каждое существо на твой выбор в этой Линии совершает спасбросок Силы. При провале существо получает силовой урон и состояние «распростёрт». При успехе существо получает только половину урона.</content>
   <content contentuid="he19de47agde53g5b49gd45ag019467942cb7" version="1">Драконье дыхание</content>
@@ -5635,15 +5640,15 @@
   <content contentuid="h2684b3a8g5785g4b36g91aag1a15e2d6235a" version="1">Доступные классы: Изобретатель, Жрец, Друид</content>
   <content contentuid="hd6b957e7gf997g46f7gb34cgd07ed973fb49" version="1">Свиток: Священное пламя</content>
   <content contentuid="hc5261503g7ffeg44f4g9adeg4a453b390776" version="1">Доступные классы: Жрец</content>
-  <content contentuid="h969e79f8ga241g4f3eg904ag8f4858d7c146" version="1">Свиток: Шиллелаг</content>
+  <content contentuid="h969e79f8ga241g4f3eg904ag8f4858d7c146" version="1">Свиток: Дубинка</content>
   <content contentuid="hf6ca44c0g6ba9g4f48g9216g56a087c03808" version="1">Доступные классы: Друид</content>
   <content contentuid="h4e359edbgd14fg48e3gaaa8gec2f6f104eff" version="1">Свиток: Чудотворство</content>
   <content contentuid="h68e674cegfb0eg4833g9161g16eb4a4a0ae6" version="1">Доступные классы: Жрец</content>
   <content contentuid="hd8acfaf2gdc2fg4a8bg85d8g786e61843d71" version="1">Свиток: Шипованный кнут</content>
   <content contentuid="h2cec4524g94f3g406cg949bgabc8f7ab61a8" version="1">Доступные классы: Изобретатель, Друид</content>
-  <content contentuid="hd794ebceg972cg429aga2fbg3d9a7db47812" version="1">Свиток: Звон по усопшим</content>
+  <content contentuid="hd794ebceg972cg429aga2fbg3d9a7db47812" version="1">Свиток: Погребальный звон</content>
   <content contentuid="h9776cce3ga97cg44bag8675g5a02e511c687" version="1">Доступные классы: Жрец, Колдун, Волшебник</content>
-  <content contentuid="h096ebfe5g0cb5g4dfeg934cg08534e139de2" version="1">Свиток: Верный удар</content>
+  <content contentuid="h096ebfe5g0cb5g4dfeg934cg08534e139de2" version="1">Свиток: Меткий удар</content>
   <content contentuid="hd82e1bf6g1c8dg4df4g85e8ge5cc7b209599" version="1">Доступные классы: Изобретатель, Бард, Чародей, Колдун, Волшебник</content>
   <content contentuid="hd6dc4fb0ga5fag40e4g94a8gf532a76634c0" version="1">Свиток: Злая насмешка</content>
   <content contentuid="h5b8d54d1ga5f7g44ebgb131g294190f528a8" version="1">Доступные классы: Бард</content>
@@ -5900,4 +5905,107 @@
   <content contentuid="h49f573e0g51d8gab8ag3788g56d525e94705" version="1">Куо-тоа</content>
   <content contentuid="hf0fa09deg1153gff8agc30fgf43e347dc403" version="1">Безумные рыбоподобные обитатели Подземья. Они поклоняются воображаемым богам с исступлённым религиозным рвением.</content>
   <content contentuid="h3f9f2b2agdef2g4181g854bgea3484c5155b" version="2">Сахуагин</content>
+  <content contentuid="h032b8a67g1d02geaddg0a67g885aa13f6da3" version="1">Формы круга</content>
+  <content contentuid="h065d0fb7gf230g4f4bgb93eg770449c981b0" version="1">Отмеченный тьмой: Луч болезни</content>
+  <content contentuid="h06e15584g7b42g42e3g9defgae871657d6f9" version="1">Посвященный в магию: Облако тумана</content>
+  <content contentuid="h07573fd6g637bg4a9eg99f4ge58d387e8342" version="1">Магия тьмы: Цветной всплеск</content>
+  <content contentuid="h0a5c529fg9486g9b83gd997g8501abdfdb1b" version="1">Пока ты не покинешь эту форму, твой КД равен 13 плюс твой модификатор Мудрости, если эта сумма выше КД зверя.</content>
+  <content contentuid="h115b8b53g622bg479ag9fd7g14390d34dc89" version="1">Посвященный в магию: Свет фей</content>
+  <content contentuid="h1243bcf0g786ag42b5gb4fbg0cbf8d10bf4e" version="1">Посвященный в магию: Жир</content>
+  <content contentuid="h13f6765agce21gaac2g7533gb00e71fd0d88" version="1">Ты можешь добавлять свой модификатор Мудрости к спасброскам Телосложения.</content>
+  <content contentuid="h15ab5126g2cc1g4af1gba03g00cfda0bb70a" version="1">Посвященный в магию: Хроматическая сфера</content>
+  <content contentuid="h184c59beg8cefg4990ga08bg9f97071dab68" version="1">Отмеченный феями: Очарование личности</content>
+  <content contentuid="h195d1d62g638dg46f4g9ae1g687f458f2200" version="1">Посвященный в магию: Покров тени</content>
+  <content contentuid="h1dcac678ge441g4e18ga33fgbbe5e379795d" version="1">Посвященный в магию: Защита от зла и добра</content>
+  <content contentuid="h1f496538gbf09g4d50gaffdg135542e5928e" version="1">Магия фей: Героизм</content>
+  <content contentuid="h23321941gc35bg4651g9eb6gf98a34d2777f" version="1">Магия фей: Ужасный смех Ташы</content>
+  <content contentuid="h23814ae4g55bbg25cbg61a4gcf6756b9d02f" version="1">Тифлинги с хтоническим наследием чувствуют не только притяжение Карцери, но и алчность Гехенны и мрак Аида. Некоторые из этих тифлингов выглядят как ходячие трупы. Другие обладают неземной красотой суккуба или имеют общие физические черты с ночной каргой, юголотом или иным нейтрально-злым исчадием-предком.</content>
+  <content contentuid="h23b5cf8bgb1a2g4710g80e0gb9671a8df06c" version="1">Магия тьмы: Нанесение ран</content>
+  <content contentuid="h2713c54cga6ddg44bfgbd2fg22ad3a219a9e" version="1">Магия фей: Диссонантный шёпот</content>
+  <content contentuid="h3210721bg910cg6d5egf7e0gace10faa1161" version="1">Получено 12 &lt;LSTag Tooltip="TemporaryHitPoints"&gt;временных очков здоровья&lt;/LSTag&gt;.</content>
+  <content contentuid="h34439d3ag8594g4874g9ca5g56e52762b609" version="1">Магия тьмы: Покров тени</content>
+  <content contentuid="h36704839gee4ag41f3g9e73gc61a6ec696a0" version="1">Посвященный в магию: Скороход</content>
+  <content contentuid="h3b3a5fecgf368g4ca4g838dg229fd96a03af" version="1">Посвященный в магию: Катапульта</content>
+  <content contentuid="h3c573a5dg1db5g476ega866g1b05ba51908d" version="1">Посвященный в магию: Приказ</content>
+  <content contentuid="h3d584bfbgb23eg45ecgb6acg46f59eb344cd" version="1">Дьявольская бодрость</content>
+  <content contentuid="h3db64f18g5e4dg4e28g992ag1e784239f0a8" version="1">Магия фей: Сон</content>
+  <content contentuid="h3e205f1agd960g4959g948fg29bb942db979" version="1">Посвященный в магию: Нанесение ран</content>
+  <content contentuid="h40188367g58fcg4db9g9794geffb5d03c4ef" version="1">Посвященный в магию: Отпугивание</content>
+  <content contentuid="h416d071cgc2fdg4999g885ag8edb4acff79c" version="1">Посвященный в магию: Лечение ран</content>
+  <content contentuid="h452ef02bg8072g459eg855cge264eb47d661" version="1">Посвященный в магию: Фальшивая жизнь</content>
+  <content contentuid="h46162844g8514g42c9g8a0bg5ec0e854c4ee" version="1">Отмеченный тьмой: Гневный удар</content>
+  <content contentuid="h470526c7g8652g4997g92f7ga0742432639f" version="1">Посвященный в магию: Маскировка</content>
+  <content contentuid="h48c46a3cg3ed8g4cb8g8a9cgfc211a2c0f09" version="1">Посвященный в магию: Сон</content>
+  <content contentuid="h4b636d62g474cg4604ga98egff95e23fd181" version="1">Ты получил это заклинание от черты «Посвященный в магию».</content>
+  <content contentuid="h4ce0ba4bg2079g403cg83a5g54abfdb0d35f" version="1">Отмеченный феями: Разговор с животными</content>
+  <content contentuid="h4d71670dg87d7g4bccga4bbgbf385cea820f" version="1">Посвященный в магию: Создание или уничтожение воды</content>
+  <content contentuid="h4fbc6dd5g38b2g47f9g9735g678004c05e74" version="1">Магия фей: Сглаз</content>
+  <content contentuid="h502c43ffg8aceg5a29gb438g81efeef8bc10" version="2">Инфернальный тифлинг</content>
+  <content contentuid="h52a19910g3cc7g493eg8fabg8b7f5c9d64ba" version="1">Посвященный в магию: Дружба с животными</content>
+  <content contentuid="h551dff5egdb3fg4e5ega360ge241592e4da6" version="1">Отмеченный тьмой: Маскировка</content>
+  <content contentuid="h5702aa7bgc62dg498dgb2feg449b551cc59f" version="1">Магия фей: Приказ</content>
+  <content contentuid="h57d8ec12g3ceeg4061gaf4eg0e05c40d93ef" version="1">Магия фей: Метка охотника</content>
+  <content contentuid="h58b730d5g4dcbg4b48g971cg5b740e2ffc3d" version="1">Отмеченный феями: Сглаз</content>
+  <content contentuid="h5cfc7c46g0600g459cg9131g7a3b7a33eef5" version="1">Посвященный в магию: Ужасный смех Ташы</content>
+  <content contentuid="h5da3e166g6f07g3d22gef0cgeb154599ff70" version="1">Инфернальное наследие связывает тифлингов не только с Гехенной, но и с Девятью Преисподними и бушующими полями сражений Ахерона. Рога, шипы, хвосты, золотые глаза и лёгкий запах серы или дыма — обычные физические черты таких тифлингов, большинство из которых возводят свою родословную к дьяволам.</content>
+  <content contentuid="h5f709a6dg1beeg401dgac54g6745b0befb35" version="1">Отмеченный феями: Приказ</content>
+  <content contentuid="h616e65feg4aa9g4dabg85c6g0011a08ab3c0" version="1">Посвященный в магию: Спешное отступление</content>
+  <content contentuid="h62dc921dgae66g4db2ga508g1e377eaf2e8c" version="1">Отмеченный феями: Сон</content>
+  <content contentuid="h64a62e32ge165g4a0bgba51g3a56f6fbc678" version="1">Посвященный в магию: Всплеск чаропламени</content>
+  <content contentuid="h665b240bge251g4890gbb5cg7879ce993465" version="1">Отмеченный феями: Героизм</content>
+  <content contentuid="h67a78096g5504g4397ga7e3g50d4c70ef812" version="1">Посвященный в магию: Магический доспех</content>
+  <content contentuid="h6d721699g12f1g47a5g9e59gb8faf326752a" version="1">Магия тьмы: Гневный удар</content>
+  <content contentuid="h6dafbdc7g7942g4ac3g9634ga623f2f279cc" version="1">Посвященный в магию: Благословение</content>
+  <content contentuid="h6eeebe55g29fcg4be9g95cfga37c5a2a251e" version="1">Посвященный в магию: Шипованный доспех</content>
+  <content contentuid="h6f04cce5g29c8g83f2gad05g7191e1a42b7d" version="1">Улучшенная форма круга</content>
+  <content contentuid="h70ce5477gbb1cg40f6g841agc7cebcf0e7cc" version="1">Магия тьмы: Маскировка</content>
+  <content contentuid="h75a2429eg5e2dg4528g91a9gc3a7fe4ecdc1" version="1">Посвященный в магию: Опутывание</content>
+  <content contentuid="h76a8c640ge73dg4733g817cg19c49fb9c591" version="1">Посвященный в магию: Разговор с животными</content>
+  <content contentuid="h77c2c16fg7fa7g45f8g99eeg5093ee84f9d3" version="1">Посвященный в магию: Цветной всплеск</content>
+  <content contentuid="h7a2fb537g5fc5g43f8gab0cgc2fafe4b4935" version="1">Посвященный в магию: Горящие руки</content>
+  <content contentuid="h7c7f5d5dg08bcg4c63g8114g9f0315f4dcca" version="1">Посвященный в магию: Убежище</content>
+  <content contentuid="h838f68ccgef72g4870ga9e0g4663276becd0" version="1">Посвященный в магию: Усиленный прыжок</content>
+  <content contentuid="h84567768gbb92g4a5cg94a3ga7549989b4f5" version="1">Посвященный в магию: Волшебная стрела</content>
+  <content contentuid="h8520752dg87bfg4a3agaa29g10bf5539480e" version="1">Посвященный в магию: Лечащее слово</content>
+  <content contentuid="h87ead348ga862g462agbdd2g7079cbc25ffe" version="1">Магия фей: Благословение</content>
+  <content contentuid="h88e4b50cg73bdg46deg82a9g19b90a463135" version="1">Отмеченный тьмой: Цветной всплеск</content>
+  <content contentuid="h8b1e18f1g4012g4e69gb0a3g8425b829678e" version="1">Отмеченный феями: Благословение</content>
+  <content contentuid="h960b967fgb408g48dbgb993gf63379043e63" version="1">Отмеченный тьмой: Покров тени</content>
+  <content contentuid="h97a5bcafge6d2g4934ga19bg37906036d192" version="1">Магия тьмы: Луч болезни</content>
+  <content contentuid="h996d1b8ega8b2g47c0g96c4gaf6bc2f78055" version="1">Посвященный в магию: Очарование личности</content>
+  <content contentuid="h9dc30fd4g3582g480bgba3dg482edb0a6f4e" version="1">Посвященный в магию: Падение пёрышком</content>
+  <content contentuid="ha143d206g7a9bg470cg83cdgbc966fec394a" version="1">Посвященный в магию: Луч болезни</content>
+  <content contentuid="haa6cb53ega264g466egae57g0fd95c9d62e4" version="1">Отмеченный феями: Принудительная дуэль</content>
+  <content contentuid="hb21ce401g18b9g45c9g80cdg70f83e883cb9" version="1">Магия фей: Принудительная дуэль</content>
+  <content contentuid="hb35411e3g6de2g4ec5g8a5fg844b807cd1dc" version="1">Отмеченный тьмой: Нанесение ран</content>
+  <content contentuid="hb88252c9g43aeg4312g85deg472a9430cfae" version="1">Магия тьмы: Фальшивая жизнь</content>
+  <content contentuid="hb920e5dbgbbccg4712g9904g35edd94a4d41" version="1">Посвященный в магию: Адский бич</content>
+  <content contentuid="hbb161f9ega89fg403eg823fge6c45b2fb19b" version="1">Отмеченный феями: Метка охотника</content>
+  <content contentuid="hbbc31f40ga186g46d4gbeadgb81be01d433d" version="1">Отмеченный тьмой: Фальшивая жизнь</content>
+  <content contentuid="hbcd13d7dgb7f9g4220g85dbg19f9150641ef" version="1">Посвященный в магию: Поиск фамильяра</content>
+  <content contentuid="hbda17fc5g7024g467aga87bg388df5baebc3" version="1">Посвященный в магию: Телесное искажение Горгорота</content>
+  <content contentuid="hbe627f0bg708bg47b4gba79gf882af49eaca" version="1">Отмеченный феями: Порча</content>
+  <content contentuid="hc7b4d637g873egedaega2b5g55638c2965cd" version="2">Хтонический тифлинг</content>
+  <content contentuid="hc7c9d88egba6dg4b3dg9f9cgc6db9ab23824" version="1">Посвященный в магию: Волна тьмы</content>
+  <content contentuid="hc8800178g3eabg44b8g93a8g0d839444e75f" version="1">Отмеченный феями: Дружба с животными</content>
+  <content contentuid="hc9d5d758gd8e4g4619g8e9eg9913b4702ebb" version="1">Посвященный в магию: Направляющий снаряд</content>
+  <content contentuid="hcde29b6bgba06g491agb023g5f000272d40b" version="1">Посвященный в магию: Громовая волна</content>
+  <content contentuid="hced8ae2egc19bg42fbg92dbg72edc975847f" version="1">Магия фей: Разговор с животными</content>
+  <content contentuid="hd00a8e92gfc21g4f3eg9974gf9e0c3d6edbb" version="1">Посвященный в магию: Порча</content>
+  <content contentuid="hd3f1c3b8gddabg4eb9g9949g8d5cedfb3391" version="1">Посвященный в магию: Теневой усик</content>
+  <content contentuid="hd50a6304ga5b5g49beg8c6fge702b2220079" version="1">Посвященный в магию: Щит</content>
+  <content contentuid="hd623321egb083g4f76g8de6g854fb06bd2fa" version="1">Посвященный в магию: Ледяной нож</content>
+  <content contentuid="hd6d90a0dg68a1g49eagb5afg8d748b721221" version="1">Посвященный в магию: Щит веры</content>
+  <content contentuid="hd754a089gcc84g46b1gb5d1gf25f7a821bb1" version="1">Магия фей: Очарование личности</content>
+  <content contentuid="hdc7ba426ge98dg4316g94c9g943ef2f71ef1" version="1">Магия фей: Дружба с животными</content>
+  <content contentuid="hdc840f83g6ad0g4288g88b6gcca1b7dcad99" version="1">Отмеченный тьмой: Жаждущий клинок</content>
+  <content contentuid="hdd4dbdd2g4659g4a31g8aa0gc4c445c1be33" version="1">Отмеченный феями: Ужасный смех Ташы</content>
+  <content contentuid="he4a975ccg5d4fg45f9g97d5g3f061079b267" version="1">Посвященный в магию: Поглощение стихий</content>
+  <content contentuid="he5309e85gddddg797fg0081g19accd6ede60" version="1">Энтропия Бездны, хаос Пандемониума и отчаяние Карцери зовут тифлингов с бездным наследием. Рога, шерсть, клыки и своеобразные запахи — обычные физические черты таких тифлингов, у большинства из которых по венам течёт кровь демонов.</content>
+  <content contentuid="he981e206gd26fg4370gb1a0g19058c7e847c" version="1">Отмеченный феями: Диссонантный шёпот</content>
+  <content contentuid="he986d9cfge7f4g4d92g9818g7c5d11e3be9a" version="1">Посвященный в магию: Добрая ягода</content>
+  <content contentuid="hf144efb7g49aeg4bb7ga35fg54d2036d782e" version="1">Посвященный в магию: Ведьмин снаряд</content>
+  <content contentuid="hf1657fa1g090bg436ag8f9fg502202b9b2f7" version="1">Магия тьмы: Жаждущий клинок</content>
+  <content contentuid="hf80f1d43g98c1g4673gb72fgdffcfee338d2" version="1">Магия фей: Порча</content>
+  <content contentuid="hfe00d696gc13ega9a7g3f41g5fe01cf6c73e" version="2">Тифлинг Бездны</content>
 </contentList>


### PR DESCRIPTION
- 'Фит' -> 'Черта' (20 leftover occurrences, incl. gender/case agreement)
- Magic Initiate: unify 'Посвящение в магию' -> 'Посвященный в магию' (4 strays)
- Hex -> 'Сглаз' (was wrongly 'Порча' which is Bane); Bane stays 'Порча'
- Spell names aligned to dnd.su 2014 canon (26 occurrences): Shillelagh: Шиллег/Шиллелаг -> Дубинка Booming Blade: Гремящий клинок -> Громовой клинок True Strike: Верный удар -> Меткий удар Longstrider: Длинноход -> Скороход Blade Ward: Оберег клинка -> Защита от оружия Sword Burst: Всплеск меча -> Вспышка мечей Inflict Wounds: Наложение ран -> Нанесение ран Spare the Dying: Пощада умирающего -> Уход за умирающим Feather Fall: Падение пера -> Падение пёрышком Toll the Dead: Звон по усопшим -> Погребальный звон