### PR TITLE
fix(war magic): let the cantrip swap return in every Attack action

### DIFF
--- a/Public/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Stats/Generated/Data/Status_BOOST.txt
+++ b/Public/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Stats/Generated/Data/Status_BOOST.txt
@@ -68,6 +68,8 @@ data "OnRemoveFunctors" "ApplyStatus(EXTRA_ATTACK_2, 100, 1)"
 new entry "WAR_MAGIC_BLOCK"
 type "StatusData"
 data "StatusType" "BOOST"
+data "RemoveConditions" "ExtraAttackSpellCheck() and HasUseCosts('ActionPoint',false,context.Target) and not IsOffHandAttack()"
+data "RemoveEvents" "OnSpellCast"
 data "StatusPropertyFlags" "DisableCombatlog;DisablePortraitIndicator;DisableOverhead"
 
 new entry "EXTRA_ATTACK_WAR_MAGIC"


### PR DESCRIPTION
## Problem

With `ExtraAttack_Warmagic;WarMagic`, the cantrip-for-attack swap works once per **turn** instead of once per **Attack action**. A Bladesinger who spends Action Surge (or is hasted) gets a second Attack action, but the free cantrip variant is no longer offered.

`WAR_MAGIC_BLOCK` had no `RemoveConditions`/`RemoveEvents`, so after `WarMagic` applied it the flag simply ran out its one-turn duration. Inside a single Attack action that is exactly the intent — one cantrip replaces one attack — but on the second Attack action the block is still up and the

```
IF(not HasStatus('WAR_MAGIC_BLOCK', context.Source) and HasPassive('WarMagic', context.Source)):
  UnlockSpellVariant(IsCantrip(), ...)
```

branch of `EXTRA_ATTACK` never fires. The 2024 rules bind the swap to the Attack action, not to the turn.

## Fix

Clear the block on the first weapon attack that actually spends an Action, which is what starts a new Attack action:

```
data "RemoveConditions" "ExtraAttackSpellCheck() and HasUseCosts('ActionPoint',false,context.Target) and not IsOffHandAttack()"
data "RemoveEvents" "OnSpellCast"
```

That predicate is not new — it is verbatim how vanilla `EXTRA_ATTACK` removes itself (`Shared.pak` → `Public/Shared/Stats/Generated/Data/Status_BOOST.txt`), on the same `OnSpellCast` event.

`WAR_MAGIC_BLOCK` is declared from scratch with no `using`, so nothing inherited by `ExtraAttack_Warmagic` / `ExtraAttack_Warmagic_2` is touched — the `StatsFunctors` chain that drives `EXTRA_ATTACK_Q` → `EXTRA_ATTACK` for all seven subclasses stays as it is.

## Why not `INITIAL_ATTACK_TECHNICAL`

It looks like the natural "new Attack action" marker, but vanilla `CombatStartAttack` gates it behind `not TurnBased(context.Source)` — it only exists for an attack begun outside turn-based mode. In combat it is never applied, and the `OnStatusRemoved` branch of `ExtraAttack.Conditions` never runs.

## Testing

Built and played with Bladesinger 6 + Action Surge: the free cantrip variant is offered again in the second Attack action, and remains limited to one cantrip per Attack action. Behaviour across turns is unchanged.

Scope is one status entry, two added lines; no other subclass or passive is affected.
