### PR TITLE
fix(war magic): limit the cantrip swap to one per Attack action (2nd attempt)

### DIFF
--- a/Public/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Stats/Generated/Data/Passive.txt
+++ b/Public/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Stats/Generated/Data/Passive.txt
@@ -72,11 +72,13 @@ new entry "ExtraAttack_Warmagic"
 type "PassiveData"
 using "ExtraAttack"
 data "Conditions" "(context.HasContextFlag(StatsFunctorContext.OnCast) and (IsCantrip() or ExtraAttackSpellCheck()) and HasUseCosts('ActionPoint', true) and not Tagged('EXTRA_ATTACK_BLOCKED',context.Source) and not HasStatus('SLAYER_PLAYER',context.Source) and not HasStatus('SLAYER_PLAYER_10',context.Source) and TurnBased(context.Source)) or (context.HasContextFlag(StatsFunctorContext.OnStatusRemoved) and StatusId('INITIAL_ATTACK_TECHNICAL') and TurnBased()) or (context.HasContextFlag(StatsFunctorContext.OnStatusApplied) and StatusId('EXTRA_ATTACK_Q'));"
+data "StatsFunctors" "IF(context.HasContextFlag(StatsFunctorContext.OnCast) and not IsCantrip()):RemoveStatus(SELF,WAR_MAGIC_BLOCK);IF(context.HasContextFlag(StatsFunctorContext.OnCast)):ApplyStatus(SELF,EXTRA_ATTACK_Q,100,1);IF(context.HasContextFlag(StatsFunctorContext.OnStatusRemoved)):ApplyStatus(EXTRA_ATTACK_Q,100,1);IF(context.HasContextFlag(StatsFunctorContext.OnStatusApplied) and not HasHigherPriorityExtraAttackQueued('EXTRA_ATTACK_Q') and not HasAnyExtraAttack()):ApplyStatus(EXTRA_ATTACK, 100, 1)"
 
 new entry "ExtraAttack_Warmagic_2"
 type "PassiveData"
 using "ExtraAttack_2"
 data "Conditions" "(context.HasContextFlag(StatsFunctorContext.OnCast) and (IsCantrip() or ExtraAttackSpellCheck()) and HasUseCosts('ActionPoint', true) and not Tagged('EXTRA_ATTACK_BLOCKED',context.Source) and not HasStatus('SLAYER_PLAYER',context.Source) and not HasStatus('SLAYER_PLAYER_10',context.Source) and TurnBased(context.Source)) or (context.HasContextFlag(StatsFunctorContext.OnStatusRemoved) and StatusId('INITIAL_ATTACK_TECHNICAL') and TurnBased()) or (context.HasContextFlag(StatsFunctorContext.OnStatusApplied) and StatusId('EXTRA_ATTACK_2_Q'));"
+data "StatsFunctors" "IF(context.HasContextFlag(StatsFunctorContext.OnCast) and not IsCantrip()):RemoveStatus(SELF,WAR_MAGIC_BLOCK);IF(context.HasContextFlag(StatsFunctorContext.OnCast)):ApplyStatus(SELF,EXTRA_ATTACK_2_Q,100,1);IF(context.HasContextFlag(StatsFunctorContext.OnStatusRemoved)):ApplyStatus(EXTRA_ATTACK_2_Q,100,1);IF(context.HasContextFlag(StatsFunctorContext.OnStatusApplied) and not HasHigherPriorityExtraAttackQueued('EXTRA_ATTACK_2_Q') and not HasAnyExtraAttack()):ApplyStatus(EXTRA_ATTACK_2, 100, 1)"
 
 new entry "WarMagic"
 type "PassiveData"


### PR DESCRIPTION
Second attempt after #1041. Your finding was correct: on an Eldritch Knight 11 the sequence **cantrip → weapon attack → cantrip** does happen inside a single Attack action.

### What was wrong

The flag that limits the swap was cleared by any weapon attack, including the free attacks inside the same Attack action. Spending one of them was enough for the cantrip to unlock a second time.

It can only show on an Eldritch Knight 11, the one War Magic carrier with three attacks. Everywhere else the cantrip takes the last free slot, so no attack is left inside the action to clear the flag. That is why my own testing missed it.

### What changed

The flag is now cleared only by an attack that actually spends an Action, that is, the first attack of a new Attack action. Free attacks leave it alone.

I did not write that check — the passive's own condition already makes it. It also puts the removal at the right point of the chain: the previous version ran too late, and the cantrip disappeared from the wizard's second Attack action. The alternatives I went through are in the commit message.

### Intended behaviour

The reference is Extra Attack itself in the base game. Haste grants `ActionResource(ActionPoint,1,0)`, a full second Action, and nothing in the `EXTRA_ATTACK` chain is limited to once per turn. So a Fighter with Extra Attack under Haste makes four weapon attacks across two Actions: the mechanic counts per Attack action, not per turn.

The cantrip swap should count the same way. A Bladesinging wizard 6 under Haste:

| Action | What is available |
|---|---|
| First | attack + cantrip |
| Second | attack + cantrip |

Four attacks in the turn, at most two of them cantrips. Three cantrips in a turn, or two cantrips inside one Action, are not possible.

### Current behaviour

Matches the above, edge cases included:

| Situation | Result |
|---|---|
| Attack action opened with a weapon attack | one attack may be replaced by a cantrip |
| Any further free attack in the same action | no second cantrip |
| Attack action opened with a full-Action cantrip | that is the swap, nothing left for another |
| Second Action (Haste, Action Surge) | the swap is available again |
| Off-hand attacks, reactions, opportunity attacks | no effect |
| Eldritch Knight 11, three attacks | one cantrip per Attack action |

Which is what the passive's own description says: one of your cantrips **instead of one of these attacks**.

### Tested in game

- Bladesinging wizard 6 under Haste — two Actions, four attacks, one attack replaceable by a cantrip in each of them.
- Eldritch Knight 11 — `cantrip → attack → cantrip` no longer offers the second cantrip for free. It shows inside a single Action, so no second Action is needed to check it.

### Worth knowing

Both passives now spell out the `StatsFunctors` chain they used to inherit: stats fields are replaced on override, not merged. The text is copied verbatim from `Shared.pak` and was verified programmatically, not retyped. The cost is that a future patch to `ExtraAttack` would no longer reach these seven subclasses. If you would rather not carry that, I am happy to rework it.
