### PR TITLE
fix: add missing cross-reference tooltips

### DIFF
--- a/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/English/english.xml
+++ b/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Localization/English/english.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0"?>
 <contentList xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <content contentuid="h6b384962g5a7bg33e2g8993g0708cacc7834" version="3">Rule: Equipping Weapons</content>
   <content contentuid="h7e686044g6737gd055gea94g27a7a4c34341" version="3">You can equip weapons when you make an attack as part of attack action. Equipping a weapon includes drawing it from a sheath or picking it up.</content>
@@ -43,7 +43,7 @@ Attacks Affected: An attack roll against you has Advantage if the attacker is wi
 
 As you reach certain levels in your class, you gain the ability to use the mastery properties of additional weapon types.</content>
   <content contentuid="he54ffab7g9288g792age85bg3fc0a39a63db" version="1">Level 1: Rage</content>
-  <content contentuid="ha33a602cg9bb2gec42g889dg5983a5346c84" version="1">You can imbue yourself with a primal power called Rage, a force that grants you extraordinary might and resilience. You can enter it as a Bonus Action if you aren’t wearing Heavy armor.
+  <content contentuid="ha33a602cg9bb2gec42g889dg5983a5346c84" version="1">You can imbue yourself with a primal power called &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt;, a force that grants you extraordinary might and resilience. You can enter it as a Bonus Action if you aren’t wearing Heavy armor.
 
 You can enter your Rage the number of times shown for your Barbarian level in the Rages column of the Barbarian Features table. You regain one expended use when you finish a Short Rest, and you regain all expended uses when you finish a Long Rest.</content>
   <content contentuid="h8abec533g47afgabaag5370ga724a70ed863" version="1">Level 1: Unarmoured Defence</content>
@@ -51,11 +51,11 @@ You can enter your Rage the number of times shown for your Barbarian level in th
   <content contentuid="hb6dea583g9359gddf3g2360g74669f67b1a6" version="1">Level 3: Primal Knowledge</content>
   <content contentuid="h860b399bg558cg749fgb64bg707d53758400" version="2">You gain proficiency in another skill of your choice from the skill list available to Barbarians at level 1.
 
-In addition, while your Rage is active, you can channel primal power when you attempt certain tasks; whenever you make an ability check using one of the following skills, you can make it as a Strength check even if it normally uses a different ability: Acrobatics, Intimidation, Perception, Stealth, or Survival. When you use this ability, your Strength represents primal power coursing through you, honing your agility, bearing, and senses.</content>
+In addition, while your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; is active, you can channel primal power when you attempt certain tasks; whenever you make an ability check using one of the following skills, you can make it as a Strength check even if it normally uses a different ability: &lt;LSTag Type="Skills" Tooltip="Acrobatics"&gt;Acrobatics&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Intimidation"&gt;Intimidation&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Perception"&gt;Perception&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Stealth"&gt;Stealth&lt;/LSTag&gt;, or &lt;LSTag Type="Skills" Tooltip="Survival"&gt;Survival&lt;/LSTag&gt;. When you use this ability, your Strength represents primal power coursing through you, honing your agility, bearing, and senses.</content>
   <content contentuid="h3fa58ccfg135bg7a66g14degc3c8b5bb8261" version="1">Level 5: Fast Movement</content>
   <content contentuid="h7c047839g4177g2aaega022g36a5cb07886a" version="1">Level 7: Feral Instinct</content>
   <content contentuid="h28d4b453gc36cg810egf9e2g1dbff5d018d8" version="1">Level 7: Instinctive Pounce</content>
-  <content contentuid="hdb025275gf26dg03dfg7370g4dddf3f0ffb9" version="1">As part of the Bonus Action you take to enter your Rage, you can move up to half your Speed.</content>
+  <content contentuid="hdb025275gf26dg03dfg7370g4dddf3f0ffb9" version="1">As part of the Bonus Action you take to enter your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt;, you can move up to half your Speed.</content>
   <content contentuid="hb6144726g336aga60cg63d6gf6c4bc669e6a" version="1">Level 9: Brutal Strike</content>
   <content contentuid="h3a320da8g90b9g9714ge237g45c9782afbd0" version="1">If you use Reckless Attack, the target takes an extra 1d10 damage of the same type dealt by the weapon or Unarmed Strike, and you can cause one Brutal Strike effect of your choice.
 
@@ -72,7 +72,7 @@ Hamstring Blow. The target’s Speed is reduced by [1] until the start of your n
   <content contentuid="hebad3866ga362g915cge97fg661e8b92ea36" version="1">Level 11: Relentless Rage</content>
   <content contentuid="hfd45d1c1g9dd3g206agfb7eg456c6af02ac0" version="1">Once per &lt;LSTag Tooltip="ShortRest"&gt;Short Rest&lt;/LSTag&gt;, when you would drop to [1] &lt;LSTag Tooltip="HitPoints"&gt;hit points&lt;/LSTag&gt; while &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Enraged&lt;/LSTag&gt;, you instead regain hit points equal to twice your Barbarian level and avoid being &lt;LSTag Type="Status" Tooltip="DOWNED"&gt;Downed&lt;/LSTag&gt;.</content>
   <content contentuid="h784061e1gf2a8g748bg99cfg9e391dd4569c" version="1">Level 3: Frenzy</content>
-  <content contentuid="hd21b5d53gc033g82abgfcdag21730bb83c68" version="1">If you use Reckless Attack while your Rage is active, you deal extra damage to the first target you hit on your turn with a Strength-based attack. To determine the extra damage, roll a number of d6s equal to your Rage Damage bonus, and add them together. The damage has the same type as the weapon or Unarmed Strike used for the attack.</content>
+  <content contentuid="hd21b5d53gc033g82abgfcdag21730bb83c68" version="1">If you use Reckless Attack while your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; is active, you deal extra damage to the first target you hit on your turn with a Strength-based attack. To determine the extra damage, roll a number of d6s equal to your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; Damage bonus, and add them together. The damage has the same type as the weapon or Unarmed Strike used for the attack.</content>
   <content contentuid="h7f8570c9g2cd6g2327g3c99g18d5c393bf5e" version="1">Level 6: Mindless Rage</content>
   <content contentuid="h42189866g05d1g89b4g6e9dg1f97d248b2a9" version="1">Level 10: Retaliation</content>
   <content contentuid="hde644cc1g1dc6g103bg095ege867e6fa22ad" version="1">When you take damage from a creature that is within [1] of you, you can take a Reaction to make one melee attack against that creature, using a weapon or an Unarmed Strike.</content>
@@ -116,7 +116,7 @@ In addition, you can cast one of your cantrips that has a casting time of an act
   <content contentuid="hbdf4d91ege560gf373gb78fgc694716131ec" version="1">Word of Radiance</content>
   <content contentuid="h0dd0eba8g9b93g7909g9d9cg2a09e01a4c46" version="2">Level 1: Divine Order: Protector</content>
   <content contentuid="h82c38cb3g39e6g13c8g7a26g5c63f737aa79" version="1">Protector: Trained for battle, you gain proficiency with Martial weapons and training with Heavy armor.</content>
-  <content contentuid="hd91012edgb1a6g4aabg14d4g0d685464de55" version="1">Thaumaturge: You know one extra cantrip from the Cleric spell list. In addition, your mystical connection to the divine gives you a bonus to your Intelligence (Arcana or Religion) checks. The bonus equals your Wisdom modifier (minimum of +1).</content>
+  <content contentuid="hd91012edgb1a6g4aabg14d4g0d685464de55" version="1">Thaumaturge: You know one extra cantrip from the Cleric spell list. In addition, your mystical connection to the divine gives you a bonus to your Intelligence (&lt;LSTag Type="Skills" Tooltip="Arcana"&gt;Arcana&lt;/LSTag&gt; or &lt;LSTag Type="Skills" Tooltip="Religion"&gt;Religion&lt;/LSTag&gt;) checks. The bonus equals your Wisdom modifier (minimum of +1).</content>
   <content contentuid="h5eae110bgf170g8febg7b95gaf9957eab275" version="1">Guidance</content>
   <content contentuid="hf42e4215gdaa7g8b2cg6d6cg34b3a7233576" version="1">Light</content>
   <content contentuid="h08e84982gdf0fgadf1g29d5g02cc8281827c" version="2">Bursting Sinew</content>
@@ -137,7 +137,7 @@ In addition, you can cast one of your cantrips that has a casting time of an act
   <content contentuid="h50136471gff21g505fg888cgf856fc01281a" version="1">Level 1: Divine Order: Thaumaturgy</content>
   <content contentuid="h9b0eeaeeg6a13gc99dg6669gc97c57ec0db5" version="1">Level 1: Divine Order: Toll the Dead</content>
   <content contentuid="h84a7d362gf65ag0f66g6103g7d1f4fc707d2" version="1">Level 2: Channel Divinity</content>
-  <content contentuid="h619804afg28a4g6f48g9db2gb39ec7c1d073" version="1">You can channel divine energy to create special effects such as Divine Spark and Turn Undead, choosing one each time you use Channel Divinity. Additional effects and uses are gained at higher Cleric levels. You regain one use on a Short Rest and all uses on a Long Rest. Saving throw DCs use your Spellcasting DC.</content>
+  <content contentuid="h619804afg28a4g6f48g9db2gb39ec7c1d073" version="1">You can channel divine energy to create special effects such as &lt;LSTag Type="Spell" Tooltip="Target_DivineSpark"&gt;Divine Spark&lt;/LSTag&gt; and Turn Undead, choosing one each time you use Channel Divinity. Additional effects and uses are gained at higher Cleric levels. You regain one use on a Short Rest and all uses on a Long Rest. Saving throw DCs use your Spellcasting DC.</content>
   <content contentuid="h0fdb1f5ag867fg21d4g6beeg681eae4df812" version="1">Divine Spark</content>
   <content contentuid="he5c89bffgb42ege4daga349g64ec3fecb28f" version="1">As a Magic action, you point your Holy Symbol at another creature you can see within [1] of yourself and focus divine energy at it. You either restore Hit Points to the creature or force the creature to make a Constitution saving throw. On a failed save, the creature takes Necrotic or Radiant damage (your choice). On a successful save, the creature takes half as much damage (round down).</content>
   <content contentuid="h49ee25b5g5f2age7acga266g96075d1e4240" version="1">Divine Spark: Heal</content>
@@ -221,13 +221,13 @@ At Higher Levels. Your Bardic Inspiration die changes when you reach certain Bar
   <content contentuid="h002f5e57g1181g2dbbg226fgf29f606b801c" version="2">Steel Wind Strike</content>
   <content contentuid="h0da58492g230cg424fg00cdg006fb672dd4d" version="2">You flourish the weapon used in the casting and then vanish to strike like the wind, reappearing beside a creature you can see within range and making a melee spell attack against it. You then continue on, moving between nearby foes to attack again, striking up to five different creatures in total. On a hit, a target takes [1].</content>
   <content contentuid="h84a10acdg5e1fgb4f6g3b55g7f5134f52d10" version="1">Mind Spike</content>
-  <content contentuid="h05f1c3ebg02fcg677cga473g464cac2d584f" version="1">You drive a spike of psionic energy into the mind of one creature you can see within range. The target makes a Wisdom saving throw, taking Psychic damage on a failed save or half as much damage on a successful one. On a failed save, you also always know the target’s location until the spell ends. While you have this knowledge, the target can’t become hidden from you, and if it has the Invisible condition, it gains no benefit from that condition against you.</content>
+  <content contentuid="h05f1c3ebg02fcg677cga473g464cac2d584f" version="1">You drive a spike of psionic energy into the mind of one creature you can see within range. The target makes a Wisdom saving throw, taking Psychic damage on a failed save or half as much damage on a successful one. On a failed save, you also always know the target’s location until the spell ends. While you have this knowledge, the target can’t become hidden from you, and if it has the &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt; condition, it gains no benefit from that condition against you.</content>
   <content contentuid="hd666f94dg1a88g5b93g7dcbgfbc951360305" version="1">Synaptic Static</content>
   <content contentuid="haddaa3c4ga780gc6c0g5533g2da826d6931f" version="1">You cause psychic energy to erupt at a point within range. Each creature in a  [1] radius Sphere centered on that point makes an Intelligence saving throw, taking Psychic damage on a failed save or half as much damage on a successful one.
 
 On a failed save, a target also has muddled thoughts for 1 minute. During that time, it subtracts 1d6 from all its attack rolls and ability checks, as well as any Constitution saving throws to maintain Concentration. The target makes an Intelligence saving throw at the end of each of its turns, ending the effect on itself on a success.</content>
   <content contentuid="hc29da1ffgb5d5g29c2g97c3g2050946f5a23" version="1">Mind Spike</content>
-  <content contentuid="h3aac9e83g2f2ag85ddgcf84ge7224ea85b8b" version="1">The creature’s location is always known to the spellcaster until the spell ends. The creature can’t hide from the spellcaster, and if it has the Invisible condition, it gains no benefit from that condition against the spellcaster.</content>
+  <content contentuid="h3aac9e83g2f2ag85ddgcf84ge7224ea85b8b" version="1">The creature’s location is always known to the spellcaster until the spell ends. The creature can’t &lt;LSTag Type="Spell" Tooltip="Shout_Hide"&gt;hide&lt;/LSTag&gt; from the spellcaster, and if it has the &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt; condition, it gains no benefit from that condition against the spellcaster.</content>
   <content contentuid="h0eb6a1ccg061cg7757g2ce7gb1ae17ae8a0f" version="1">Synaptic Static</content>
   <content contentuid="h9e56e88cg0481g2c87g52e7g140df577385c" version="1">The creature subtracts 1d6 from all its attack rolls and ability checks, as well as from any Constitution saving throws it makes to maintain Concentration. At the end of each of its turns, the target makes an Intelligence saving throw, ending the effect on a success.</content>
   <content contentuid="h32658116g9dc9g1364g0f58g311a9cad82b8" version="1">Level 3: Mind Magic</content>
@@ -237,9 +237,9 @@ On a failed save, a target also has muddled thoughts for 1 minute. During that t
 
 Add half of your Wisdom Modifier to &lt;LSTag Tooltip="AbilityCheck"&gt;Ability Checks&lt;/LSTag&gt; that you are not &lt;LSTag Tooltip="Proficiency"&gt;Proficient&lt;/LSTag&gt; in.</content>
   <content contentuid="hf5d6de51g8683g514bgcfd2gd52016de99fe" version="1">Starry Wisp</content>
-  <content contentuid="h9cbc738dgd21bg77f4g2687gd1ac412ca2b4" version="1">You launch a mote of light at one creature or object within range. Make a ranged spell attack against the target. On a hit, the target takes Radiant damage, and until the end of your next turn, it emits Dim Light in a [1] radius and can’t benefit from the Invisible condition.</content>
+  <content contentuid="h9cbc738dgd21bg77f4g2687gd1ac412ca2b4" version="1">You launch a mote of light at one creature or object within range. Make a ranged spell attack against the target. On a hit, the target takes Radiant damage, and until the end of your next turn, it emits Dim Light in a [1] radius and can’t benefit from the &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt; condition.</content>
   <content contentuid="h6d4e8665g6567g3bc4gd9f1g206db8efad20" version="1">Starry Wisp</content>
-  <content contentuid="he44a89e4gd251g9a1dg6abagca1e9807a226" version="1">The creature emits Dim Light in a [1] radius and can’t benefit from the Invisible condition.</content>
+  <content contentuid="he44a89e4gd251g9a1dg6abagca1e9807a226" version="1">The creature emits Dim Light in a [1] radius and can’t benefit from the &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt; condition.</content>
   <content contentuid="h8d4a4bb1g65b7g5025g4514gdfa80f1282ba" version="1">Thunderclap</content>
   <content contentuid="h853f3b07gf693g964eg9f97g97a2cfda50ef" version="1">Each creature in a [1] Emanation originating from you must succeed on a Constitution saving throw or take Thunder damage.</content>
   <content contentuid="hbd2e3aa0g3258g4710g9504gbadee9cd0ea6" version="1">Level 1: Druidic</content>
@@ -247,7 +247,7 @@ Add half of your Wisdom Modifier to &lt;LSTag Tooltip="AbilityCheck"&gt;Ability 
   <content contentuid="h1193aa13ge0d7ge702g2f85ga0c0527d229d" version="2">Level 1: Primal Order: Warden</content>
   <content contentuid="h236eb2e6g63d1g6008gac03gd13912a2af7b" version="1">Warden. Trained for battle, you gain proficiency with Martial weapons and training with Medium armor.</content>
   <content contentuid="hdc66e2feg6dc9g8e0dg69c3g1ac135e77240" version="1">Level 1: Primal Order: Guidance</content>
-  <content contentuid="h261201bdgf3e1gc0a9g001bg9f21c4b6eb0b" version="1">Magician. You know one extra cantrip from the Druid spell list. In addition, your mystical connection to nature gives you a bonus to your Intelligence (Arcana or Nature) checks. The bonus equals your Wisdom modifier (minimum bonus of +1).</content>
+  <content contentuid="h261201bdgf3e1gc0a9g001bg9f21c4b6eb0b" version="1">Magician. You know one extra cantrip from the Druid spell list. In addition, your mystical connection to nature gives you a bonus to your Intelligence (&lt;LSTag Type="Skills" Tooltip="Arcana"&gt;Arcana&lt;/LSTag&gt; or &lt;LSTag Type="Skills" Tooltip="Nature"&gt;Nature&lt;/LSTag&gt;) checks. The bonus equals your Wisdom modifier (minimum bonus of +1).</content>
   <content contentuid="hf498864agc7beg3cdbgca11g269c576f1a01" version="1">Guidance</content>
   <content contentuid="h4e0c0b74gabceg8644g0a67g8c877d23dd83" version="1">Level 1: Primal Order: Poison Spray</content>
   <content contentuid="h3635dadfgfe4eg55c4g39dfgaf968256d2d8" version="1">Poison Spray</content>
@@ -362,7 +362,7 @@ Temporary Hit Points: You gain a number of Temporary Hit Points equal to three t
   <content contentuid="h858b33e5g3b62g9b7fg692fg50cb883ac903" version="1">Tactical Master: Push</content>
   <content contentuid="h69435982g810ege56dgacebg3bb3b371ccd9" version="1">You can additionally apply the Push mastery property to that attack.</content>
   <content contentuid="h6c90bdcbg9d73g2f85g8df7g47fbedfb078f" version="1">Level 9: Tactical Master</content>
-  <content contentuid="h2c920020g431dge64eg8e26g01537cb63450" version="1">When you make a weapon attack, you can additionally apply one of the Push, Sap, or Slow mastery properties to that attack.</content>
+  <content contentuid="h2c920020g431dge64eg8e26g01537cb63450" version="1">When you make a weapon attack, you can additionally apply one of the Push, &lt;LSTag Type="Passive" Tooltip="Fighter_9_TacticalMaster_Sap"&gt;Sap&lt;/LSTag&gt;, or Slow mastery properties to that attack.</content>
   <content contentuid="h53c4a6c9g7930g55a2ga6d9g74f864e922d2" version="1">Tactical Master: Sap</content>
   <content contentuid="h0558e9e5gd74bg0f9fg2820gc589e678173e" version="1">You can additionally apply the Sap mastery property to that attack.</content>
   <content contentuid="h1bcf613agff33gdd61g8288g83128f467505" version="1">Tactical Master: Slow</content>
@@ -373,13 +373,13 @@ Temporary Hit Points: You gain a number of Temporary Hit Points equal to three t
   <content contentuid="h1855925eg36d7g774cg4917gc8135001356f" version="1">Rule: Strength Requirement (Plate Armor)</content>
   <content contentuid="h36e05e75gb0acgebbeg511ag25cc56fcde31" version="1">If a creature wearing this Heavy Armor has a Strength score lower than [1], its Speed is reduced by [2].</content>
   <content contentuid="h1378b9e1g8e8cgbb1eg3cb7g5aad15a2e9d3" version="1">Level 3: Remarkable Athlete</content>
-  <content contentuid="h8a4c8a20gcc89g49e5g2025g934de8342619" version="1">Thanks to your athleticism, you have Advantage on Initiative rolls and Strength (Athletics) checks.
+  <content contentuid="h8a4c8a20gcc89g49e5g2025g934de8342619" version="1">Thanks to your athleticism, you have Advantage on Initiative rolls and Strength (&lt;LSTag Type="Skills" Tooltip="Athletics"&gt;Athletics&lt;/LSTag&gt;) checks.
 
 In addition, immediately after you score a Critical Hit, you can move up to half your Speed without provoking Opportunity Attacks.</content>
   <content contentuid="h070ecbffg0669ge021gd9f2gf9d31bf77f88" version="1">Remarkable Athlete</content>
   <content contentuid="h20fe10e3g6a5cg1394g9602g64f7640b6f6d" version="1">Immediately after you score a Critical Hit, you can move up to half your Speed without provoking Opportunity Attacks.</content>
   <content contentuid="hdc98f803g35c5gf1e3g8979g2a5e77165301" version="1">Level 10: Heroic Warrior</content>
-  <content contentuid="ha8f342f0g6dafg2cb0g07ffg5de2b08f710e" version="1">The thrill of battle drives you toward victory. During combat, you can give yourself Heroic Inspiration whenever you start your turn without it.</content>
+  <content contentuid="ha8f342f0g6dafg2cb0g07ffg5de2b08f710e" version="1">The thrill of battle drives you toward victory. During combat, you can give yourself &lt;LSTag Type="Status" Tooltip="HEROIC_INSPIRATION_TEMP"&gt;Heroic Inspiration&lt;/LSTag&gt; whenever you start your turn without it.</content>
   <content contentuid="h6ae0967eg345cg0ef5g653cg5c51675a3b5a" version="1">Heroic Warrior: Reroll Attacker's Die</content>
   <content contentuid="h7e67754bg739bg3c96gcd25g72c30f60a4d8" version="1">Force a creature to reroll its &lt;LSTag Tooltip="AttackRoll"&gt;Attack Roll&lt;/LSTag&gt;. </content>
   <content contentuid="h81c64052g4f2bg8257g3f1ag716712683b25" version="1">Heroic Warrior: Reroll with Advantage</content>
@@ -407,7 +407,7 @@ In addition, you can cast one of your cantrips that has a casting time of an act
   <content contentuid="hd1fc430dg69bagc256g2318g1055bfa2fc27" version="1">Patient Defense</content>
   <content contentuid="h4c44c0abg262cg8e6egf06cg92cf676855e3" version="1">You can expend 1 Focus Point to take both the Disengage and the Dodge actions as a Bonus Action.</content>
   <content contentuid="hdd4e66dbg0ac9g5c5dg463eg6076392563ce" version="1">Step of the Wind</content>
-  <content contentuid="h83374bedgf40agd759g1784gd9c5f24545a3" version="1">You can expend 1 Focus Point to take both the Disengage and Dash actions as a Bonus Action, and your jump distance is doubled for the turn.</content>
+  <content contentuid="h83374bedgf40agd759g1784gd9c5f24545a3" version="1">You can expend 1 Focus Point to take both the Disengage and &lt;LSTag Type="Spell" Tooltip="Shout_Dash"&gt;Dash&lt;/LSTag&gt; actions as a Bonus Action, and your jump distance is doubled for the turn.</content>
   <content contentuid="h554e1c9cgf636g08a4gf6ebg1d3611ee623a" version="1">Step of the Wind</content>
   <content contentuid="ha6d44a5ag5a9ag0c67gfbb0ge9a5772193c3" version="1">Your jump distance is doubled for the turn.</content>
   <content contentuid="h8e2c71efgf381g9eb7gaf5cg2760015a45e2" version="1">Dash</content>
@@ -441,7 +441,7 @@ If this reduces the damage to 0, you can spend 1 Ki Point to use Redirect Attack
   <content contentuid="hc6a55712gd62cgd5e7g68d8g0007496a3e1e" version="2">Level 9: Acrobatic Movement</content>
   <content contentuid="hcb9a361cg3dadgecb2gdae1g23fc5f5c3919" version="1">Level 7: Evasion</content>
   <content contentuid="h33c22a3cg9bbaga9c8g65e2g0701352832a0" version="1">Level 10: Heightened Focus</content>
-  <content contentuid="h3bb523e2gc26eg22c2g87e9g4e1e0da5e1af" version="2">Your Flurry of Blows, Patient Defense, and Step of the Wind gain the following benefits:
+  <content contentuid="h3bb523e2gc26eg22c2g87e9g4e1e0da5e1af" version="2">Your Flurry of Blows, &lt;LSTag Type="Spell" Tooltip="Shout_PatientDefense"&gt;Patient Defense&lt;/LSTag&gt;, and Step of the Wind gain the following benefits:
 
 Flurry of Blows: You can expend 1 Focus Point to use Flurry of Blows, making three Unarmed Strikes instead of two.
 
@@ -456,7 +456,7 @@ Patient Defense and Step of the Wind: When you expend a Focus Point to use eithe
 Darkness. You can expend 1 Focus Point to cast the Darkness spell without spell components. You can see within the spell’s area when you cast it with this feature. While the spell persists, you can move its area of Darkness to a space within [1] of yourself at the start of each of your turns.
 Darkvision. You gain Darkvision with a range of [1]. If you already have Darkvision, its range increases by 60 feet.
 
-Shadowy Figments. You know the Minor Illusion spell. Wisdom is your spellcasting ability for it.</content>
+Shadowy Figments. You know the &lt;LSTag Type="Spell" Tooltip="Target_ImprovedMinorIllusion"&gt;Minor Illusion&lt;/LSTag&gt; spell. Wisdom is your spellcasting ability for it.</content>
   <content contentuid="hf18cec4dgc5a5gd248gadb2gacd0002e8ee0" version="1">Elemental Attunement</content>
   <content contentuid="hdd54bf99g06bfg8a6cg5904g1e14b2426411" version="2">At the start of your turn, you can expend 1 Focus Point to imbue yourself with elemental energy. The energy lasts for 10 minutes. You gain the following benefits while this feature is active.
 
@@ -486,7 +486,7 @@ Each creature in the Sphere must make a Dexterity saving throw. On a failed save
   <content contentuid="hb75cfe1fg5fb8gb857g1067ge5e38e4b4046" version="1">Elemental Burst: Lightning</content>
   <content contentuid="ha9461978g325bg8b56g0b7fga747967bcf5b" version="1">Elemental Burst: Thunder</content>
   <content contentuid="hd0321dfag2f41g5984g2a27g4ba878286102" version="1">Level 11: Stride of the Elements</content>
-  <content contentuid="h90c565bfgdc8eg1fc2gde60ga457cc60135b" version="1">While your Elemental Attunement is active, you also have a Fly Speed and a Swim Speed equal to your Speed.</content>
+  <content contentuid="h90c565bfgdc8eg1fc2gde60ga457cc60135b" version="1">While your &lt;LSTag Type="Spell" Tooltip="Shout_HarmonyOfFireAndWater"&gt;Elemental Attunement&lt;/LSTag&gt; is active, you also have a Fly Speed and a Swim Speed equal to your Speed.</content>
   <content contentuid="hbe92a07bg1800gd2e8g079fg1e0f39ce73ce" version="1">Wholeness of Body</content>
   <content contentuid="h4feabb8egaa22g3d36gc857g512930772995" version="1">Level 6: Wholeness of Body</content>
   <content contentuid="hd5f70284g45c5g71b8g7505g337ea5751295" version="1">You gain the ability to heal yourself. As a Bonus Action, you can roll your Martial Arts die. You regain a number of Hit Points equal to the number rolled plus your Wisdom modifier (minimum of 1 Hit Point regained).
@@ -519,7 +519,7 @@ You can also cast the spell once without expending a spell slot, and you regain 
   <content contentuid="h75d1a2deg8c23gb291g4a07g0b23ca7da55c" version="1">Find Steed</content>
   <content contentuid="hca271062g4f0eg4316gc46ag52e3d54b2851" version="3">You summon an otherworldly steed and immediately mount it.
 
-The steed can take one of the following actions of your choice on each of its turns: Dash, Disengage, Dodge, or Attack.
+The steed can take one of the following actions of your choice on each of its turns: &lt;LSTag Type="Spell" Tooltip="Shout_Dash"&gt;Dash&lt;/LSTag&gt;, Disengage, Dodge, or Attack.
 
 While mounted on the steed, when you take damage of 4 or higher, you must make a DC 8 Dexterity saving throw. On a failed save, you fall off the steed and have the Prone condition for 1 turn.
 
@@ -528,7 +528,7 @@ Only a player with a pure heart can see the steed.</content>
   <content contentuid="h969b831eg23d1g5115g756bg2f5d95f425ab" version="1">Find Steed</content>
   <content contentuid="h2e3d13a5gdd90g80a4g970dg3282a7a7bfa9" version="1">You summon an otherworldly steed and immediately mount it.
 
-The steed can take one of the following actions of your choice on each of its turns: Dash, Disengage, Dodge, or Attack.
+The steed can take one of the following actions of your choice on each of its turns: &lt;LSTag Type="Spell" Tooltip="Shout_Dash"&gt;Dash&lt;/LSTag&gt;, Disengage, Dodge, or Attack.
 
 While mounted on the steed, when you take damage of 4 or higher, you must make a DC 8 Dexterity saving throw. On a failed save, you fall off the steed and have the Prone condition for 1 turn.</content>
   <content contentuid="h1a6f7528gc5efg5c9bge4f9gf7eb55315d54" version="1">Steed Action Point</content>
@@ -546,7 +546,7 @@ While mounted on the steed, when you take damage of 4 or higher, you must make a
   <content contentuid="he923c53cgfecbgb456g1ee5gbc97fd5f5a9a" version="1">Your strikes now carry supernatural power. When you hit a target with an attack roll using a Melee weapon or an Unarmed Strike, the target takes an extra 1d8 Radiant damage.</content>
   <content contentuid="h1b6d335fg71e3g921bg96efgd3563a3e9d4b" version="1">The paladin and nearby allies have Resistance to Necrotic, Psychic, and Radiant damage.</content>
   <content contentuid="he4565ab2g2625gaeb8g694eg929ab02e448c" version="1">The paladin and nearby allies have Resistance to Necrotic, Psychic, and Radiant damage.</content>
-  <content contentuid="hae6c4966g7a68ga1edg4bc6gae39ac7aeb6b" version="1">You and any nearby allies have Resistance to Necrotic, Psychic, and Radiant damage. The aura disappears if you fall Unconscious.</content>
+  <content contentuid="hae6c4966g7a68ga1edg4bc6gae39ac7aeb6b" version="1">You and any nearby allies have Resistance to Necrotic, Psychic, and Radiant damage. The aura disappears if you fall &lt;LSTag Type="Status" Tooltip="DOWNED"&gt;Unconscious&lt;/LSTag&gt;.</content>
   <content contentuid="h36197b70g60e1g9d30g020ag5ebf5202eade" version="1">Level 7: Relentless Avenger</content>
   <content contentuid="h2c05bd1dg9548g9d0ag66dbgd31ce3af6dab" version="1">If you hit an enemy with an &lt;LSTag Tooltip="OpportunityAttack"&gt;Opportunity Attack&lt;/LSTag&gt;, you can reduce the creature’s Speed to 0 until the end of the current turn. And your &lt;LSTag Tooltip="MovementSpeed"&gt;movement speed&lt;/LSTag&gt; increases by [1] on your next turn.</content>
   <content contentuid="hd54cf49fg52f9gc82fg23ddg240455666d75" version="1">Relentless Avenger Foe</content>
@@ -767,18 +767,18 @@ Sometimes the magic surges and deals additional damage. The chance of a magical 
   <content contentuid="heb8d0bd4gf518g09cbgdf04g875209dd858a" version="1">Once per turn when you hit a creature with your pact weapon, you can expend a Pact Magic spell slot to deal an extra 1d8 Force damage to the target, plus another 1d8 per level of the spell slot, and you can give the target the Prone condition if it is Huge or smaller.</content>
   <content contentuid="hd23c4cc6g5a99gc62eg7220ge0f7cee47aba" version="1">Once per turn when you hit a creature with your pact weapon, you can expend a Pact Magic spell slot to deal an extra 1d8 Force damage to the target, plus another 1d8 per level of the spell slot, and you can give the target the Prone condition if it is Huge or smaller.</content>
   <content contentuid="h24650f10g65f0gdad5g30cdg3e4777297c7c" version="1">Level 2: Scholar</content>
-  <content contentuid="h32ed567egee36g91e1g2accgb992c0f4d730" version="1">While studying magic, you also specialized in another field of study. Choose one of the following skills in which you have proficiency: Arcana, History, Investigation, Medicine, Nature, or Religion. You have Expertise in the chosen skill.</content>
+  <content contentuid="h32ed567egee36g91e1g2accgb992c0f4d730" version="1">While studying magic, you also specialized in another field of study. Choose one of the following skills in which you have proficiency: &lt;LSTag Type="Skills" Tooltip="Arcana"&gt;Arcana&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="History"&gt;History&lt;/LSTag&gt;, Investigation, &lt;LSTag Type="Skills" Tooltip="Medicine"&gt;Medicine&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Nature"&gt;Nature&lt;/LSTag&gt;, or &lt;LSTag Type="Skills" Tooltip="Religion"&gt;Religion&lt;/LSTag&gt;. You have Expertise in the chosen skill.</content>
   <content contentuid="h2f5671feg10a3g6221g9db1gcd1af3a88f5b" version="1">Level 2: Expertise</content>
-  <content contentuid="h9e315a90g0705gb2c6g1a8eg13de362924de" version="1">You gain Expertise (see the rules glossary) in two of your skill proficiencies of your choice. Performance and Persuasion are recommended if you have proficiency in them.
+  <content contentuid="h9e315a90g0705gb2c6g1a8eg13de362924de" version="1">You gain Expertise (see the rules glossary) in two of your skill proficiencies of your choice. &lt;LSTag Type="Skills" Tooltip="Performance"&gt;Performance&lt;/LSTag&gt; and &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Persuasion&lt;/LSTag&gt; are recommended if you have proficiency in them.
 
 At Bard level 9, you gain Expertise in two more of your skill proficiencies of your choice.</content>
   <content contentuid="h1d573d0cg0ef8gc58cg5d87gf7b0ce7fc23d" version="1">Level 10: Magical Secrets</content>
   <content contentuid="hd5715a4dge184g890agee7ag4f904fb90c6b" version="1">You’ve learned secrets from various magical traditions. Whenever you reach a Bard level (including this level) and the Prepared Spells number in the Bard Features table increases, you can choose any of your new prepared spells from the Bard, Cleric, Druid, and Wizard spell lists, and the chosen spells count as Bard spells for you (see a class’s section for its spell list). In addition, whenever you replace a spell prepared for this class, you can replace it with a spell from those lists.</content>
   <content contentuid="hd4f3b039g6204g1bbagd21fgb72f806b54d8" version="1">Level 3: Combat Inspiration</content>
   <content contentuid="hd0e61f8bg955fgda33g3e08gc99c259c8a16" version="1">Level 3: Blessings of Knowledge</content>
-  <content contentuid="hc9341211ge6c1g1fd9gddbeg13315817fedb" version="1">You gain proficiency in two of the following skills of your choice: Arcana, History, Nature, or Religion. You have Expertise in those two skills.</content>
+  <content contentuid="hc9341211ge6c1g1fd9gddbeg13315817fedb" version="1">You gain proficiency in two of the following skills of your choice: &lt;LSTag Type="Skills" Tooltip="Arcana"&gt;Arcana&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="History"&gt;History&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Nature"&gt;Nature&lt;/LSTag&gt;, or &lt;LSTag Type="Skills" Tooltip="Religion"&gt;Religion&lt;/LSTag&gt;. You have Expertise in those two skills.</content>
   <content contentuid="ha8b64524g7467g0f1eg9214gbd3da8ce6302" version="1">Level 1: Expertise</content>
-  <content contentuid="h75d54fe5g6285g141fgd2b8gca722e196ecc" version="1">You gain Expertise in two of your skill proficiencies of your choice. Sleight of Hand and Stealth are recommended if you have proficiency in them.
+  <content contentuid="h75d54fe5g6285g141fgd2b8gca722e196ecc" version="1">You gain Expertise in two of your skill proficiencies of your choice. &lt;LSTag Type="Skills" Tooltip="SleightOfHand"&gt;Sleight of Hand&lt;/LSTag&gt; and &lt;LSTag Type="Skills" Tooltip="Stealth"&gt;Stealth&lt;/LSTag&gt; are recommended if you have proficiency in them.
 
 At Rogue level 6, you gain Expertise in two more of your skill proficiencies of your choice.</content>
   <content contentuid="hac07bd19g5886gc2efgf8dfgb838d23ca0bd" version="1">Level 5: Cunning Strike</content>
@@ -856,7 +856,7 @@ After selecting a spell, this mode ends.</content>
   <content contentuid="h711b7815g70c9g4712ga219g0ff6e0b8c207" version="1">Magic Initiate: Acid Splash</content>
   <content contentuid="h70fd1410g49a4g44d1g9f8eg7f6bc1c21fea" version="1">Magic Initiate: Friends</content>
   <content contentuid="ha6ce862fg4edeg49f7g9320gb8580541d70a" version="1">Magic Initiate: Fire Bolt</content>
-  <content contentuid="h97d2ab9cgaaf9g4bd4gb544g5862fb5d10b9" version="1">Magic Initiate: Dancing Lights</content>
+  <content contentuid="h97d2ab9cgaaf9g4bd4gb544g5862fb5d10b9" version="1">Magic Initiate: &lt;LSTag Type="Spell" Tooltip="Target_DancingLights"&gt;Dancing Lights&lt;/LSTag&gt;</content>
   <content contentuid="hc5fa63acg91f7g498fg8be8g4f77f6e608e1" version="1">Magic Initiate: Chill Touch</content>
   <content contentuid="h8cab8439g423ag41e7ga45bg7c1a4c23cde3" version="1">Magic Initiate: Bursting Sinew</content>
   <content contentuid="h4def798ag029dg4d00g8d1eg8929e03098d6" version="1">Magic Initiate: Booming Blade</content>
@@ -866,7 +866,7 @@ After selecting a spell, this mode ends.</content>
   <content contentuid="h1e7a31c9g35c0g4b54g8f69g25b327a4c999" version="1">Magic Initiate: Light</content>
   <content contentuid="hee3244d3g6916g4229gb4b7gd98a4f519f8e" version="1">Magic Initiate: Mage Hand</content>
   <content contentuid="hd455a5aag6fb4g48ccgbec8gdf13c11a88ab" version="1">Magic Initiate: Mind Sliver</content>
-  <content contentuid="h965b7dc5ga4acg4b60g9e4bgcd236212e8b4" version="1">Magic Initiate: Minor Illusion</content>
+  <content contentuid="h965b7dc5ga4acg4b60g9e4bgcd236212e8b4" version="1">Magic Initiate: &lt;LSTag Type="Spell" Tooltip="Target_ImprovedMinorIllusion"&gt;Minor Illusion&lt;/LSTag&gt;</content>
   <content contentuid="hcb1e67e1g69e7g4710g9cd5ga81a12763305" version="1">Magic Initiate: Poison Spray</content>
   <content contentuid="hf6e4b463g8945g4e41g8f63g065eb4ecdd0b" version="1">Magic Initiate: Produce Flame</content>
   <content contentuid="h4f7e0ea1g2ff6g48b2g937bg7cc4f590d0e7" version="1">Magic Initiate: Prestidigitation</content>
@@ -874,7 +874,7 @@ After selecting a spell, this mode ends.</content>
   <content contentuid="heda822d9g6ca8g4d69g862cg8e593ceb6f22" version="1">Magic Initiate: Resistance</content>
   <content contentuid="h04241b75g4f7eg40dagbac2g1acb8e2326f5" version="1">Magic Initiate: Sacred Flame</content>
   <content contentuid="hdd5d9c2cg059eg4e76gb6b6g01e4d851171d" version="1">Magic Initiate: Shillelagh</content>
-  <content contentuid="h4527bdb1gf97cg4adcg9003g64255fe6abdf" version="1">Magic Initiate: Shocking Grasp</content>
+  <content contentuid="h4527bdb1gf97cg4adcg9003g64255fe6abdf" version="1">Magic Initiate: &lt;LSTag Type="Spell" Tooltip="Target_ShockingGrasp"&gt;Shocking Grasp&lt;/LSTag&gt;</content>
   <content contentuid="h29d6991cg8d76g4e4bga787g7f988a72fe15" version="1">Magic Initiate: Spare the Dying</content>
   <content contentuid="hb163e2e9gb2d2g4adeg8801g80dbb2b50492" version="1">Magic Initiate: Starry Wisp</content>
   <content contentuid="h9f283e92g10dfg43b6g837dg39ee82977d4b" version="1">Magic Initiate: Sword Burst</content>
@@ -1037,7 +1037,7 @@ Jumping. Once per turn, you can make a Jump by spending only 10 feet of movement
 
 Charge Attack. If you move at least 10 feet in a straight line toward a target immediately before hitting it with a melee attack roll as part of the Attack action, choose one of the following effects: gain a 1d8 bonus to the attack’s damage roll, or push the target up to 10 feet away if it is no more than one size larger than you. You can use this benefit only once on each of your turns.</content>
   <content contentuid="hbc6e4744g6835g4d25g3453g224b9eed2a70" version="1">Feat: Charger</content>
-  <content contentuid="h4e972de5g72bbgc7d9gfda3g1c89f2af41d0" version="2">Improved Dash. When you take the Dash action, your Speed increases by 10 feet for that action.
+  <content contentuid="h4e972de5g72bbgc7d9gfda3g1c89f2af41d0" version="2">Improved &lt;LSTag Type="Spell" Tooltip="Shout_Dash"&gt;Dash&lt;/LSTag&gt;. When you take the Dash action, your Speed increases by 10 feet for that action.
 
 Charge Attack. If you move at least 10 feet in a straight line toward a target immediately before hitting it with a melee attack roll as part of the Attack action, choose one of the following effects: gain a 1d8 bonus to the attack’s damage roll, or push the target up to 10 feet away if it is no more than one size larger than you. You can use this benefit only once on each of your turns.</content>
   <content contentuid="hafd66c3cg4becg70e3gdeb1g96e635182645" version="1">Crossbow Expert</content>
@@ -1058,7 +1058,7 @@ Wounding Bolt. When you hit a creature with a ranged attack, it has a chance to 
   <content contentuid="h7ed3574cg898aga3cage4bcg72bfa5e60a5c" version="1">Feat: Dual Wielder</content>
   <content contentuid="hb2bf6fc5g6c41geefag4186g751dda5c0a20" version="1">Off-Hand Attack (Dual Wielder)</content>
   <content contentuid="hfba39959g9b2dg1bffgffd6g069588fe122e" version="1">Dungeon Delver</content>
-  <content contentuid="h9dd8a551g9f01g98dbg64f1ga485e59f0e9d" version="2">You gain &lt;LSTag Tooltip="Advantage"&gt;Advantage&lt;/LSTag&gt; on Perception &lt;LSTag Tooltip="AbilityCheck"&gt;Checks&lt;/LSTag&gt; made to detect hidden objects and on &lt;LSTag Tooltip="SavingThrow"&gt;Saving Throws&lt;/LSTag&gt; made to avoid or resist traps.
+  <content contentuid="h9dd8a551g9f01g98dbg64f1ga485e59f0e9d" version="2">You gain &lt;LSTag Tooltip="Advantage"&gt;Advantage&lt;/LSTag&gt; on &lt;LSTag Type="Skills" Tooltip="Perception"&gt;Perception&lt;/LSTag&gt; &lt;LSTag Tooltip="AbilityCheck"&gt;Checks&lt;/LSTag&gt; made to detect hidden objects and on &lt;LSTag Tooltip="SavingThrow"&gt;Saving Throws&lt;/LSTag&gt; made to avoid or resist traps.
 
 You gain &lt;LSTag Tooltip="Resistant"&gt;Resistance&lt;/LSTag&gt; to the damage dealt by traps.
 
@@ -1102,7 +1102,7 @@ Guarded Mind. If you fail an Intelligence, a Wisdom, or a Charisma saving throw,
   <content contentuid="h9f345cf4g20e3g3adbg0568g4c6d7a467ed6" version="2">Speedy</content>
   <content contentuid="h9aba9e0ag4af1g9f8fg922ag7e65e5b8a86b" version="2">Speed Increase. Your Speed increases by 10 feet.
 
-Dash over Difficult Terrain. When you take the Dash action on your turn, Difficult Terrain doesn't cost you extra movement for the rest of that turn.
+Dash over &lt;LSTag Type="Status" Tooltip="DIFFICULT_TERRAIN"&gt;Difficult Terrain&lt;/LSTag&gt;. When you take the Dash action on your turn, Difficult Terrain doesn't cost you extra movement for the rest of that turn.
 
 Agile Movement. Opportunity Attacks have Disadvantage against you.</content>
   <content contentuid="h8eacabe1gf4e0g46a9g32adg16f61a4b3530" version="1">Moderately Armoured</content>
@@ -1110,7 +1110,7 @@ Agile Movement. Opportunity Attacks have Disadvantage against you.</content>
   <content contentuid="h064d8f79g7d9eg262fg76e0g2d04ce1515a6" version="2">Feat: Speedy</content>
   <content contentuid="h1ea9a52fg1499gbdd8g9ab4g8e8ff63c7f3f" version="1">Speed Increase. Your Speed increases by 10 feet.
 
-Dash over Difficult Terrain. When you take the Dash action on your turn, Difficult Terrain doesn't cost you extra movement for the rest of that turn.
+&lt;LSTag Type="Spell" Tooltip="Shout_Dash"&gt;Dash&lt;/LSTag&gt; over &lt;LSTag Type="Status" Tooltip="DIFFICULT_TERRAIN"&gt;Difficult Terrain&lt;/LSTag&gt;. When you take the Dash action on your turn, Difficult Terrain doesn't cost you extra movement for the rest of that turn.
 
 Agile Movement. Opportunity Attacks have Disadvantage against you.</content>
   <content contentuid="hcece8c3cgbda0g0cf1g3872g9d5fba9e3f61" version="1">Feat: Moderately Armoured</content>
@@ -1199,30 +1199,30 @@ You can use a &lt;LSTag Type="ActionResource" Tooltip="ReactionActionPoint"&gt;r
 
 You gain two weapon mastery properties of your choice.</content>
   <content contentuid="hed4fadaag2f33gc2b5g10bcg877f54981719" version="4">Path of the World Tree</content>
-  <content contentuid="h07ac58a7gdc95gd7d3g0b48g2015e769d0d0" version="1">Barbarians who follow the Path of the World Tree connect with the cosmic tree Yggdrasil through their Rage. This tree grows among the Outer Planes, connecting them to each other and the Material Plane. These Barbarians draw on the tree’s magic for vitality and as a means of dimensional travel.</content>
+  <content contentuid="h07ac58a7gdc95gd7d3g0b48g2015e769d0d0" version="1">Barbarians who follow the Path of the World Tree connect with the cosmic tree Yggdrasil through their &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt;. This tree grows among the Outer Planes, connecting them to each other and the Material Plane. These Barbarians draw on the tree’s magic for vitality and as a means of dimensional travel.</content>
   <content contentuid="h7f11fde8g7022gc624gc07cg0bf0afe43eb0" version="1">Level 3: Vitality of the Tree</content>
-  <content contentuid="h17806188g48eag72daga9fag423961387d39" version="1">Your Rage taps into the life force of the World Tree. You gain the following benefits.
+  <content contentuid="h17806188g48eag72daga9fag423961387d39" version="1">Your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; taps into the life force of the World Tree. You gain the following benefits.
 
 Vitality Surge. When you activate your Rage, you gain a number of Temporary Hit Points equal to your Barbarian level.
 
-Life-Giving Force. At the start of each of your turns while your Rage is active, you can choose another creature within 10 feet of yourself to gain Temporary Hit Points. To determine the number of Temporary Hit Points, roll a number of d6s equal to your Rage Damage bonus, and add them together. If any of these Temporary Hit Points remain when your Rage ends, they vanish.</content>
+Life-Giving Force. At the start of each of your turns while your Rage is active, you can choose another creature within 10 feet of yourself to gain Temporary Hit Points. To determine the number of Temporary Hit Points, roll a number of d6s equal to your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; Damage bonus, and add them together. If any of these Temporary Hit Points remain when your Rage ends, they vanish.</content>
   <content contentuid="h39e02d12g9361g9427gcabbg9c625c015d9e" version="1">Level 6: Branches of the Tree</content>
-  <content contentuid="hc973bce4g12d2g5a53g43a8g98cefe571124" version="2">While your Rage is active, you can use your Reaction to lash out with spectral branches of the World Tree and pull a creature you can see within 30 feet of you. The target must succeed on a Strength saving throw (DC 8 + your Strength modifier + your Proficiency Bonus) or be pulled up to 20 feet straight toward you. After pulling the target, you can reduce its Speed to 0 until the start of your next turn.</content>
+  <content contentuid="hc973bce4g12d2g5a53g43a8g98cefe571124" version="2">While your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; is active, you can use your Reaction to lash out with spectral branches of the World Tree and pull a creature you can see within 30 feet of you. The target must succeed on a Strength saving throw (DC 8 + your Strength modifier + your Proficiency Bonus) or be pulled up to 20 feet straight toward you. After pulling the target, you can reduce its Speed to 0 until the start of your next turn.</content>
   <content contentuid="h73b80082g2131g52abg5e7bg5ef03ffa6906" version="1">Level 10: Battering Roots</content>
-  <content contentuid="h26a9d040g90ffg7098gc158g401ddd420d2e" version="1">During your turn, your reach is 10 feet greater with any Melee weapon that has the Heavy or Versatile property, as tendrils of the World Tree extend from you. When you hit with such a weapon on your turn, you can activate the Push or Topple mastery property in addition to a different mastery property you’re using with that weapon.</content>
+  <content contentuid="h26a9d040g90ffg7098gc158g401ddd420d2e" version="1">During your turn, your reach is 10 feet greater with any Melee weapon that has the Heavy or Versatile property, as tendrils of the World Tree extend from you. When you hit with such a weapon on your turn, you can activate the &lt;LSTag Type="Passive" Tooltip="WeaponMasteryPush"&gt;Push&lt;/LSTag&gt; or Topple mastery property in addition to a different mastery property you’re using with that weapon.</content>
   <content contentuid="h460429dfgc912g3f17g81b4g0b1e6420baf6" version="1">Vitality Surge</content>
-  <content contentuid="hcc3ad546g16bcgfa68g23a7g1b2b0bcd4801" version="1">When you activate your Rage, you gain a number of Temporary Hit Points equal to your Barbarian level.</content>
+  <content contentuid="hcc3ad546g16bcgfa68g23a7g1b2b0bcd4801" version="1">When you activate your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt;, you gain a number of Temporary Hit Points equal to your Barbarian level.</content>
   <content contentuid="haa81c0f2ge2b2gd7b9gc090gd87edfd50eab" version="1">Vitality Surge</content>
-  <content contentuid="hde63b209g1d1dg2fb9gf3abg0f84f42a69f8" version="1">When you activate your Rage, you gain a number of Temporary Hit Points equal to your Barbarian level.</content>
+  <content contentuid="hde63b209g1d1dg2fb9gf3abg0f84f42a69f8" version="1">When you activate your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt;, you gain a number of Temporary Hit Points equal to your Barbarian level.</content>
   <content contentuid="hc60cc039g3202g31b4gacf6gcd33f83a5892" version="1">Life-Giving Force</content>
-  <content contentuid="hb7d8ce7cga74egd272g4ed3gebe2eec3f346" version="1">A creature affected by this feature gains Temporary Hit Points. To determine the number of Temporary Hit Points, roll a number of d6s equal to Barbarian's Rage Damage bonus and add them together.</content>
+  <content contentuid="hb7d8ce7cga74egd272g4ed3gebe2eec3f346" version="1">A creature affected by this feature gains Temporary Hit Points. To determine the number of Temporary Hit Points, roll a number of d6s equal to Barbarian's &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; Damage bonus and add them together.</content>
   <content contentuid="h89126fa9g133eg379eg0309gc7c31b95136d" version="1">Branches of the Tree</content>
   <content contentuid="hed7feb7bg4d7cg4f19g7010g6ecd461345dd" version="1">A creature affected by this feature has its Speed reduced to 0 until the end of its next turn.</content>
   <content contentuid="hf26f1c7dg99f2g62d7g6798gaf1e5640053f" version="1">Battering Roots: Push</content>
   <content contentuid="hd109b0dbg19e8ga1d2g4826gc3978e7b2e7f" version="1">Battering Roots: Topple</content>
   <content contentuid="hacfddf65g2ec1gdb58g7ef1g360e33d3d696" version="1">You can additionally apply the Topple mastery property to that attack.</content>
-  <content contentuid="h21000e09gdda6g7a5fg404eg1458b9ccd985" version="2">At the start of each of your turns while your Rage is active, you can choose another creature within 10 feet of yourself to gain Temporary Hit Points. To determine the number of Temporary Hit Points, roll a number of d6s equal to your Rage Damage bonus, and add them together. If any of these Temporary Hit Points remain when your Rage ends, they vanish.</content>
-  <content contentuid="h1d68851cgda5ag5482g75f2gc0f7b6817b16" version="3">While your Rage is active, you can use your Reaction to lash out with spectral branches of the World Tree and pull a creature you can see within 30 feet of you. The target must succeed on a Strength saving throw (DC 8 + your Strength modifier + your Proficiency Bonus) or be pulled up to 20 feet straight toward you. After pulling the target, you can reduce its Speed to 0 until the start of your next turn.</content>
+  <content contentuid="h21000e09gdda6g7a5fg404eg1458b9ccd985" version="2">At the start of each of your turns while your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; is active, you can choose another creature within 10 feet of yourself to gain Temporary Hit Points. To determine the number of Temporary Hit Points, roll a number of d6s equal to your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; Damage bonus, and add them together. If any of these Temporary Hit Points remain when your Rage ends, they vanish.</content>
+  <content contentuid="h1d68851cgda5ag5482g75f2gc0f7b6817b16" version="3">While your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; is active, you can use your Reaction to lash out with spectral branches of the World Tree and pull a creature you can see within 30 feet of you. The target must succeed on a Strength saving throw (DC 8 + your Strength modifier + your Proficiency Bonus) or be pulled up to 20 feet straight toward you. After pulling the target, you can reduce its Speed to 0 until the start of your next turn.</content>
   <content contentuid="hbc51a963g20c5g876cgc0b3g1fda844b3830" version="1">Life-Giving Force</content>
   <content contentuid="h0742adb9g8528gcb3ag3596ge883d9faa6ab" version="1">Branches of the Tree</content>
   <content contentuid="hb477d444g2e4egabe4g8bd0g64d34fe959ee" version="1">Level 3: Divine Fury</content>
@@ -1230,19 +1230,19 @@ Life-Giving Force. At the start of each of your turns while your Rage is active,
   <content contentuid="h37bdd6afg8377ga414g06b2gd12131f14c73" version="1">Level 6: Fanatical Focus</content>
   <content contentuid="h9ac99198g4fe0gd34bg57a0g52acb98ed35f" version="1">Level 10: Zealous Presence</content>
   <content contentuid="hfa0367c5gd524g439egbb91gf1d01da462a1" version="4">Path of the Zealot</content>
-  <content contentuid="h0e363cf3g0162gc215g7872g2aa8512bdbd6" version="1">Barbarians who walk the Path of the Zealot receive boons from a god or pantheon. These Barbarians experience their Rage as an ecstatic episode of divine union that infuses them with power. They are often allies to the priests and other followers of their god or pantheon.</content>
-  <content contentuid="h15b91354gf2d6ga550g86cag97a1796054d7" version="1">You can channel divine power into your strikes. On each of your turns while your Rage is active, the first creature you hit with a weapon or an Unarmed Strike takes extra damage equal to 1d6 plus half your Barbarian level (round down). The extra damage is Necrotic or Radiant; you choose the type each time you deal the damage.</content>
+  <content contentuid="h0e363cf3g0162gc215g7872g2aa8512bdbd6" version="1">Barbarians who walk the Path of the Zealot receive boons from a god or pantheon. These Barbarians experience their &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; as an ecstatic episode of divine union that infuses them with power. They are often allies to the priests and other followers of their god or pantheon.</content>
+  <content contentuid="h15b91354gf2d6ga550g86cag97a1796054d7" version="1">You can channel divine power into your strikes. On each of your turns while your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; is active, the first creature you hit with a weapon or an Unarmed Strike takes extra damage equal to 1d6 plus half your Barbarian level (round down). The extra damage is Necrotic or Radiant; you choose the type each time you deal the damage.</content>
   <content contentuid="hc4c144a0g2e9bg6166g297cg8829f3a2bd83" version="1">A divine entity helps ensure you can continue the fight. You have a pool of four d12s that you can spend to heal yourself. As a Bonus Action, you can expend dice from the pool, roll them, and regain a number of Hit Points equal to the roll’s total.
 
 Your pool regains all expended dice when you finish a Long Rest.
 
 The pool’s maximum number of dice increases by one when you reach Barbarian levels 6 (5 dice), 12 (6 dice), and 17 (7 dice).</content>
-  <content contentuid="h9416ea15g9b17g07abg6c06gd6905fe706ed" version="1">While your Rage is active, you add a bonus equal to your Rage Damage bonus to your saving throws.</content>
-  <content contentuid="hd421ade2g497bg2094g6654geebf64ed20f1" version="2">Once per Short Rest, as a Bonus Action, you unleash a battle cry infused with divine energy; creatures of your choice within 60 feet of you gain Advantage on attack rolls and saving throws until the start of your next turn.</content>
+  <content contentuid="h9416ea15g9b17g07abg6c06gd6905fe706ed" version="1">While your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; is active, you add a bonus equal to your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; Damage bonus to your saving throws.</content>
+  <content contentuid="hd421ade2g497bg2094g6654geebf64ed20f1" version="2">Once per Short Rest, as a Bonus Action, you unleash a &lt;LSTag Type="Spell" Tooltip="Shout_ZealousPresence"&gt;battle cry&lt;/LSTag&gt; infused with divine energy; creatures of your choice within 60 feet of you gain Advantage on attack rolls and saving throws until the start of your next turn.</content>
   <content contentuid="h3e0f83eag20c7gefccg3505g67e905536f9c" version="1">Divine Fury: Radiant</content>
-  <content contentuid="hd5d65420g6479g285bg4c8ag03e208bc40e5" version="1">While your Rage is active, the first creature you hit on each of your turns with a weapon or an Unarmed Strike takes extra Radiant damage equal to 1d6 plus half your Barbarian level (rounded down).</content>
+  <content contentuid="hd5d65420g6479g285bg4c8ag03e208bc40e5" version="1">While your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; is active, the first creature you hit on each of your turns with a weapon or an Unarmed Strike takes extra Radiant damage equal to 1d6 plus half your Barbarian level (rounded down).</content>
   <content contentuid="hc0013b90g841eg2935g8b77g5e53735b98a6" version="1">Divine Fury: Necrotic</content>
-  <content contentuid="h47b388afge0d2g2240g7d34g00c0f0fbd7f3" version="1">While your Rage is active, the first creature you hit on each of your turns with a weapon or an Unarmed Strike takes extra Necrotic damage equal to 1d6 plus half your Barbarian level (rounded down).</content>
+  <content contentuid="h47b388afge0d2g2240g7d34g00c0f0fbd7f3" version="1">While your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; is active, the first creature you hit on each of your turns with a weapon or an Unarmed Strike takes extra Necrotic damage equal to 1d6 plus half your Barbarian level (rounded down).</content>
   <content contentuid="hf168720fgd4dbgc575ge2c3g9a0841c3efc9" version="1">Warrior of the Gods</content>
   <content contentuid="h46ea941fg771dgceb6g2492gb66d8a8c13e0" version="1">A divine entity helps ensure you can continue the fight. You have a pool of four d12s that you can spend to heal yourself. As a Bonus Action, you can expend dice from the pool, roll them, and regain a number of Hit Points equal to the roll’s total.
 
@@ -1252,7 +1252,7 @@ The pool’s maximum number of dice increases by one when you reach Barbarian le
   <content contentuid="h9ae5d499g6937g51d5g2d3eg9854133655cd" version="1">Warrior of the Gods</content>
   <content contentuid="h5059c8f8g9435g5e50g19c7g899613e62b54" version="1">A divine entity helps ensure you can continue the fight. You have a pool of four d12s that you can spend to heal yourself</content>
   <content contentuid="hdefa5de2gb9bfgc136gf8e6gf90eb2739837" version="1">Fanatical Focus</content>
-  <content contentuid="he4612c48gfd84gd95cg77b9g94667cfad8a4" version="1">While your Rage is active, you add a bonus equal to your Rage Damage bonus to your saving throws.</content>
+  <content contentuid="he4612c48gfd84gd95cg77b9g94667cfad8a4" version="1">While your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; is active, you add a bonus equal to your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; Damage bonus to your saving throws.</content>
   <content contentuid="hf40dc054gd469gf99cg895bgc27babafe771" version="1">Zealous Presence</content>
   <content contentuid="h2a819702g2758g04dcg200age5456cbe7459" version="1">Once per Short Rest, as a Bonus Action, you unleash a battle cry infused with divine energy; creatures of your choice within 60 feet of you gain Advantage on attack rolls and saving throws until the start of your next turn.</content>
   <content contentuid="h509f959fg0fe6gec34gedb0gc6a719773d5b" version="1">Zealous Presence</content>
@@ -1260,7 +1260,7 @@ The pool’s maximum number of dice increases by one when you reach Barbarian le
   <content contentuid="h284201cfg7ef2g3386g799dgb94060c50b96" version="1">Level 3: Dazzling Footwork</content>
   <content contentuid="h7d579a81g52d6g1a4cg3fe1ge97bcb251943" version="1">While you aren’t wearing armor or wielding a Shield, you gain the following benefits.
 
-Dance Virtuoso. You have Advantage on any Charisma (Performance) check you make that involves you dancing.
+Dance Virtuoso. You have Advantage on any Charisma (&lt;LSTag Type="Skills" Tooltip="Performance"&gt;Performance&lt;/LSTag&gt;) check you make that involves you dancing.
 
 Unarmored Defense. Your base Armor Class equals 10 plus your Dexterity and Charisma modifiers.
 
@@ -1541,7 +1541,7 @@ On your later turns, you can take a Magic action to move the Cylinder up to 30 f
   <content contentuid="he922cbadga1cagc50eg44aagb22738ab6296" version="1">Phantom Steed</content>
   <content contentuid="h7d1b5755g3943g8854gdc14g83c3921a9c89" version="1">You summon a phantom steed in an unoccupied space near the target, and the target immediately mounts it.
 
-The steed can take one of the following actions of your choice on each of its turns: Dash, Disengage, Dodge
+The steed can take one of the following actions of your choice on each of its turns: &lt;LSTag Type="Spell" Tooltip="Shout_Dash"&gt;Dash&lt;/LSTag&gt;, Disengage, Dodge
 
 While mounted on the steed, when you take damage of 4 or higher, you must make a DC 8 Dexterity saving throw. On a failed save, you fall off the steed and have the Prone condition for 1 turn.
 
@@ -1550,7 +1550,7 @@ Only a player with a pure heart can see the steed.</content>
   <content contentuid="h0f489216gb640gb35fg24f2ge484d18842ab" version="1">Phantom Steed</content>
   <content contentuid="he5f0f47cg9e31g78f9g3de0gbcdc5fe67dd8" version="1">You summon a phantom steed in an unoccupied space near the target, and the target immediately mounts it.
 
-The steed can take one of the following actions of your choice on each of its turns: Dash, Disengage, Dodge
+The steed can take one of the following actions of your choice on each of its turns: &lt;LSTag Type="Spell" Tooltip="Shout_Dash"&gt;Dash&lt;/LSTag&gt;, Disengage, Dodge
 
 While mounted on the steed, when you take damage of 4 or higher, you must make a DC 8 Dexterity saving throw. On a failed save, you fall off the steed and have the Prone condition for 1 turn.
 
@@ -1586,12 +1586,12 @@ On a failed save, the target has Disadvantage on Strength-based D20 Tests for th
   <content contentuid="hb291dd01gaa36gf848g9cb2g11776f6a95ba" version="1">You touch a willing creature. When the creature takes damage before the spell ends, the creature reduces the total damage taken by 1d4. A creature can benefit from this spell only once per turn.</content>
   <content contentuid="h9d6a4e32g87edg4607g6cd5g19197e4e0034" version="1">When the creature takes damage before the spell ends, the creature reduces the total damage taken by 1d4. A creature can benefit from this spell only once per turn.</content>
   <content contentuid="h1e40a51eg6772g87d3ga8a6gd8b5dcc5e0f0" version="1">When the creature takes damage before the spell ends, the creature reduces the total damage taken by 1d4. A creature can benefit from this spell only once per turn.</content>
-  <content contentuid="h0fb46065g45fege74age2e5g0f1ff68942df" version="2">Each creature of your choice in a 5-foot-radius Sphere centered on a point within range must succeed on a Wisdom saving throw or have the Incapacitated condition until the end of its next turn, at which point it must repeat the save. If the target fails the second save, the target has the Unconscious condition for the duration. The spell ends on a target if it takes damage or someone within 5 feet of it takes an action to shake it out of the spell’s effect.</content>
-  <content contentuid="h4fcec4c9gde1eg19b6gebddg9af35fef4ff5" version="2">Each creature of your choice in a 5-foot-radius Sphere centered on a point within range must succeed on a Wisdom saving throw or have the Incapacitated condition until the end of its next turn, at which point it must repeat the save. If the target fails the second save, the target has the Unconscious condition for the duration. The spell ends on a target if it takes damage or someone within 5 feet of it takes an action to shake it out of the spell’s effect.</content>
-  <content contentuid="h2ba0acdeg33d2g33c7g5f83gb4c34e1444c0" version="2">Each creature of your choice in a 5-foot-radius Sphere centered on a point within range must succeed on a Wisdom saving throw or have the Incapacitated condition until the end of its next turn, at which point it must repeat the save. If the target fails the second save, the target has the Unconscious condition for the duration. The spell ends on a target if it takes damage or someone within 5 feet of it takes an action to shake it out of the spell’s effect.</content>
-  <content contentuid="ha765fffag4904gfe52g8d54gd4472a83f8fc" version="2">Each creature of your choice in a 5-foot-radius Sphere centered on a point within range must succeed on a Wisdom saving throw or have the Incapacitated condition until the end of its next turn, at which point it must repeat the save. If the target fails the second save, the target has the Unconscious condition for the duration. The spell ends on a target if it takes damage or someone within 5 feet of it takes an action to shake it out of the spell’s effect.</content>
-  <content contentuid="h804ad0f1g6cb1ge2ecg1066g91b9c7f2effa" version="2">Each creature of your choice in a 5-foot-radius Sphere centered on a point within range must succeed on a Wisdom saving throw or have the Incapacitated condition until the end of its next turn, at which point it must repeat the save. If the target fails the second save, the target has the Unconscious condition for the duration. The spell ends on a target if it takes damage or someone within 5 feet of it takes an action to shake it out of the spell’s effect.</content>
-  <content contentuid="h47a0106cg9a69g79a5g7f31g8c859cf2dd61" version="2">Each creature of your choice in a 5-foot-radius Sphere centered on a point within range must succeed on a Wisdom saving throw or have the Incapacitated condition until the end of its next turn, at which point it must repeat the save. If the target fails the second save, the target has the Unconscious condition for the duration. The spell ends on a target if it takes damage or someone within 5 feet of it takes an action to shake it out of the spell’s effect.</content>
+  <content contentuid="h0fb46065g45fege74age2e5g0f1ff68942df" version="2">Each creature of your choice in a 5-foot-radius Sphere centered on a point within range must succeed on a Wisdom saving throw or have the Incapacitated condition until the end of its next turn, at which point it must repeat the save. If the target fails the second save, the target has the &lt;LSTag Type="Status" Tooltip="SLEEP"&gt;Unconscious&lt;/LSTag&gt; condition for the duration. The spell ends on a target if it takes damage or someone within 5 feet of it takes an action to shake it out of the spell’s effect.</content>
+  <content contentuid="h4fcec4c9gde1eg19b6gebddg9af35fef4ff5" version="2">Each creature of your choice in a 5-foot-radius Sphere centered on a point within range must succeed on a Wisdom saving throw or have the Incapacitated condition until the end of its next turn, at which point it must repeat the save. If the target fails the second save, the target has the &lt;LSTag Type="Status" Tooltip="SLEEP"&gt;Unconscious&lt;/LSTag&gt; condition for the duration. The spell ends on a target if it takes damage or someone within 5 feet of it takes an action to shake it out of the spell’s effect.</content>
+  <content contentuid="h2ba0acdeg33d2g33c7g5f83gb4c34e1444c0" version="2">Each creature of your choice in a 5-foot-radius Sphere centered on a point within range must succeed on a Wisdom saving throw or have the Incapacitated condition until the end of its next turn, at which point it must repeat the save. If the target fails the second save, the target has the &lt;LSTag Type="Status" Tooltip="SLEEP"&gt;Unconscious&lt;/LSTag&gt; condition for the duration. The spell ends on a target if it takes damage or someone within 5 feet of it takes an action to shake it out of the spell’s effect.</content>
+  <content contentuid="ha765fffag4904gfe52g8d54gd4472a83f8fc" version="2">Each creature of your choice in a 5-foot-radius Sphere centered on a point within range must succeed on a Wisdom saving throw or have the Incapacitated condition until the end of its next turn, at which point it must repeat the save. If the target fails the second save, the target has the &lt;LSTag Type="Status" Tooltip="SLEEP"&gt;Unconscious&lt;/LSTag&gt; condition for the duration. The spell ends on a target if it takes damage or someone within 5 feet of it takes an action to shake it out of the spell’s effect.</content>
+  <content contentuid="h804ad0f1g6cb1ge2ecg1066g91b9c7f2effa" version="2">Each creature of your choice in a 5-foot-radius Sphere centered on a point within range must succeed on a Wisdom saving throw or have the Incapacitated condition until the end of its next turn, at which point it must repeat the save. If the target fails the second save, the target has the &lt;LSTag Type="Status" Tooltip="SLEEP"&gt;Unconscious&lt;/LSTag&gt; condition for the duration. The spell ends on a target if it takes damage or someone within 5 feet of it takes an action to shake it out of the spell’s effect.</content>
+  <content contentuid="h47a0106cg9a69g79a5g7f31g8c859cf2dd61" version="2">Each creature of your choice in a 5-foot-radius Sphere centered on a point within range must succeed on a Wisdom saving throw or have the Incapacitated condition until the end of its next turn, at which point it must repeat the save. If the target fails the second save, the target has the &lt;LSTag Type="Status" Tooltip="SLEEP"&gt;Unconscious&lt;/LSTag&gt; condition for the duration. The spell ends on a target if it takes damage or someone within 5 feet of it takes an action to shake it out of the spell’s effect.</content>
   <content contentuid="h36a49c70g93aeg56fag31d6g861694b3eca0" version="1">Turn a creature's flesh hard as stone. It takes only &lt;LSTag Tooltip="Resistant"&gt;half the damage&lt;/LSTag&gt; of all Bludgeoning, Piercing, and Slashing damage.</content>
   <content contentuid="hbd15ec06ga1begd062g730ega5c6e100ec6f" version="1">Turn a creature's flesh hard as stone. It takes only &lt;LSTag Tooltip="Resistant"&gt;half the damage&lt;/LSTag&gt; of all Bludgeoning, Piercing, and Slashing damage.</content>
   <content contentuid="h901059e2g5cefg4bbbg2e95g491ea1dbb812" version="1">Turn a creature's flesh hard as stone. It takes only &lt;LSTag Tooltip="Resistant"&gt;half the damage&lt;/LSTag&gt; of all Bludgeoning, Piercing, and Slashing damage.</content>
@@ -1616,7 +1616,7 @@ On a failed save, the target has Disadvantage on Strength-based D20 Tests for th
   <content contentuid="h8155116dgb434g017cg6396g666179cd6bbd" version="1">Feat: Ritual Caster</content>
   <content contentuid="h81682b22g3da3g86c5g11f5gbebe41d25951" version="1">You have learnt three &lt;LSTag Tooltip="RitualSpell"&gt;ritual spells&lt;/LSTag&gt; of your choice.</content>
   <content contentuid="hca029b39g4097g0379g6a74gd52bb5fd4a04" version="1">Feat: Dungeon Delver</content>
-  <content contentuid="h5cc8709eg0974gcec1g323cg0a299d48a147" version="2">You have &lt;LSTag Tooltip="Advantage"&gt;Advantage&lt;/LSTag&gt; on Perception &lt;LSTag Tooltip="AbilityCheck"&gt;Checks&lt;/LSTag&gt; made to detect hidden objects.
+  <content contentuid="h5cc8709eg0974gcec1g323cg0a299d48a147" version="2">You have &lt;LSTag Tooltip="Advantage"&gt;Advantage&lt;/LSTag&gt; on &lt;LSTag Type="Skills" Tooltip="Perception"&gt;Perception&lt;/LSTag&gt; &lt;LSTag Tooltip="AbilityCheck"&gt;Checks&lt;/LSTag&gt; made to detect hidden objects.
 
 You have &lt;LSTag Tooltip="Advantage"&gt;Advantage&lt;/LSTag&gt; on &lt;LSTag Tooltip="SavingThrow"&gt;Saving Throws&lt;/LSTag&gt; made to avoid traps and &lt;LSTag Tooltip="Resistant"&gt;Resistance&lt;/LSTag&gt; to trap damage.
 
@@ -1692,7 +1692,7 @@ Enhanced Critical. When you score a Critical Hit that deals Slashing damage to a
   <content contentuid="h6f880a83gf538g3473g56f7g616ba93a3e5b" version="1">Feat: Poisoner</content>
   <content contentuid="h9e96b030g4a5fgfbd9g8d73g10831d134be3" version="3">Potent Poison. Spells you cast and attacks you make ignore &lt;LSTag Tooltip="Resistant"&gt;Resistance&lt;/LSTag&gt; to Poison damage. In addition, when you deal Poison damage with a spell, you cannot roll a 1. 
 
-Brew Poison. You gain a Poisoner’s Kit, and you have proficiency with them. When you deal poison damage to a creature, it must succeed on a Constitution saving throw or become Poisoned.</content>
+Brew Poison. You gain a Poisoner’s Kit, and you have proficiency with them. When you deal poison damage to a creature, it must succeed on a Constitution saving throw or become &lt;LSTag Type="Status" Tooltip="POISONED"&gt;Poisoned&lt;/LSTag&gt;.</content>
   <content contentuid="h98f7bf60g0be6g2f80g7ff8g89648f02353b" version="2">Mounted Combatant</content>
   <content contentuid="hc9a0b12cgc8fegf87fgb641gfcf715d58982" version="1">While you are mounted on the steed, you have Advantage on melee attack rolls against creatures of Small size or smaller. In addition, while mounted, you can’t be dismounted or knocked prone as a result of taking damage.</content>
   <content contentuid="hd96c9a15gcab7gfe30g113bg3a931597f197" version="1">Use Poisoner’s Kit</content>
@@ -1716,7 +1716,7 @@ If you choose Arid Land, you have Blur, Burning Hands, and Fire Bolt prepared at
 
 If you choose Polar Land, you have Fog Cloud, Hold Person, and Ray of Frost prepared at 3rd level; Sleet Storm at 5th level; Ice Storm at 7th level; and Cone of Cold at 9th level.
 
-If you choose Temperate Land, you have Misty Step, Shocking Grasp, and Sleep prepared at 3rd level; Lightning Bolt at 5th level; Freedom of Movement at 7th level; and Tree Stride at 9th level.
+If you choose Temperate Land, you have Misty Step, &lt;LSTag Type="Spell" Tooltip="Target_ShockingGrasp"&gt;Shocking Grasp&lt;/LSTag&gt;, and Sleep prepared at 3rd level; Lightning Bolt at 5th level; Freedom of Movement at 7th level; and Tree Stride at 9th level.
 
 If you choose Tropical Land, you have Acid Splash, Ray of Sickness, and Web prepared at 3rd level; Stinking Cloud at 5th level; Polymorph at 7th level; and Insect Plague at 9th level.</content>
   <content contentuid="hfcdb19afgd772g8c06gc034g42384d832b3b" version="1">Level 3: Circle of the Land Spells</content>
@@ -1726,7 +1726,7 @@ If you choose Arid Land, you have Blur, Burning Hands, and Fire Bolt prepared at
 
 If you choose Polar Land, you have Fog Cloud, Hold Person, and Ray of Frost prepared at 3rd level; Sleet Storm at 5th level; Ice Storm at 7th level; and Cone of Cold at 9th level.
 
-If you choose Temperate Land, you have Misty Step, Shocking Grasp, and Sleep prepared at 3rd level; Lightning Bolt at 5th level; Freedom of Movement at 7th level; and Greater Restoration at 9th level.
+If you choose Temperate Land, you have Misty Step, &lt;LSTag Type="Spell" Tooltip="Target_ShockingGrasp"&gt;Shocking Grasp&lt;/LSTag&gt;, and Sleep prepared at 3rd level; Lightning Bolt at 5th level; Freedom of Movement at 7th level; and Greater Restoration at 9th level.
 
 If you choose Tropical Land, you have Acid Splash, Ray of Sickness, and Web prepared at 3rd level; Stinking Cloud at 5th level; Polymorph at 7th level; and Insect Plague at 9th level.</content>
   <content contentuid="h571a7b7dg53fbg6786ge07dg6b9749737b6d" version="1">Circle of the Land Spells</content>
@@ -1736,7 +1736,7 @@ If you choose Arid Land, you have Blur, Burning Hands, and Fire Bolt prepared at
 
 If you choose Polar Land, you have Fog Cloud, Hold Person, and Ray of Frost prepared at 3rd level; Sleet Storm at 5th level; Ice Storm at 7th level; and Cone of Cold at 9th level.
 
-If you choose Temperate Land, you have Misty Step, Shocking Grasp, and Sleep prepared at 3rd level; Lightning Bolt at 5th level; Freedom of Movement at 7th level; and Greater Restoration at 9th level.
+If you choose Temperate Land, you have Misty Step, &lt;LSTag Type="Spell" Tooltip="Target_ShockingGrasp"&gt;Shocking Grasp&lt;/LSTag&gt;, and Sleep prepared at 3rd level; Lightning Bolt at 5th level; Freedom of Movement at 7th level; and Greater Restoration at 9th level.
 
 If you choose Tropical Land, you have Acid Splash, Ray of Sickness, and Web prepared at 3rd level; Stinking Cloud at 5th level; Polymorph at 7th level; and Insect Plague at 9th level.</content>
   <content contentuid="h60146c67g6a55gece0g343eg45527c9e429a" version="1">Circle of the Land Spells: Arid Land</content>
@@ -1744,7 +1744,7 @@ If you choose Tropical Land, you have Acid Splash, Ray of Sickness, and Web prep
   <content contentuid="hd1d44523g69ccgf313g036bga0c866484988" version="1">Circle of the Land Spells: Polar Land</content>
   <content contentuid="h5838ca69g39e0g1e69gd726g82f4309227aa" version="1">If you choose Polar Land, you have Fog Cloud, Hold Person, and Ray of Frost prepared at 3rd level; Sleet Storm at 5th level; Ice Storm at 7th level; and Cone of Cold at 9th level.</content>
   <content contentuid="hc4166e3bg3c8fgd921g84f9g8a343922a258" version="1">Circle of the Land Spells: Temperate Land</content>
-  <content contentuid="h53adaf69g02c4gd6a7ge1ddg668563523831" version="3">If you choose Temperate Land, you have Misty Step, Shocking Grasp, and Sleep prepared at 3rd level; Lightning Bolt at 5th level; Freedom of Movement at 7th level; and Greater Restoration at 9th level.</content>
+  <content contentuid="h53adaf69g02c4gd6a7ge1ddg668563523831" version="3">If you choose Temperate Land, you have Misty Step, &lt;LSTag Type="Spell" Tooltip="Target_ShockingGrasp"&gt;Shocking Grasp&lt;/LSTag&gt;, and Sleep prepared at 3rd level; Lightning Bolt at 5th level; Freedom of Movement at 7th level; and Greater Restoration at 9th level.</content>
   <content contentuid="h4c72b567g1ff6gde9ag626fg50843dbe309d" version="1">Circle of the Land Spells: Tropical Land</content>
   <content contentuid="hdd145debg872fgb1b1gc2f0g1c799a4601c4" version="1">If you choose Tropical Land, you have Acid Splash, Ray of Sickness, and Web prepared at 3rd level; Stinking Cloud at 5th level; Polymorph at 7th level; and Insect Plague at 9th level.</content>
   <content contentuid="h2fad506dgc3b4g8cf6g2268g89dd01b7b7be" version="1">Circle of the Land Spells: Arid Land</content>
@@ -1752,7 +1752,7 @@ If you choose Tropical Land, you have Acid Splash, Ray of Sickness, and Web prep
   <content contentuid="h58de7593g077bg934ag945fg4fe25fcdc09e" version="1">Circle of the Land Spells: Polar Land</content>
   <content contentuid="ha94194efgfa4agc8ddgfe31g0bc3f36c48a3" version="1">If you choose Polar Land, you have Fog Cloud, Hold Person, and Ray of Frost prepared at 3rd level; Sleet Storm at 5th level; Ice Storm at 7th level; and Cone of Cold at 9th level.</content>
   <content contentuid="h088b6f4dg6df4g191egb507g382423e458d7" version="1">Circle of the Land Spells: Temperate Land</content>
-  <content contentuid="h317cdc52gc540g98dagc75eg4b43a1c01018" version="2">If you choose Temperate Land, you have Misty Step, Shocking Grasp, and Sleep prepared at 3rd level; Lightning Bolt at 5th level; Freedom of Movement at 7th level; and Greater Restoration at 9th level.</content>
+  <content contentuid="h317cdc52gc540g98dagc75eg4b43a1c01018" version="2">If you choose Temperate Land, you have Misty Step, &lt;LSTag Type="Spell" Tooltip="Target_ShockingGrasp"&gt;Shocking Grasp&lt;/LSTag&gt;, and Sleep prepared at 3rd level; Lightning Bolt at 5th level; Freedom of Movement at 7th level; and Greater Restoration at 9th level.</content>
   <content contentuid="hb15d992cg437fg17e9g455bg7ba99f72dc7c" version="1">Circle of the Land Spells: Tropical Land</content>
   <content contentuid="hf78b7f33g6aa9g43f9g5859ga51f9e7facde" version="1">If you choose Tropical Land, you have Acid Splash, Ray of Sickness, and Web prepared at 3rd level; Stinking Cloud at 5th level; Polymorph at 7th level; and Insect Plague at 9th level.</content>
   <content contentuid="h59bddf9bg3094g2868gce0dgb0fbfbb3fdd4" version="1">Elemental Fury</content>
@@ -1840,13 +1840,13 @@ When you use an bonus action that expends a Focus Point, you can use this featur
   <content contentuid="h32916177g482ag7227g21aagbd4d6aed7f71" version="1">Hand of Healing</content>
   <content contentuid="h0fc86f08g49ceg3decg4adfg5398a052f261" version="1">As a Magic action, you can expend 1 Focus Point to touch a creature and restore a number of Hit Points equal to a roll of your Martial Arts die plus your Wisdom modifier.</content>
   <content contentuid="hb7d53c92gd795g4719g0be5g78a9b3fa1a4a" version="1">Level 3: Implements of Mercy</content>
-  <content contentuid="h0e2f0dfaga02cg9ad3g9586ga7ad2ece81cf" version="2">You gain proficiency in the Insight and Medicine skills. You can brew two alchemical solutions instead of one when combining extracts, if you succeed a &lt;LSTag Tooltip="DifficultyClass"&gt;DC&lt;/LSTag&gt; 15 Medicine &lt;LSTag Tooltip="AbilityCheck"&gt;Check&lt;/LSTag&gt;.</content>
+  <content contentuid="h0e2f0dfaga02cg9ad3g9586ga7ad2ece81cf" version="2">You gain proficiency in the &lt;LSTag Type="Skills" Tooltip="Insight"&gt;Insight&lt;/LSTag&gt; and &lt;LSTag Type="Skills" Tooltip="Medicine"&gt;Medicine&lt;/LSTag&gt; skills. You can brew two alchemical solutions instead of one when combining extracts, if you succeed a &lt;LSTag Tooltip="DifficultyClass"&gt;DC&lt;/LSTag&gt; 15 Medicine &lt;LSTag Tooltip="AbilityCheck"&gt;Check&lt;/LSTag&gt;.</content>
   <content contentuid="hf114f234gb61fg2c9cg3fbeg05b349dd435f" version="1">Level 6: Physician’s Touch</content>
   <content contentuid="h02367640g69e6gdb06g9a72g6354c8a4ccb6" version="2">Hand of Harm. When you use Hand of Harm on a creature, you can also give that creature the Poisoned condition until the end of your next turn.
 
-Hand of Healing. When you use Hand of Healing, you can also end the following conditions on the creature you heal: Blinded, Disease, Paralyzed, Poisoned.</content>
+&lt;LSTag Type="Spell" Tooltip="Target_HandOfHealing"&gt;Hand of Healing&lt;/LSTag&gt;. When you use Hand of Healing, you can also end the following conditions on the creature you heal: &lt;LSTag Type="Status" Tooltip="BLINDED"&gt;Blinded&lt;/LSTag&gt;, Disease, Paralyzed, Poisoned.</content>
   <content contentuid="h5e476a49g95c8g6d46g4a14g10e6a16853c0" version="1">Level 11: Flurry of Healing and Harm</content>
-  <content contentuid="hfb72e3c9g9b45g5b84g8517gffe9d7e74d19" version="1">You can use Flurry of Healing and Flurry of Harm.
+  <content contentuid="hfb72e3c9g9b45g5b84g8517gffe9d7e74d19" version="1">You can use &lt;LSTag Type="Spell" Tooltip="Target_FlurryOfHealing"&gt;Flurry of Healing&lt;/LSTag&gt; and &lt;LSTag Type="Spell" Tooltip="Target_FlurryOfHarm"&gt;Flurry of Harm&lt;/LSTag&gt;.
 
 You can use these benefits a total number of times equal to your Wisdom modifier (minimum of once). You regain all expended uses when you finish a Long Rest.</content>
   <content contentuid="h71d21302ge040g032cg8f4egbd6bca2cfd63" version="1">Flurry of Healing and Harm</content>
@@ -1861,13 +1861,13 @@ Inspire others to strive for glory.</content>
   <content contentuid="h1f4761f8g70f7ge58fg4098g3ada7c0d7a24" version="1">Level 3: Inspiring Glory</content>
   <content contentuid="h94d2b863gce81ge85ag20a9gd351c1d2fbe8" version="2">You can expend one use of your Channel Oath and distribute Temporary Hit Points to creatures of your choice within 30 feet of yourself, which can include you. The total number of Temporary Hit Points equals 2d8 plus your Paladin level, divided among the chosen creatures however you like.</content>
   <content contentuid="h03040e0bgc3c2g707bg30dcgcf793eb4b7da" version="1">Level 3: Peerless Athlete</content>
-  <content contentuid="h7b9c5b5dg52ddg7d07gf72dgc579b62da603" version="1">You have Advantage on Strength (Athletics) and Dexterity (Acrobatics) checks, and the distance of your Long and High Jumps increases by 10 feet (this extra distance costs movement as normal).</content>
+  <content contentuid="h7b9c5b5dg52ddg7d07gf72dgc579b62da603" version="1">You have Advantage on Strength (&lt;LSTag Type="Skills" Tooltip="Athletics"&gt;Athletics&lt;/LSTag&gt;) and Dexterity (&lt;LSTag Type="Skills" Tooltip="Acrobatics"&gt;Acrobatics&lt;/LSTag&gt;) checks, and the distance of your Long and High Jumps increases by 10 feet (this extra distance costs movement as normal).</content>
   <content contentuid="hadc15c48g3bdeg8e40g44fagefe0290db6ee" version="1">Level 7: Aura of Alacrity</content>
   <content contentuid="h4b966c82g6ac4g74b4g1befg09e4bfb45f98" version="1">Your Speed increases by 10 feet.
 
 In addition, whenever an ally enters your Aura of Protection for the first time on a turn or starts their turn there, the ally’s Speed increases by 10 feet until the end of their next turn.</content>
   <content contentuid="h39f392e7g879agff67g5eafg1fbe11db0e2a" version="1">Level 3: Oath of Glory Spells</content>
-  <content contentuid="hc41356d2g2208g0d0fg0023g8a9c6958aaac" version="1">The magic of your oath ensures that you always have certain spells ready. When you reach the Paladin levels specified in the Oath of Glory Spells table, you thereafter always have the following spells prepared: at 3rd level, Guiding Bolt and Heroism; at 5th level, Enhance Ability and Magic Weapon; and at 9th level, Haste and Protection from Energy.
+  <content contentuid="hc41356d2g2208g0d0fg0023g8a9c6958aaac" version="1">The magic of your oath ensures that you always have certain spells ready. When you reach the Paladin levels specified in the Oath of Glory Spells table, you thereafter always have the following spells prepared: at 3rd level, Guiding Bolt and Heroism; at 5th level, Enhance Ability and Magic Weapon; and at 9th level, &lt;LSTag Type="Spell" Tooltip="Target_Haste"&gt;Haste&lt;/LSTag&gt; and Protection from Energy.
 </content>
   <content contentuid="he69c1c77gfc97gb4e2g7877gb843a6c497b6" version="1">Inspiring Glory</content>
   <content contentuid="h46a88a7bg99ddgbfe4gc4aeg5843b027814d" version="2">You can expend one use of your Channel Oath and distribute Temporary Hit Points to creatures of your choice within 30 feet of yourself, which can include you. The total number of Temporary Hit Points equals 2d8 plus your Paladin level, divided among the chosen creatures however you like.</content>
@@ -1900,7 +1900,7 @@ You regain one of your expended Psionic Energy Dice when you finish a Short Rest
   <content contentuid="h3580697bg942bgc735g6a43g973225efaf2b" version="1">Level 3: Homing Strikes</content>
   <content contentuid="h9469e0a4gb203g618fg7964ge5af1758af45" version="2">If you make an attack roll with your Psychic Blade and miss the target, you can roll one Psionic Energy Die and add the number rolled to the attack roll.</content>
   <content contentuid="h688284efg92e3g531egd411g61df3c36b276" version="1">Level 9: Psychic Veil</content>
-  <content contentuid="h9446d065gc473g7595g3b13gfb953f314f52" version="2">You can weave a veil of psychic static to mask yourself. As a Magic action, you gain the Invisible condition for 1 hour. This invisibility ends early immediately after you deal damage to a creature or you force a creature to make a saving throw.</content>
+  <content contentuid="h9446d065gc473g7595g3b13gfb953f314f52" version="2">You can weave a veil of psychic static to mask yourself. As a Magic action, you gain the &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt; condition for 1 hour. This invisibility ends early immediately after you deal damage to a creature or you force a creature to make a saving throw.</content>
   <content contentuid="h601e5866g9f98g634egeeacg4867d033d389" version="1">If you make an attack roll with your Psychic Blade and miss the target, you can roll one Psionic Energy Die and add the number rolled to the attack roll.</content>
   <content contentuid="h71aac9ecg0f80gd235g2f2agef4ffc97d6a4" version="1">Homing Strikes</content>
   <content contentuid="he29c5d51gec42gc381gbc4bg435221bc0568" version="1">Psychic Teleportation</content>
@@ -1910,7 +1910,7 @@ You regain one of your expended Psionic Energy Dice when you finish a Short Rest
 
 While wielding a dagger, shortsword, or scimitar, you can change the weapon’s damage type to Psychic and give it the &lt;LSTag Tooltip="Thrown"&gt;Thrown&lt;/LSTag&gt; property.</content>
   <content contentuid="hd00572e3g8539gf0b2ga34cg5f825b6672dd" version="1">Psychic Veil</content>
-  <content contentuid="hff09f5d5ga364g24e6ga7a8g00dbb675ea16" version="1">You can weave a veil of psychic static to mask yourself. As a Magic action, you gain the Invisible condition for 1 hour. This invisibility ends early immediately after you deal damage to a creature or you force a creature to make a saving throw.</content>
+  <content contentuid="hff09f5d5ga364g24e6ga7a8g00dbb675ea16" version="1">You can weave a veil of psychic static to mask yourself. As a Magic action, you gain the &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt; condition for 1 hour. This invisibility ends early immediately after you deal damage to a creature or you force a creature to make a saving throw.</content>
   <content contentuid="hae54a45dgb7adgc45dg59cag1d1146c839dc" version="1">Psychic Blades</content>
   <content contentuid="h47c75c00gad45gcc7agd1fbg3816f09eaa53" version="2">Deals Psychic damage and has the &lt;LSTag Tooltip="Thrown"&gt;Thrown&lt;/LSTag&gt; property.
 
@@ -1980,7 +1980,7 @@ If you do cast a Sorcerer spell with a spell slot before you finish a Long Rest,
   <content contentuid="hb352a2d9g2b29g035bgcae6ge065a7ef8fe8" version="1">Level 3: Archfey Spells</content>
   <content contentuid="hd7701b33g6b2fg2417gbd20g2eb61af61f00" version="1">The magic of your patron ensures that you always have certain spells ready. Upon reaching specific Warlock levels, you gain additional spells as shown in the Archfey Spells table, and you always have those spells prepared thereafter. 
 
-At 3rd level, you gain Calm Emotions, Faerie Fire, Misty Step, Phantasmal Force, and Sleep. At 5th level, you gain Blink and Plant Growth. At 7th level, you gain Dominate Beast and Greater Invisibility. At 9th level, you gain Dominate Person and Seeming.</content>
+At 3rd level, you gain Calm Emotions, Faerie Fire, Misty Step, Phantasmal Force, and Sleep. At 5th level, you gain Blink and Plant Growth. At 7th level, you gain Dominate Beast and &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;Greater Invisibility&lt;/LSTag&gt;. At 9th level, you gain Dominate Person and Seeming.</content>
   <content contentuid="h46177747g5549g5775gad78g65fbcd1fc3a6" version="1">Level 3: Steps of the Fey</content>
   <content contentuid="h8adb922fgacb1g0f7fg68fagec7157198cc9" version="4">Your patron grants you the ability to move between the boundaries of the planes. You can cast Misty Step without expending a spell slot a number of times equal to your Charisma modifier (minimum of once), and you regain all expended uses when you finish a Long Rest.
 
@@ -1994,7 +1994,7 @@ Taunting Step. Creatures within 10 feet of the space you left must succeed on a 
 
 In addition, the following effects are now among your Steps of the Fey options.
 
-Disappearing Step. You have the Invisible condition until the start of your next turn or until immediately after you make an attack roll, deal damage, or cast a spell.
+Disappearing Step. You have the &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt; condition until the start of your next turn or until immediately after you make an attack roll, deal damage, or cast a spell.
 
 Dreadful Step. Creatures within 10 feet of the space you left or the space you appear in (your choice) must succeed on a Wisdom saving throw against your spell save DC or take 2d10 Psychic damage.</content>
   <content contentuid="h308c54bfg7af4ga905g67ffg8c054f26beab" version="1">Level 10: Beguiling Defenses</content>
@@ -2009,7 +2009,7 @@ In addition, immediately after a creature you can see hits you with an attack ro
   <content contentuid="h444275c2g565cg45a9gdfbdg183d47facddb" version="1">Creatures within 10 feet of the space you left must succeed on a Wisdom saving throw against your spell save DC or have Disadvantage on attack rolls against creatures other than you until the start of your next turn.</content>
   <content contentuid="ha4fa9aabgb628g9f25g60a6g8ef2736d6490" version="1">Taunting Step</content>
   <content contentuid="h81e4c4fcge764ge0d3g745cgea094c73c3cc" version="1">Disappearing Step</content>
-  <content contentuid="h7bd1bb01g45ccge8e6g5722g3072b6b0bf23" version="1">You have the Invisible condition until the start of your next turn or until immediately after you make an attack roll, deal damage, or cast a spell.</content>
+  <content contentuid="h7bd1bb01g45ccge8e6g5722g3072b6b0bf23" version="1">You have the &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt; condition until the start of your next turn or until immediately after you make an attack roll, deal damage, or cast a spell.</content>
   <content contentuid="h6153da66gbfbeg1d0dgec8agfbc6490c04f5" version="1">Creatures within 10 feet of the space you left or the space you appear in (your choice) must succeed on a Wisdom saving throw against your spell save DC or take 2d10 Psychic damage.</content>
   <content contentuid="h417a65f0geb7ag67d8g7e8eg6c0ea35a7357" version="1">Dreadful Step</content>
   <content contentuid="h30f638b6g1b28g3f1fgb8cbge2ee1097d9ae" version="1">Dreadful Step</content>
@@ -2048,19 +2048,19 @@ As a Bonus Action, you can heal yourself or one creature you can see within 60 f
   <content contentuid="h792db4a7g911aga472g7377ge4c0224fc65a" version="1">When you reach character level 5, you can channel draconic magic to give yourself temporary flight. As a Bonus Action, you sprout spectral wings on your back that last for 10 minutes or until you retract the wings (no action required) or have the Incapacitated condition. During that time, you have a Fly Speed equal to your Speed. Your wings appear to be made of the same energy as your Breath Weapon. Once you use this trait, you can’t use it again until you finish a Long Rest.</content>
   <content contentuid="h24e5006bg1411g65a8g188eg3cd830a72dbf" version="1">You have Advantage on saving throws you make to avoid or end the Charmed condition.</content>
   <content contentuid="h71c75422gccadg03e2gacb5g05a65c1f8188" version="1">Resourceful</content>
-  <content contentuid="hd06d9d97g3639gb022g0e2eg25f5ab8ca49e" version="1">You gain Heroic Inspiration whenever you finish a Long Rest. If you have Heroic Inspiration, you can expend it to reroll any die immediately after rolling it.</content>
+  <content contentuid="hd06d9d97g3639gb022g0e2eg25f5ab8ca49e" version="1">You gain &lt;LSTag Type="Status" Tooltip="HEROIC_INSPIRATION_TEMP"&gt;Heroic Inspiration&lt;/LSTag&gt; whenever you finish a Long Rest. If you have Heroic Inspiration, you can expend it to reroll any die immediately after rolling it.</content>
   <content contentuid="h229c085dgef48gd2b7ga8b1g7ed5f027b17a" version="2">Heroic Inspiration: Reroll with Advantage (Attack Roll)</content>
   <content contentuid="hac21fc5bg9d5cg705egede3g663945541420" version="2">Gain &lt;LSTag Tooltip="Advantage"&gt;Advantage&lt;/LSTag&gt; on your &lt;LSTag Tooltip="AttackRoll"&gt;Attack Roll&lt;/LSTag&gt;.</content>
   <content contentuid="hd3b6f9bdga558g9498gb53egf8707edcbf80" version="1">Heroic Inspiration</content>
   <content contentuid="h43bcb1b9g7661gd847g5c69g16cf92019e88" version="1">If you have Heroic Inspiration, you can expend it to reroll any die immediately after rolling it.</content>
   <content contentuid="h046f2142g4017g500fg9e5cg829c2bf7808e" version="1">Adrenaline Rush</content>
-  <content contentuid="h8306332bg4a42gfdaag8e32g05d5b2d0a005" version="1">You can take the Dash action as a Bonus Action. When you do so, you gain a number of Temporary Hit Points equal to your Proficiency Bonus.
+  <content contentuid="h8306332bg4a42gfdaag8e32g05d5b2d0a005" version="1">You can take the &lt;LSTag Type="Spell" Tooltip="Shout_Dash"&gt;Dash&lt;/LSTag&gt; action as a Bonus Action. When you do so, you gain a number of Temporary Hit Points equal to your Proficiency Bonus.
 
 You can use this trait a number of times equal to your Proficiency Bonus, and you regain all expended uses when you finish a Short or Long Rest.</content>
   <content contentuid="hff787feeg6644g2b33g0be6g8fd958b702b8" version="1">Adrenaline Rush</content>
   <content contentuid="ha554c47egeb81g75ccgd39cg1311b5e29042" version="1">You gain a number of Temporary Hit Points equal to your Proficiency Bonus.</content>
   <content contentuid="hf861876fg4ca8gf9c0g6492g1bb8a0a92ebb" version="1">Adrenaline Rush</content>
-  <content contentuid="he98b170fg0b2bg4502g8a0fg3f8f765d62aa" version="1">You can take the Dash action as a Bonus Action. When you do so, you gain a number of Temporary Hit Points equal to your Proficiency Bonus.</content>
+  <content contentuid="he98b170fg0b2bg4502g8a0fg3f8f765d62aa" version="1">You can take the &lt;LSTag Type="Spell" Tooltip="Shout_Dash"&gt;Dash&lt;/LSTag&gt; action as a Bonus Action. When you do so, you gain a number of Temporary Hit Points equal to your Proficiency Bonus.</content>
   <content contentuid="hebe3b6e0g1e21g24c8g8ce2gd9aaa9e5dde4" version="1">High Elf Cantrip</content>
   <content contentuid="h9adf7805gb424g309ag6e71g53eca41cd8d5" version="1">You may change your cantrip by selecting another one from the Wizard spell list below. This cantrip doesn't use &lt;LSTag Tooltip="SpellSlot"&gt;spell slots&lt;/LSTag&gt; and can be cast at will.</content>
   <content contentuid="h9b697d45g3dd3gf371g2860g7b65899c8fc7" version="1">Resistance</content>
@@ -2122,7 +2122,7 @@ Once you use this feature, you can’t use it again until you finish a Short or 
   <content contentuid="h70590391g8a16g000bg3b85gb758c7f01fc9" version="1">Draconic Resilience: Hit Points</content>
   <content contentuid="hd08ff7b2gae53g91e3g1c43g984682ce4af8" version="1">Your &lt;LSTag Tooltip="HitPoints"&gt;hit point&lt;/LSTag&gt; maximum increases by 1 for each Sorcerer level.</content>
   <content contentuid="h425e3ae9ge949g55bbg3aecg26401432f816" version="1">When you inspire an ally using &lt;LSTag Type="Spell" Tooltip="Target_BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt;, you gain [1], equal to your Bard level.</content>
-  <content contentuid="h4b3bbd82gcfdegf0b2g8843g1b27f8c2a5b8" version="1">When you inspire an ally using &lt;LSTag Type="Spell" Tooltip="Target_BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt;, they also regain [1], equal to the result of your Bardic Inspiration die.</content>
+  <content contentuid="h4b3bbd82gcfdegf0b2g8843g1b27f8c2a5b8" version="1">When you inspire an ally using &lt;LSTag Type="Spell" Tooltip="Target_BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt;, they also regain [1], equal to the result of your &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die.</content>
   <content contentuid="h67022386g828fg30bag1c0cg215dae9c4f39" version="3">Undead creatures that hit the wearer take [1]. Beasts that hit the wearer become &lt;LSTag Type="Status" Tooltip="CHARMED"&gt;Charmed&lt;/LSTag&gt;.</content>
   <content contentuid="hca956f6fg7446gdf7fg60bag36e7853ca0c9" version="1">The spell ends if you drop to 0 Hit Points. It also ends if the spell is cast again on either of the connected creatures. The spell remains in effect only while you and the target are within 60 feet of each other.</content>
   <content contentuid="hd0f268c5ga792g388ag89beg27993a801b4e" version="1">The spell ends if you drop to 0 Hit Points. It also ends if the spell is cast again on either of the connected creatures. The spell remains in effect only while you and the target are within 60 feet of each other.</content>
@@ -2135,15 +2135,15 @@ Once you use this feature, you can’t use it again until you finish a Short or 
   <content contentuid="h90381d36g6a66g678dgc622g940db553e2a2" version="1">Feat: Fey Touched</content>
   <content contentuid="hfaef3824g8845gb735gf4dfgd86da7822941" version="1">Choose one 1st-level spell from the Divination or Enchantment school. You always have that spell and Misty Step prepared. You also gain one 1st-level spell slot and one 2nd-level spell slot.</content>
   <content contentuid="h373ea885g4542g96b0g1626g9afe46582637" version="1">Feat: Shadow Touched</content>
-  <content contentuid="h0c8f8629gcdb5g21d2g6ba3g68301d16a9ea" version="1">Choose one 1st-level spell from the Illusion or Necromancy school. You always have that spell and Invisibility prepared. You also gain one 1st-level spell slot and one 2nd-level spell slot.</content>
+  <content contentuid="h0c8f8629gcdb5g21d2g6ba3g68301d16a9ea" version="1">Choose one 1st-level spell from the Illusion or Necromancy school. You always have that spell and &lt;LSTag Type="Spell" Tooltip="Target_Invisibility"&gt;Invisibility&lt;/LSTag&gt; prepared. You also gain one 1st-level spell slot and one 2nd-level spell slot.</content>
   <content contentuid="h3e078741g3071gaa98ga931g651f9cac58d8" version="1">Fey Touched</content>
   <content contentuid="h9dd19073g7262gabe8g561dga56e7269712b" version="1">Choose one 1st-level spell from the Divination or Enchantment school. You always have that spell and Misty Step prepared. You also gain one 1st-level spell slot and one 2nd-level spell slot.</content>
   <content contentuid="h45c39024gdfe0g1fbeg74d2g67115110174b" version="1">Shadow Touched</content>
-  <content contentuid="hbd7f0193ge427g3d75gc0adgfdba8212fb8b" version="1">Choose one 1st-level spell from the Illusion or Necromancy school. You always have that spell and Invisibility prepared. You also gain one 1st-level spell slot and one 2nd-level spell slot.</content>
+  <content contentuid="hbd7f0193ge427g3d75gc0adgfdba8212fb8b" version="1">Choose one 1st-level spell from the Illusion or Necromancy school. You always have that spell and &lt;LSTag Type="Spell" Tooltip="Target_Invisibility"&gt;Invisibility&lt;/LSTag&gt; prepared. You also gain one 1st-level spell slot and one 2nd-level spell slot.</content>
   <content contentuid="hc8800178g3eabg44b8g93a8g0d839444e75f" version="1">Fey Touched: Animal Friendship</content>
   <content contentuid="hdc7ba426ge98dg4316g94c9g943ef2f71ef1" version="1">Fey Magic: Animal Friendship</content>
   <content contentuid="hbe627f0bg708bg47b4gba79gf882af49eaca" version="1">Fey Touched: Bane</content>
-  <content contentuid="hf80f1d43g98c1g4673gb72fgdffcfee338d2" version="1">Fey Magic: Bane</content>
+  <content contentuid="hf80f1d43g98c1g4673gb72fgdffcfee338d2" version="1">Fey Magic: &lt;LSTag Type="Spell" Tooltip="Target_Bane"&gt;Bane&lt;/LSTag&gt;</content>
   <content contentuid="h8b1e18f1g4012g4e69gb0a3g8425b829678e" version="1">Fey Touched: Bless</content>
   <content contentuid="h87ead348ga862g462agbdd2g7079cbc25ffe" version="1">Fey Magic: Bless</content>
   <content contentuid="h184c59beg8cefg4990ga08bg9f97071dab68" version="1">Fey Touched: Charm Person</content>
@@ -2308,11 +2308,11 @@ When you land a &lt;LSTag Tooltip="CriticalHit"&gt;Critical Hit&lt;/LSTag&gt; wi
 You are uncommonly nimble for your race.
 
 Increase your walking speed by 5 feet.
-You gain proficiency in the Acrobatics or Athletics skill (your choice).
+You gain proficiency in the &lt;LSTag Type="Skills" Tooltip="Acrobatics"&gt;Acrobatics&lt;/LSTag&gt; or &lt;LSTag Type="Skills" Tooltip="Athletics"&gt;Athletics&lt;/LSTag&gt; skill (your choice).
 You have advantage on any Strength (Athletics) or Dexterity (Acrobatics) check you make to escape from being restrained.</content>
   <content contentuid="h1dbe3f90g3d47gc1cagd861g317e83891368" version="1">Feat: Squat Nimbleness</content>
   <content contentuid="h40770da0g7507g2a0eg4c0dgbab4e296bc1d" version="1">Increase your walking speed by 5 feet.
-You gain proficiency in the Acrobatics or Athletics skill (your choice).
+You gain proficiency in the &lt;LSTag Type="Skills" Tooltip="Acrobatics"&gt;Acrobatics&lt;/LSTag&gt; or &lt;LSTag Type="Skills" Tooltip="Athletics"&gt;Athletics&lt;/LSTag&gt; skill (your choice).
 You have advantage on any Strength (Athletics) or Dexterity (Acrobatics) check you make to escape from being restrained.</content>
   <content contentuid="h35050c0eg78deg45e0g4f6fg8c9ef353a3a9" version="1">Eldritch Adept</content>
   <content contentuid="h12be78fcg4014gf53egdd87g0988b8262c10" version="1">Studying occult lore, you learn one Eldritch Invocation option of your choice from the warlock class. If the invocation has a prerequisite of any kind, you can choose that invocation only if you’re a warlock who meets the prerequisite.</content>
@@ -2328,7 +2328,7 @@ You gain 2 sorcery points to spend on Metamagic (these points are added to any s
   <content contentuid="h0d2663e7ga6eag1b82g8e4bg4351babc6226" version="2">Origin Feat: Cult of the Dragon Initiate</content>
   <content contentuid="h5648b3eag0325g46d8g5cd1g0463117aab6a" version="4">Dragon's Terror. You can take a Magic action to instill terror in a creature you can see within 30 feet of yourself. The target must succeed on a Wisdom saving throw or have the Frightened condition until the end of your next turn.
 
-Inspired by Fear. When you cause a creature to gain the Frightened condition and you are the source of its fear, you gain Heroic Inspiration. Once you use this benefit, you can’t use it again until you finish a Short or Long Rest.</content>
+Inspired by Fear. When you cause a creature to gain the Frightened condition and you are the source of its fear, you gain &lt;LSTag Type="Status" Tooltip="HEROIC_INSPIRATION_TEMP"&gt;Heroic Inspiration&lt;/LSTag&gt;. Once you use this benefit, you can’t use it again until you finish a Short or Long Rest.</content>
   <content contentuid="hee930e39g569egbf9bgf8d4gce1dcff3b5cd" version="1">Heroic Inspiration</content>
   <content contentuid="hd9193a10g8e78g28bagc22eg90d1be20c4d7" version="1">You gain Heroic Inspiration whenever you finish a Long Rest. If you have Heroic Inspiration, you can expend it to reroll any die immediately after rolling it.</content>
   <content contentuid="h07d286f6gc9ceg419dgb13dg7480d479c810" version="3">Forgotten Realms: Heroes of Faerûn: Origin Feats</content>
@@ -2358,21 +2358,21 @@ Distracting Melody. When you take the Distract action to assist an ally’s atta
 Reassert Honor. When an enemy you can see deals damage to you, you have Advantage on your next attack roll against that enemy before the end of your next turn.</content>
   <content contentuid="h32098dd3g6f72g92eag10cbg76fc72c357c4" version="2">Origin Feat: Harper Agent</content>
   <content contentuid="hb61939ecg2158g4da3gadf9g7aace51ea588" version="2">Origin Feat: Lords’ Alliance Agent</content>
-  <content contentuid="h6c140161ge881g7f60g8a89gbf47719d5f66" version="1">Inspiring Strike. Once per turn when you score a Critical Hit against a creature, you gain Heroic Inspiration.
+  <content contentuid="h6c140161ge881g7f60g8a89gbf47719d5f66" version="1">Inspiring Strike. Once per turn when you score a Critical Hit against a creature, you gain &lt;LSTag Type="Status" Tooltip="HEROIC_INSPIRATION_TEMP"&gt;Heroic Inspiration&lt;/LSTag&gt;.
 
 Reassert Honor. When an enemy you can see deals damage to you, you have Advantage on your next attack roll against that enemy before the end of your next turn.</content>
   <content contentuid="he4b058a0g2cdbgba7agf3cfg71fa968bbd61" version="1">Lords' Alliance Agent</content>
   <content contentuid="h9fa0d3deg53aag92d4g5ba5g0185574f2cd7" version="1">Lords' Alliance Agent</content>
-  <content contentuid="hf2f81938g5ca0gb0eega680g3ec73dd11dd8" version="1">Entreat. You gain proficiency in Persuasion.
+  <content contentuid="hf2f81938g5ca0gb0eega680g3ec73dd11dd8" version="1">Entreat. You gain proficiency in &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Persuasion&lt;/LSTag&gt;.
 
 Rallying Cry. You can choose a number of creatures equal to your Proficiency Bonus that you can see within 30 feet of yourself. Those creatures gain Heroic Inspiration. Once you use this benefit, you can’t do so again until you finish a Long Rest.</content>
   <content contentuid="ha118d2a1gbbb4gcfd3g1676g37accfee78d4" version="1">Purple Dragon Rook</content>
   <content contentuid="h460435aaga1b3g7abbg15e5g3ca6334b18ec" version="2">Origin Feat: Purple Dragon Rook</content>
-  <content contentuid="h76a090b6gcb17g375dg822fgdf79bae4b00a" version="1">Entreat. You gain proficiency in Persuasion.
+  <content contentuid="h76a090b6gcb17g375dg822fgdf79bae4b00a" version="1">Entreat. You gain proficiency in &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Persuasion&lt;/LSTag&gt;.
 
-Rallying Cry. You can choose a number of creatures equal to your Proficiency Bonus that you can see within 30 feet of yourself. Those creatures gain Heroic Inspiration. Once you use this benefit, you can’t do so again until you finish a Long Rest.</content>
+Rallying Cry. You can choose a number of creatures equal to your Proficiency Bonus that you can see within 30 feet of yourself. Those creatures gain &lt;LSTag Type="Status" Tooltip="HEROIC_INSPIRATION_TEMP"&gt;Heroic Inspiration&lt;/LSTag&gt;. Once you use this benefit, you can’t do so again until you finish a Long Rest.</content>
   <content contentuid="hbd9d344cgf966g1f1ag6c2ag2c71696c22ea" version="1">Rallying Cry</content>
-  <content contentuid="h5084d2fcg51fdgc84dg02cfg9b81d8b498cd" version="1">You can choose a number of creatures equal to your Proficiency Bonus that you can see within 30 feet of yourself. Those creatures gain Heroic Inspiration.</content>
+  <content contentuid="h5084d2fcg51fdgc84dg02cfg9b81d8b498cd" version="1">You can choose a number of creatures equal to your Proficiency Bonus that you can see within 30 feet of yourself. Those creatures gain &lt;LSTag Type="Status" Tooltip="HEROIC_INSPIRATION_TEMP"&gt;Heroic Inspiration&lt;/LSTag&gt;.</content>
   <content contentuid="h37427b79gd475g84c7g03e9g66f300db641b" version="1">Spellfire Spark</content>
   <content contentuid="hdefd07e9gac32g3227g03d6g27116876f808" version="1">Magic Absorption. Once per turn, when you take damage from a spell or magical effect, you reduce the total damage taken by 1d4.
 
@@ -2514,7 +2514,7 @@ Mythals are sources of great magical power that can alter the Weave or even the 
 
 You’ve pledged your life to the safety of Cormyr and sought admission to that realm’s order of elite warriors: the Purple Dragon Knights. But before you have the chance to join the ranks officially, you must first serve as a knight’s squire. You’ve found a liege willing to take you on and teach you the order’s ways. Will you uphold the Purple Dragon Knights’ ideals of glory, honor, and strength and prove yourself worthy of knighthood?
 
-Entreat. You gain proficiency in Persuasion.
+Entreat. You gain proficiency in &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Persuasion&lt;/LSTag&gt;.
 
 Rallying Cry. You can choose a number of creatures equal to your Proficiency Bonus that you can see within 30 feet of yourself. Those creatures gain Heroic Inspiration. Once you use this benefit, you can’t do so again until you finish a Long Rest.</content>
   <content contentuid="h625450b8g42bdgc0cag5d94g932492b64ed0" version="1">Rashemi Wanderer</content>
@@ -2712,13 +2712,13 @@ You can deal extra damage to a target when you deal damage to it with an attack 
   <content contentuid="h9223661bgace2gba01g10dcgfc1ea09add5a" version="1">Level 3: Moon's Inspiration</content>
   <content contentuid="he8fec49dgf4c3g6a97g790bg3a7f505054bf" version="1">The primal and ever-changing power of the moon flows through you, granting you the following benefits.
 
-Inspired Eclipse. When you take a Bonus Action to give a creature a Bardic Inspiration die, you can have the Invisible condition and teleport up to 30 feet to an unoccupied space you can see as part of that Bonus Action. This invisibility lasts until the start of your next turn and ends early immediately after you make an attack roll, deal damage, or cast a spell.
+Inspired Eclipse. When you take a Bonus Action to give a creature a &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die, you can have the &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt; condition and teleport up to 30 feet to an unoccupied space you can see as part of that Bonus Action. This invisibility lasts until the start of your next turn and ends early immediately after you make an attack roll, deal damage, or cast a spell.
 
 Lunar Vitality. Once per turn when you restore Hit Points to a creature with a spell, you can expend a Bardic Inspiration die and increase the amount of Hit Points restored by a number equal to a roll of the Bardic Inspiration die. The creature’s Speed also increases by 10 feet until the end of its next turn.</content>
   <content contentuid="haca3aef8ga626gc323g22acg746bfa4a9426" version="1">Level 3: Primal Lore</content>
   <content contentuid="h16bfd443g2ac4gcdcegaa91gcadfccb20761" version="1">You learn Druidic and one cantrip from the Druid spell list. It counts as a Bard spell for you but doesn’t count against the number of cantrips you know. 
 
-Additionally, choose one of the following skills: Animal Handling, Insight, Medicine, Nature, Perception, or Survival. You have proficiency in that skill.</content>
+Additionally, choose one of the following skills: &lt;LSTag Type="Skills" Tooltip="AnimalHandling"&gt;Animal Handling&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Insight"&gt;Insight&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Medicine"&gt;Medicine&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Nature"&gt;Nature&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Perception"&gt;Perception&lt;/LSTag&gt;, or &lt;LSTag Type="Skills" Tooltip="Survival"&gt;Survival&lt;/LSTag&gt;. You have proficiency in that skill.</content>
   <content contentuid="h3911c437g16cagdddcgede4gaa0c643aec8c" version="1">Level 6: Blessings of Moonlight</content>
   <content contentuid="haa5e73d8ga7e5ge281g8b67gae695bb23d75" version="1">You always have the Moonbeam spell prepared.
 
@@ -2727,13 +2727,13 @@ While you cast Moonbeam, a creature of your choice that you can see within 60 fe
 Once you use this feature to modify a casting of Moonbeam, you can’t use it again until you finish a Long Rest.
 </content>
   <content contentuid="h4b8c5fb1g0cb0gdf42g5d1bgd60b7110c837" version="1">Inspired Eclipse</content>
-  <content contentuid="h354b3d9ag3986g5438g5c7fg5f7f7196c4c4" version="1">When you take a Bonus Action to give a creature a Bardic Inspiration die, you can have the Invisible condition and teleport up to 30 feet to an unoccupied space you can see as part of that Bonus Action. This invisibility lasts until the start of your next turn and ends early immediately after you make an attack roll, deal damage, or cast a spell.</content>
+  <content contentuid="h354b3d9ag3986g5438g5c7fg5f7f7196c4c4" version="1">When you take a Bonus Action to give a creature a &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die, you can have the &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt; condition and teleport up to 30 feet to an unoccupied space you can see as part of that Bonus Action. This invisibility lasts until the start of your next turn and ends early immediately after you make an attack roll, deal damage, or cast a spell.</content>
   <content contentuid="ha0ddac76g013eg8574g0831g4fde2e2fef92" version="1">Inspired Eclipse</content>
-  <content contentuid="h976048b3gf9c6gba32g7185g9373737f96b8" version="1">When you take a Bonus Action to give a creature a Bardic Inspiration die, you can have the Invisible condition and teleport up to 30 feet to an unoccupied space you can see as part of that Bonus Action. This invisibility lasts until the start of your next turn and ends early immediately after you make an attack roll, deal damage, or cast a spell.</content>
+  <content contentuid="h976048b3gf9c6gba32g7185g9373737f96b8" version="1">When you take a Bonus Action to give a creature a &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die, you can have the &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt; condition and teleport up to 30 feet to an unoccupied space you can see as part of that Bonus Action. This invisibility lasts until the start of your next turn and ends early immediately after you make an attack roll, deal damage, or cast a spell.</content>
   <content contentuid="h9f1b45feg3a13g4bccg4842g98f511ae2e02" version="1">Lunar Vitality</content>
   <content contentuid="h88fd7cb1g4a94g8ad2g4bf8ga268d1168276" version="1">The creature’s Speed also increases by 10 feet.</content>
   <content contentuid="h6088fb76ga8b7g5ae5gfb3eg1af90e35d769" version="1">Lunar Vitality</content>
-  <content contentuid="h81c2cbd1ge2a2g4781g89a2gf1b79723f601" version="1">Once per turn when you restore Hit Points to a creature with a spell, you can expend a Bardic Inspiration die and increase the amount of Hit Points restored by a number equal to a roll of the Bardic Inspiration die. The creature’s Speed also increases by 10 feet until the end of its next turn.</content>
+  <content contentuid="h81c2cbd1ge2a2g4781g89a2gf1b79723f601" version="1">Once per turn when you restore Hit Points to a creature with a spell, you can expend a &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die and increase the amount of Hit Points restored by a number equal to a roll of the Bardic Inspiration die. The creature’s Speed also increases by 10 feet until the end of its next turn.</content>
   <content contentuid="hc939b12eg2ee5g197bgc522ga5abc592a4b0" version="1">Lunar Vitality</content>
   <content contentuid="h97618a1dg57f7g2acfg001dg5ba785249fde" version="1">Blessings of Moonlight</content>
   <content contentuid="h13f755b1gb20cg69d9g98a6g40d319bcab11" version="1">While you cast Moonbeam, a creature of your choice that you can see within 60 feet of yourself regains 2d4 Hit Points.</content>
@@ -2742,7 +2742,7 @@ Once you use this feature to modify a casting of Moonbeam, you can’t use it ag
 
 A Banneret relies on judgment, bravery, and fidelity to the code of chivalry to guide them in defeating evildoers. A lone Banneret is a skilled warrior, but when leading a band of allies one of these warriors can transform even a poorly equipped militia into a ferocious war band.</content>
   <content contentuid="h40c5a6a5g42eagbba6g5c64g5ece9eb7fe14" version="1">Level 3: Knightly Envoy</content>
-  <content contentuid="ha6aeb659gba2ag0648g1d28g8d765621e3a9" version="1">You gain expertise in all of the following skills: Insight, Intimidation, Persuasion, and Performance.</content>
+  <content contentuid="ha6aeb659gba2ag0648g1d28g8d765621e3a9" version="1">You gain expertise in all of the following skills: &lt;LSTag Type="Skills" Tooltip="Insight"&gt;Insight&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Intimidation"&gt;Intimidation&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Persuasion&lt;/LSTag&gt;, and &lt;LSTag Type="Skills" Tooltip="Performance"&gt;Performance&lt;/LSTag&gt;.</content>
   <content contentuid="h3f223b42g605egefc2g504ag6ef36cc460ed" version="1">Level 3: Group Recovery</content>
   <content contentuid="ha8111f35ge4bag28bcg4d99g339262b0a595" version="2">When you use your Second Wind to regain Hit Points, you can choose a number of allies within a 30-foot emanation originating from you, up to a number of allies equal to your Charisma modifier. Each of those allies regains Hit Points equal to 1d10 + your Fighter level.</content>
   <content contentuid="hc240e7f1g2979geff6gfcc4g1d63a78b39bd" version="1">Level 7: Team Tactics</content>
@@ -2772,7 +2772,7 @@ Additionally, while a creature is marked by your Hunter’s Mark, it can’t tak
 
 Once you use this feature, you can’t use it again until you finish a Long Rest.</content>
   <content contentuid="hd373a822gfb21g38dfge5a8g77c001185e3a" version="1">Level 11: Chilling Retribution</content>
-  <content contentuid="hb6e753d8g25f2gee18g87d6gdda8a5857b4c" version="3">When a creature hits you with an attack roll, you can take a Reaction to force the creature to make a Wisdom saving throw against your spell save DC. On a failed save, the target has the Stunned condition for 2 turns.
+  <content contentuid="hb6e753d8g25f2gee18g87d6gdda8a5857b4c" version="3">When a creature hits you with an attack roll, you can take a Reaction to force the creature to make a Wisdom saving throw against your spell save DC. On a failed save, the target has the &lt;LSTag Type="Status" Tooltip="STUNNED"&gt;Stunned&lt;/LSTag&gt; condition for 2 turns.
 
 You can use this feature a number of times equal to your Wisdom modifier (minimum of once), and you regain all expended uses when you finish a Long Rest.</content>
   <content contentuid="hd3324082ga20dg104bg944cg8e9d750a54a5" version="1">Hunter's Rime</content>
@@ -2784,10 +2784,10 @@ You can use this feature a number of times equal to your Wisdom modifier (minimu
   <content contentuid="haf330cbag9da5g81b9gc9c4g13038dc4bc59" version="1">Fortifying Soul</content>
   <content contentuid="h1b6a7023gadf1g5468g1b86gda2cac4d8e2b" version="1">Have Advantage on saving throws to avoid or end the Frightened condition</content>
   <content contentuid="hcf64a967g8805ge99bg1ff7ga0cb9cd0764c" version="1">Chilling Retribution</content>
-  <content contentuid="hae8770acg873fg844dgedd5g825cc772d72c" version="1">When a creature hits you with an attack roll, you can take a Reaction to force the creature to make a Wisdom saving throw against your spell save DC. On a failed save, the target has the Stunned condition until the end of your next turn.</content>
+  <content contentuid="hae8770acg873fg844dgedd5g825cc772d72c" version="1">When a creature hits you with an attack roll, you can take a Reaction to force the creature to make a Wisdom saving throw against your spell save DC. On a failed save, the target has the &lt;LSTag Type="Status" Tooltip="STUNNED"&gt;Stunned&lt;/LSTag&gt; condition until the end of your next turn.</content>
   <content contentuid="h2dc72da7geb6fg6757g65b9g28c64f77f068" version="1">Chilling Retribution</content>
   <content contentuid="h4ff1d8aeg3628g34f5gd2e0gf05e758e89f6" version="1">Chilling Retribution</content>
-  <content contentuid="h7683213dgcd67g8a04g76bdg263469054d80" version="1">When a creature hits you with an attack roll, you can take a Reaction to force the creature to make a Wisdom saving throw against your spell save DC. On a failed save, the target has the Stunned condition for 2 turns.</content>
+  <content contentuid="h7683213dgcd67g8a04g76bdg263469054d80" version="1">When a creature hits you with an attack roll, you can take a Reaction to force the creature to make a Wisdom saving throw against your spell save DC. On a failed save, the target has the &lt;LSTag Type="Status" Tooltip="STUNNED"&gt;Stunned&lt;/LSTag&gt; condition for 2 turns.</content>
   <content contentuid="h6c8f835eg0910g6b96ga78bg651c0ba6cd54" version="1">Winter Walker</content>
   <content contentuid="h11ed03f2g16a9g0ee9g4b45g6c8ca4ac593d" version="1">Winter Walkers hone their craft in the bleak and frozen wilds of places like Icewind Dale. These ruthless, rimed Rangers hunt monsters that haunt arctic wastelands, eventually becoming frigid terrors themselves. Winter Walkers are well versed in the phenomena of Icewind Dale, including the latent magic of fallen Netherese cities, endemic monsters like yetis and crag cats, and the rising threat of Underdark invaders. Due to their cold pragmatism, terrifying magic, and mastery of the region, Winter Walkers are regarded with equal parts respect and fear. Ten-Towns citizens say that Winter Walkers’ frequent exposure to malignant entities gives them their fearsome powers. Many Reghed nomads, on the other hand, believe that nature spirits bestow on Winter Walkers a unique curse.</content>
   <content contentuid="hfc2052ffgc5b0gbd9agca4bg0c13d926684c" version="1">Oath of the Noble Genies</content>
@@ -2813,7 +2813,7 @@ Marid’s Surge. The target and each creature of your choice in a 10-foot Emanat
   <content contentuid="h9ef367bcg743fg6596ga14cgdc4842c967b1" version="1">Level 3: Genie's Splendor</content>
   <content contentuid="h9f395fe8g244dg8ddcgcbe0g3ee47a325f9f" version="1">When you aren’t wearing any armor, your base Armor Class equals 10 plus your Dexterity and Charisma modifiers. You can use a Shield and still gain this benefit.
 
-You also gain proficiency in one of the following skills of your choice: Acrobatics, Intimidation, Performance, or Persuasion.</content>
+You also gain proficiency in one of the following skills of your choice: &lt;LSTag Type="Skills" Tooltip="Acrobatics"&gt;Acrobatics&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Intimidation"&gt;Intimidation&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Performance"&gt;Performance&lt;/LSTag&gt;, or &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Persuasion&lt;/LSTag&gt;.</content>
   <content contentuid="h1ad2ebf2gb473g88deg2fb9gc419b2fa63cf" version="1">Level 7: Aura of Elemental Shielding</content>
   <content contentuid="h4ed8c047g25f9g2d20g185eg45a7a0f16ff5" version="1">You and your allies have Resistance to Acid, Cold, Fire, Lightning, and Thunder damage while within your Aura of Protection.</content>
   <content contentuid="h7ce47465gdfeag71dcgb0bdgeadc0c987cab" version="1">Dao’s Crush</content>
@@ -2838,14 +2838,14 @@ The Bladesong lasts for 1 minute and ends early if you have the Incapacitated co
 You can invoke the Bladesong a number of times equal to your Intelligence modifier (minimum of once), and you regain all expended uses when you finish a Long Rest. You regain one expended use when you use Arcane Recovery.</content>
   <content contentuid="hcf424f73gfc0dg7cc2gd583ga378200e953d" version="1">While the Bladesong is active, you gain the following benefits.
 
-Agility. You gain a bonus to your AC equal to your Intelligence modifier (minimum of +1), and your Speed increases by 10 feet. In addition, you have Advantage on Dexterity (Acrobatics) checks.
+Agility. You gain a bonus to your AC equal to your Intelligence modifier (minimum of +1), and your Speed increases by 10 feet. In addition, you have Advantage on Dexterity (&lt;LSTag Type="Skills" Tooltip="Acrobatics"&gt;Acrobatics&lt;/LSTag&gt;) checks.
 
 Bladework. Whenever you attack with a weapon with which you have proficiency, you can use your Intelligence modifier for the attack and damage rolls instead of using Strength or Dexterity.
 
 Focus. When you make a Constitution saving throw to maintain Concentration, you can add your Intelligence modifier to the total.</content>
   <content contentuid="he1fbff1eg96ceg2664g8478gd2144519fd4d" version="1">&lt;LSTag Type="Image" Info="SoftWarning"/&gt; You can't wear Armour or Shields while Bladesinging.</content>
   <content contentuid="he1710159g6478g8470g4eecg831913a667d2" version="1">&lt;LSTag Type="Image" Info="SoftWarning"/&gt; You must be wielding a weapon in one hand.</content>
-  <content contentuid="h1669b47agf0fagd245g92f2g0e39a2c90370" version="1">Agility. You gain a bonus to your AC equal to your Intelligence modifier (minimum of +1), and your Speed increases by 10 feet. In addition, you have Advantage on Dexterity (Acrobatics) checks.
+  <content contentuid="h1669b47agf0fagd245g92f2g0e39a2c90370" version="1">Agility. You gain a bonus to your AC equal to your Intelligence modifier (minimum of +1), and your Speed increases by 10 feet. In addition, you have Advantage on Dexterity (&lt;LSTag Type="Skills" Tooltip="Acrobatics"&gt;Acrobatics&lt;/LSTag&gt;) checks.
 
 Bladework. Whenever you attack with a weapon with which you have proficiency, you can use your Intelligence modifier for the attack and damage rolls instead of using Strength or Dexterity.
 
@@ -2855,7 +2855,7 @@ Focus. When you make a Constitution saving throw to maintain Concentration, you 
   <content contentuid="h2bf11353gf199g41edg8f9eg584aaad22078" version="1">Level 3: Training in War and Song</content>
   <content contentuid="h352f38e9g6190gf239gf947g79ecb474c84f" version="1">You gain proficiency with all Melee Martial weapons that don’t have the Two-Handed or Heavy property. You can use a Melee weapon with which you have proficiency as a Spellcasting Focus for your Wizard spells.
 
-You also gain proficiency in one of the following skills of your choice: Acrobatics, Athletics, Performance, or Persuasion.</content>
+You also gain proficiency in one of the following skills of your choice: &lt;LSTag Type="Skills" Tooltip="Acrobatics"&gt;Acrobatics&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Athletics"&gt;Athletics&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Performance"&gt;Performance&lt;/LSTag&gt;, or &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Persuasion&lt;/LSTag&gt;.</content>
   <content contentuid="hede4cb27g87edg8c8fg8923ga74ca862fc12" version="1">Bladesinger</content>
   <content contentuid="hf106deb5gfb07g4bdeg0a01g623dd85de6b9" version="1">Bladesingers master a tradition of wizardry that incorporates swordplay and dance. In combat, a Bladesinger uses intricate, elegant maneuvers that fend off harm and allow the Bladesinger to channel magic into devastating attacks and a cunning defense. Many who have observed a Bladesinger at work remember the display as one of the more beautiful experiences in their life—a glorious dance accompanied by a singing blade.
 
@@ -2869,9 +2869,9 @@ Scions of the Three are most common in Baldur’s Gate, where the Dead Three liv
   <content contentuid="h7fa7c6fagab40g7237g2bd1g55927793880a" version="1">Level 3: Dread Allegiance</content>
   <content contentuid="h717c2effgcfefg6531g04eeg3d6a10c88329" version="2">You form a Dread Allegiance by choosing one of the Dead Three: Bane, Bhaal, or Myrkul. Your choice grants you Resistance to a specific damage type and the ability to cast an associated cantrip, using Intelligence as your spellcasting ability.
 
-If you choose Bane, you gain Resistance to Psychic damage and can cast Minor Illusion.
+If you choose Bane, you gain Resistance to Psychic damage and can cast &lt;LSTag Type="Spell" Tooltip="Target_ImprovedMinorIllusion"&gt;Minor Illusion&lt;/LSTag&gt;.
 
-If you choose Bhaal, you gain Resistance to Poison damage and can cast Blade Ward.
+If you choose Bhaal, you gain Resistance to Poison damage and can cast &lt;LSTag Type="Spell" Tooltip="Shout_BladeWard"&gt;Blade Ward&lt;/LSTag&gt;.
 
 If you choose Myrkul, you gain Resistance to Necrotic damage and can cast Chill Touch.
 
@@ -2893,15 +2893,15 @@ The Frightened target repeats the save at the end of each of its turns, ending t
   <content contentuid="hd359e4cbgb627ga19fg33d9g819888bf29c9" version="1">Dread Allegiance</content>
   <content contentuid="hed1840dbga25bga18bg158cg2e3656728e43" version="1">You form a Dread Allegiance by choosing one of the Dead Three: Bane, Bhaal, or Myrkul. Your choice grants you Resistance to a specific damage type and the ability to cast an associated cantrip, using Intelligence as your spellcasting ability.</content>
   <content contentuid="h6d6ec091g6782g7736g3633g063bf2cee187" version="1">Dread Allegiance: Bane</content>
-  <content contentuid="h7601f4ccg5ecfg89a8gf4d4gc425820bf2a2" version="1">If you choose Bane, you gain Resistance to Psychic damage and can cast Minor Illusion.</content>
+  <content contentuid="h7601f4ccg5ecfg89a8gf4d4gc425820bf2a2" version="1">If you choose Bane, you gain Resistance to Psychic damage and can cast &lt;LSTag Type="Spell" Tooltip="Target_ImprovedMinorIllusion"&gt;Minor Illusion&lt;/LSTag&gt;.</content>
   <content contentuid="h51a11419g7905g3848gd5bfgf6d72fd1a609" version="1">Dread Allegiance: Bhaal</content>
-  <content contentuid="hb4a3c0b4g39f9g3519g8885g8624730cfa75" version="1">If you choose Bhaal, you gain Resistance to Poison damage and can cast Blade Ward.</content>
+  <content contentuid="hb4a3c0b4g39f9g3519g8885g8624730cfa75" version="1">If you choose Bhaal, you gain Resistance to Poison damage and can cast &lt;LSTag Type="Spell" Tooltip="Shout_BladeWard"&gt;Blade Ward&lt;/LSTag&gt;.</content>
   <content contentuid="h23fa8e89g70f4g44b2g3bceg2ab0350c9dde" version="1">Dread Allegiance: Myrkul</content>
   <content contentuid="h6523df3dgbad7g0fafg867dg13134c55e3c3" version="1">If you choose Myrkul, you gain Resistance to Necrotic damage and can cast Chill Touch.</content>
   <content contentuid="h9a96305agf2f9g7267gdc69g37c278977066" version="1">Dread Allegiance: Bane</content>
   <content contentuid="haa7b4b2bga3d4g5493g0cd0g0d1480ede8e3" version="1">You gain Resistance to Psychic damage and can cast Minor Illusion.</content>
   <content contentuid="h3d0aa39dg266bg7c47g97e8g8d257554171a" version="1">Dread Allegiance: Bhaal</content>
-  <content contentuid="h58ee4755g4d7eg3830g0e23g9eeb9de00bf1" version="1">You gain Resistance to Poison damage and can cast Blade Ward.</content>
+  <content contentuid="h58ee4755g4d7eg3830g0e23g9eeb9de00bf1" version="1">You gain Resistance to Poison damage and can cast &lt;LSTag Type="Spell" Tooltip="Shout_BladeWard"&gt;Blade Ward&lt;/LSTag&gt;.</content>
   <content contentuid="hb44a03abgc118ge0f2g55eegf877db7779de" version="1">Dread Allegiance: Myrkul</content>
   <content contentuid="h6e38ab81gffdegf60dgddc7gdd71c617d269" version="1">You gain Resistance to Necrotic damage and can cast Chill Touch.</content>
   <content contentuid="h4d43ff27g7af4g7c74gd48dg5f5bf9706659" version="1">1</content>
@@ -3006,7 +3006,7 @@ At Gunslinger level 9, your attack rolls with Ranged weapons score a Critical Hi
   <content contentuid="h2efd301eg6691g78bfg2023g744d09c12743" version="2">When a creature you can see hits you with an attack roll, you can take a Reaction and expend one Risk Die to dodge out of harm’s way. Roll the die and add the number rolled to your AC against this attack, potentially causing it to miss. You can only use this maneuver once per turn.</content>
   <content contentuid="h92d115e1gde3cg3ce4g07ebg1a8454c06194" version="1">Level 10: Risk Taker</content>
   <content contentuid="ha818ea6cg6ab5g343dga9bag8a6101e2e6ac" version="1">Level 3: Poker Face</content>
-  <content contentuid="h9fff4318g1d24gfe2bgf7a2g1e0bcaa80c6d" version="1">You gain proficiency with all Gaming Sets and in one of the following skills of your choice: Deception, Insight, or Perception.</content>
+  <content contentuid="h9fff4318g1d24gfe2bgf7a2g1e0bcaa80c6d" version="1">You gain proficiency with all Gaming Sets and in one of the following skills of your choice: &lt;LSTag Type="Skills" Tooltip="Deception"&gt;Deception&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Insight"&gt;Insight&lt;/LSTag&gt;, or &lt;LSTag Type="Skills" Tooltip="Perception"&gt;Perception&lt;/LSTag&gt;.</content>
   <content contentuid="hf4b9bf75gff89ga519g3c73g4e032d899801" version="1">Level 3: Liar’s Dice</content>
   <content contentuid="h0602a34cg6491g63b2g1d28g66f745219e94" version="1">Level 6: Risky Business</content>
   <content contentuid="hb4e272e9gcca8g7303g07c8g417f217bf042" version="1">You can use your Maverick Spirit and Skin of Your Teeth maneuvers without expending a Risk Die. When you do so, roll a d6 instead of a Risk Die.</content>
@@ -3055,7 +3055,7 @@ While in Dragon Shape, you can use claw attacks and a breath weapon. You gain a 
 
 Druids from this Circle know that dragons, and draconic magic, are as connected to the world as plants or beasts, and utilize that connection to transform into a unique and powerful draconic form all their own.</content>
   <content contentuid="hea0350ecg3563gf151g3949ge2a04d0eb3da" version="1">Level 3: Draconic Lore</content>
-  <content contentuid="hda6df4cdg93a3gab23g3fd8ga7f8a4585d19" version="1">You gain expertise in History checks.</content>
+  <content contentuid="hda6df4cdg93a3gab23g3fd8ga7f8a4585d19" version="1">You gain expertise in &lt;LSTag Type="Skills" Tooltip="History"&gt;History&lt;/LSTag&gt; checks.</content>
   <content contentuid="h8ea85d5eg5bc3gd5aagf3e6g7179f506b3ef" version="1">Level 3: Dragon Shape</content>
   <content contentuid="hc9360440gfe54g46f9gbb9dge1b352d710ba" version="2">You can expend a use of your Wild Shape as a Bonus Action to transform into a unique form: your Dragon Shape. While in this form, you become a Medium dragon that stands on all fours, but you retain your normal game statistics and senses.
 
@@ -3089,7 +3089,7 @@ Once you cast the spell with this feature, you can’t do so in this way again u
   <content contentuid="h613fc304gdb88g758bgc98cg5ab761c0998b" version="1">Hair Trigger</content>
   <content contentuid="hc50e8dbcg2bbagfb26gb64fg9efcb00f26ed" version="1">You can make one weapon attack on the first turn of combat without using an action.</content>
   <content contentuid="h63ce4017geac0gc60egf8b5g9dce552352fa" version="1">Level 3: Bonus Proficiency</content>
-  <content contentuid="h51fe1e07g2424g5ddcg0df6g20465b6f7342" version="1">You gain proficiency in one of the following skills of your choice: Animal Handling, History, Insight, Performance, or Persuasion.</content>
+  <content contentuid="h51fe1e07g2424g5ddcg0df6g20465b6f7342" version="1">You gain proficiency in one of the following skills of your choice: &lt;LSTag Type="Skills" Tooltip="AnimalHandling"&gt;Animal Handling&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="History"&gt;History&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Insight"&gt;Insight&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Performance"&gt;Performance&lt;/LSTag&gt;, or &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Persuasion&lt;/LSTag&gt;.</content>
   <content contentuid="h07ffaea2g95cdgb266g0772gc36a0178e777" version="1">Level 3: Born to the Saddle</content>
   <content contentuid="h92ac32f2gae16g6effgdffege7984a067a57" version="1">You always have the Find Steed spell prepared. With this feature, you can cast it without a spell slot or components, and your spellcasting ability for it is Intelligence.
 
@@ -3188,7 +3188,7 @@ Arcane Shot. When you hit a target with a Finger Guns attack, you can expend one
 
 Concentration-Breaker. Whenever you make a ranged attack roll, you disrupt protective magic affecting the target and break its concentration.
 
-Antimagic Shot. When you score a Critical Hit against a target affected by your Gut Shot feature, you also impede its ability to cast spells. While the projectile remains lodged in the target, it can’t cast spells or take the Magic action.
+Antimagic Shot. When you score a Critical Hit against a target affected by your &lt;LSTag Type="Status" Tooltip="GUT_SHOT"&gt;Gut Shot&lt;/LSTag&gt; feature, you also impede its ability to cast spells. While the projectile remains lodged in the target, it can’t cast spells or take the Magic action.
 
 Inured to Magic. When you fail a saving throw against a spell or magical effect, you can take a Reaction to roll 1d6 and add it to the result, potentially turning the failure into a success.</content>
   <content contentuid="hfee38a66g5042g2c16g753dg9b88aa769f46" version="1">Antimagic Shot</content>
@@ -3342,7 +3342,7 @@ Mercy Is Power. In granting succor to my allies, I prove how great my power is. 
   <content contentuid="hb5dc95fdga8fdga177gedf9g3d1def6b18b4" version="1">Exsanguinate</content>
   <content contentuid="h8b8b45b5g6648g381bg1bccg8ba31a12abd5" version="1">You can drain enemies to embolden your allies. Whenever you burn one or more seals on a creature, you can choose an ally you can see within 30 feet of you. That ally gains Temporary Hit Points equal to the number rolled on one Seal damage die.</content>
   <content contentuid="hf1c1d608gab6fgea97g5ce7g12f4e4ddb16c" version="1">Level 3: Sutekh’s Blessing</content>
-  <content contentuid="h16ca83e4gd87cge240g4682g2480a4a6ba19" version="1">When Sutekh accepts you as his illrigger, he grants you access to his sacrilegious command of blood and life. You gain proficiency in the Religion skill.</content>
+  <content contentuid="h16ca83e4gd87cge240g4682g2480a4a6ba19" version="1">When Sutekh accepts you as his illrigger, he grants you access to his sacrilegious command of blood and life. You gain proficiency in the &lt;LSTag Type="Skills" Tooltip="Religion"&gt;Religion&lt;/LSTag&gt; skill.</content>
   <content contentuid="h08b904f9gd5aeg7159g0bb5g4f1a264718cc" version="1">Level 3: Embolden Allies</content>
   <content contentuid="h1e93a04fgfcb3ge71cg8edcg9d735d49cff7" version="1">As a bonus action, you restore a total number of hit points equal to five times your illrigger level, divided however you choose between yourself and other creatures within 30 feet of you.</content>
   <content contentuid="h3193c1b1g81cegd32cg4ceag8e352d5d18eb" version="1">Embolden Allies</content>
@@ -3375,11 +3375,11 @@ Doubt Is Certainty. I need not convince my enemy, only sow doubt and wait for it
 Trust Me. For each lie I utter, I tell the truth tenfold. One who always lies says nothing.
 
 Never Tell the Same Lie Twice. An overused skill becomes too predictable. Keep moving, switch targets, keep them guessing.</content>
-  <content contentuid="hb052fe34g86bfg992cg2672g146c445e9dc4" version="1">When Moloch accepts you as his illrigger, you gain &lt;LSTag Tooltip="Expertise"&gt;Expertise&lt;/LSTag&gt; in Persuasion and  Deception &lt;LSTag Tooltip="AbilityCheck"&gt;Checks&lt;/LSTag&gt;.</content>
+  <content contentuid="hb052fe34g86bfg992cg2672g146c445e9dc4" version="1">When Moloch accepts you as his illrigger, you gain &lt;LSTag Tooltip="Expertise"&gt;Expertise&lt;/LSTag&gt; in &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Persuasion&lt;/LSTag&gt; and  &lt;LSTag Type="Skills" Tooltip="Deception"&gt;Deception&lt;/LSTag&gt; &lt;LSTag Tooltip="AbilityCheck"&gt;Checks&lt;/LSTag&gt;.</content>
   <content contentuid="h02827317g8f4fgf0ebgdc73g2e240e81362a" version="1">Level 3: Moloch’s Blessing</content>
-  <content contentuid="h4b29ebdegfa87g42bege4a2g3b10f7973640" version="1">When Moloch accepts you as his illrigger, you gain &lt;LSTag Tooltip="Expertise"&gt;Expertise&lt;/LSTag&gt; in Persuasion and  Deception &lt;LSTag Tooltip="AbilityCheck"&gt;Checks&lt;/LSTag&gt;.</content>
+  <content contentuid="h4b29ebdegfa87g42bege4a2g3b10f7973640" version="1">When Moloch accepts you as his illrigger, you gain &lt;LSTag Tooltip="Expertise"&gt;Expertise&lt;/LSTag&gt; in &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Persuasion&lt;/LSTag&gt; and  &lt;LSTag Type="Skills" Tooltip="Deception"&gt;Deception&lt;/LSTag&gt; &lt;LSTag Tooltip="AbilityCheck"&gt;Checks&lt;/LSTag&gt;.</content>
   <content contentuid="h6dff901fgee2cg0571g1cd5g5cccc5298b3e" version="1">Level 3: Charm Enemy</content>
-  <content contentuid="h3eabef8fg88cagb8c2g7625g98663b906cac" version="3">When you use your Bonus Action to place a seal on a creature, you can charm it for 10 turns.</content>
+  <content contentuid="h3eabef8fg88cagb8c2g7625g98663b906cac" version="3">When you use your Bonus Action to place a &lt;LSTag Type="Spell" Tooltip="Target_Seal"&gt;seal&lt;/LSTag&gt; on a creature, you can charm it for 10 turns.</content>
   <content contentuid="he8f7350dgec9cga3c4g613agaeb7f4a54136" version="1">Level 3: Honey-Sweet Blade</content>
   <content contentuid="h6adc649fgbd08g1d76g0aecg4e5c0ef03271" version="2">When you make a weapon attack against a Charmed creature, you can gain Advantage on the attack roll (no action required). If the attack hits, it becomes a Critical Hit.</content>
   <content contentuid="h2cf5b57fgaa9bg9d02g3619g774b755bf5d6" version="1">Honey-Sweet Blades</content>
@@ -3466,20 +3466,20 @@ Hesitation Is Failure. Though I usually rely on agents, when the opportunity pre
 
 You gain darkvision out to 60 feet. If you already have darkvision, its range increases by 60 feet.
 Your movement speed increases by 10 feet.
-You have advantage on Dexterity (Stealth) checks made to hide. Whenever you make a Dexterity saving throw to take only half damage from an effect, you instead take no damage if you succeed on the saving throw, and half damage if you fail.</content>
+You have advantage on Dexterity (&lt;LSTag Type="Skills" Tooltip="Stealth"&gt;Stealth&lt;/LSTag&gt;) checks made to hide. Whenever you make a Dexterity saving throw to take only half damage from an effect, you instead take no damage if you succeed on the saving throw, and half damage if you fail.</content>
   <content contentuid="h5265c616g7dacgad00gefc6ge34e7ec6e7f4" version="1">Umbral Killer</content>
   <content contentuid="h9b666f81g3924gf39eg6868gd20519f6b190" version="1">Shadows are your companion, aiding you in your exploits. You gain the following benefits:
 
 You gain darkvision out to 60 feet. If you already have darkvision, its range increases by 60 feet.
 Your movement speed increases by 10 feet.
-You have advantage on Dexterity (Stealth) checks made to hide. Whenever you make a Dexterity saving throw to take only half damage from an effect, you instead take no damage if you succeed on the saving throw, and half damage if you fail.</content>
+You have advantage on Dexterity (&lt;LSTag Type="Skills" Tooltip="Stealth"&gt;Stealth&lt;/LSTag&gt;) checks made to hide. Whenever you make a Dexterity saving throw to take only half damage from an effect, you instead take no damage if you succeed on the saving throw, and half damage if you fail.</content>
   <content contentuid="h59478469g65f2gdc36g0515g15430765aa77" version="2">Level 11: Umbral Killer</content>
   <content contentuid="hecbd9ffcg2be8gbb16g7102g34164bd0d262" version="2">Shadows are your companion, aiding you in your exploits. You gain the following benefits:
 
 You gain darkvision out to 60 feet. If you already have darkvision, its range increases by 60 feet.
 You can see normally in darkness, both magical and non-magical.
 Your movement speed increases by 10 feet.
-You have advantage on Dexterity (Stealth) checks made to hide. Whenever you make a Dexterity saving throw to take only half damage from an effect, you instead take no damage if you succeed on the saving throw, and half damage if you fail.</content>
+You have advantage on Dexterity (&lt;LSTag Type="Skills" Tooltip="Stealth"&gt;Stealth&lt;/LSTag&gt;) checks made to hide. Whenever you make a Dexterity saving throw to take only half damage from an effect, you instead take no damage if you succeed on the saving throw, and half damage if you fail.</content>
   <content contentuid="h2a979e60g8047g338bg7d21g17a10ae143c0" version="2">You understand the power of striking from the shadows. Once per turn, when you hit an interdicted creature with a melee weapon attack and you have advantage on the attack roll, you can roll a number of d4s equal to your proficiency bonus and deal extra damage equal to the total you rolled.</content>
   <content contentuid="h29339e6ag5488gb3c9gf071g0b4a21da192a" version="2">As a Bonus Action, wrap a shadow rope around a creature's throat to start &lt;LSTag Type="Status" Tooltip="GARROTE_TARGET_HUMANOID"&gt;Garrotting&lt;/LSTag&gt; it.</content>
   <content contentuid="hf7851a9dg2c90ga420g9853gd855b8d447bc" version="1">Strike from the Dark</content>
@@ -3533,7 +3533,7 @@ Knowledge Is Power. Lore is as powerful as steel. I learn every detail about my 
 
 Magic Is Mine to Command. Cunning is also as powerful as steel. I wield the dark arcane arts to manipulate your senses, weaken your resolve, and strengthen my blade. Your soldiers will quake for fear of what dark magics may next cloak my blade.</content>
   <content contentuid="h01f5bb00ga933g06e9g6166g6a590fca24a4" version="2">Level 3: Asmodeus’s Blessing</content>
-  <content contentuid="ha816b389ge8bag72c4gef70g5e1232a276d1" version="1">When Asmodeus accepts you as an Architect of Ruin, he grants you access to his infernal knowledge. You gain proficiency in one of the following skills of your choice: Arcana, History, Nature, or Religion.</content>
+  <content contentuid="ha816b389ge8bag72c4gef70g5e1232a276d1" version="1">When Asmodeus accepts you as an Architect of Ruin, he grants you access to his infernal knowledge. You gain proficiency in one of the following skills of your choice: &lt;LSTag Type="Skills" Tooltip="Arcana"&gt;Arcana&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="History"&gt;History&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Nature"&gt;Nature&lt;/LSTag&gt;, or &lt;LSTag Type="Skills" Tooltip="Religion"&gt;Religion&lt;/LSTag&gt;.</content>
   <content contentuid="h90cf32b2gf820g9778g512fge7868eab0c47" version="2">Level 3: Spellblade</content>
   <content contentuid="h1d004939g5a78gcfbage143g31b8dc1c1405" version="1">You can cast the spell once per Short Rest without expending an action.</content>
   <content contentuid="h136b52acg55efge3ecge543gaf51e46232a0" version="1">Spellblade</content>
@@ -3559,7 +3559,7 @@ Magic Is Mine to Command. Cunning is also as powerful as steel. I wield the dark
   <content contentuid="h01e4f65cg7f45g4509g7911g655523dbfc23" version="1">Magic Initiate: Wizard</content>
   <content contentuid="hf53d0a43g624eg7762g6910g0264f0ae7c73" version="1">You learn 2 &lt;LSTag Tooltip="Cantrip"&gt;cantrips&lt;/LSTag&gt; and a Level 1 spell from the wizard spell list.</content>
   <content contentuid="hb45ab210g4dfeg44aage273g11ab2c83f7b8" version="1">Warding Seals</content>
-  <content contentuid="hd8757627g198cg4659gbdcbgf8c916e4b023" version="1">When you use your bonus action to place an illrigger’s seal on a creature, or when you burn a seal placed on a creature, you gain the effects of Blade Ward for 2 turns.</content>
+  <content contentuid="hd8757627g198cg4659gbdcbgf8c916e4b023" version="1">When you use your bonus action to place an illrigger’s seal on a creature, or when you burn a seal placed on a creature, you gain the effects of &lt;LSTag Type="Spell" Tooltip="Shout_BladeWard"&gt;Blade Ward&lt;/LSTag&gt; for 2 turns.</content>
   <content contentuid="h6fbb1933ge0e0gc26ag9144gcde944d43651" version="1">As a Magic action, you present your Holy Symbol and expend a use of your Channel Divinity to emit a flash of light in a 30-foot Emanation originating from yourself. Any magical Darkness—such as that created by the Darkness spell—in that area is dispelled. Additionally, each creature of your choice in that area must make a Constitution saving throw, taking Radiant damage equal to 2d10 plus your Cleric level on a failed save or half as much damage on a successful one.</content>
   <content contentuid="h42e7e44fge041g864egc55fgbbdba0e4da67" version="1">Whenever you take radiant damage, your attacker takes force damage equal to their proficiency bonus.</content>
   <content contentuid="h40874a69g2e20g65d7g2444g9bccdb153fa5" version="5">True Name</content>
@@ -3668,7 +3668,7 @@ Divine Channel. You gain one use of the Channel Divinity feature from the Cleric
   <content contentuid="hc89f541bg33a9g6e04g2561g6e4b1e11a18e" version="1">Astral</content>
   <content contentuid="hf149dfc0gc190g57f0g98c9g5ca3daadd069" version="1">Gods of the Astral Plane are as lost to time and space as the realm they reign over. The Astral Plane fills the gaps between the planes of existence and is an important balancing force in the cosmic ecosystem of the multiverse. Practitioners of this domain see the absence of anything as something and consider the Astral Plane as the ultimate destination of all things. These acolytes follow the ultimate path to their destination, and help shepherd others along their way in a grand mission of entropy. Clerics of the Astral Domain are chaotic by nature, but typically choose to destroy evil where they find it and hasten its inevitable journey to the Astral Plane.</content>
   <content contentuid="h6da1597ag642dg0e69g9c1cg73fd7e25fe9f" version="1">Level 3: Astral Domain Spells</content>
-  <content contentuid="h1b7aecd7g65c1g83b6g50ddg7fe12c1c16a8" version="1">Your connection to the Astral Domain ensures that you always have certain spells prepared. When you reach specific Cleric levels, as shown in the Astral Domain Spells table, you automatically gain the listed spells and they are always prepared for you. At 3rd level, you gain Blur, Guiding Bolt, Invisibility, Longstrider, and Starry Wisp. At 5th level, you gain Blink and Slow. At 7th level, you gain Banishment and Dimension Door. At 9th level, you gain Dispel Evil and Good and Wall of Stone.</content>
+  <content contentuid="h1b7aecd7g65c1g83b6g50ddg7fe12c1c16a8" version="1">Your connection to the Astral Domain ensures that you always have certain spells prepared. When you reach specific Cleric levels, as shown in the Astral Domain Spells table, you automatically gain the listed spells and they are always prepared for you. At 3rd level, you gain Blur, Guiding Bolt, &lt;LSTag Type="Spell" Tooltip="Target_Invisibility"&gt;Invisibility&lt;/LSTag&gt;, Longstrider, and Starry Wisp. At 5th level, you gain Blink and Slow. At 7th level, you gain Banishment and Dimension Door. At 9th level, you gain Dispel Evil and Good and Wall of Stone.</content>
   <content contentuid="h84a93262ga4eag809fg7a75gd6a9a6da35cf" version="1">Level 3: Create Void</content>
   <content contentuid="h520a3350gab70g330fge64fgd34f7914b820" version="1">As a Bonus Action, you can expend a use of your Channel Divinity to open a planar tear at a point you can see within 60 feet of you, creating a powerful vacuum in a 15-foot-radius Sphere centered on that point. Each creature in the area must make a Dexterity saving throw. On a failed save, a creature takes Force damage equal to 1d8 plus your Cleric level and is pulled up to 15 feet toward the point. On a successful save, a creature takes half as much Force damage only. The tear then vanishes.</content>
   <content contentuid="hf2358cb4g9ac5g070fg4962g945473af7540" version="1">Level 3: Planar Reach</content>
@@ -3689,7 +3689,7 @@ While the chaotic bend of nature is found within these Druids, their bodies and 
   <content contentuid="he9c252edgc46cg4450gfb88g57508151df65" version="1">Level 3: Circle of the Unbroken Spells</content>
   <content contentuid="head50b7eg3179gbc89g1334gbee0de9d925c" version="1">Your connection to the Unbroken Circle ensures that you always have certain spells prepared. When you reach a Druid level specified in the Unbroken Circle Spells table, you thereafter always have the listed spells prepared.
 
-At 3rd level, you always have Ensnaring Strike, Shillelagh, Shining Smite, and True Strike prepared. At 5th level, you always have Haste prepared. At 7th level, you always have Fire Shield prepared. At 9th level, you always have Flame Strike prepared.
+At 3rd level, you always have Ensnaring Strike, Shillelagh, Shining Smite, and True Strike prepared. At 5th level, you always have &lt;LSTag Type="Spell" Tooltip="Target_Haste"&gt;Haste&lt;/LSTag&gt; prepared. At 7th level, you always have Fire Shield prepared. At 9th level, you always have Flame Strike prepared.
 </content>
   <content contentuid="h8ed0d8e9g85baga28cg5d7eg2778cf1bbf0a" version="1">Level 3: Wild Recovery</content>
   <content contentuid="heb2a7f7ag521bg6a02g5dffg52cdf49a9788" version="2">You gain the ability to recover using the wild, bestial magic that courses through you. As a Bonus Action, you can expend a use of your Wild Shape to regain a number of Hit Points equal to 2d6 plus your Druid level. This healing increases by 1d6 when you reach Druid levels 5 (3d6 plus your Druid level) and 10 (4d6 plus your Druid level).</content>
@@ -3740,7 +3740,7 @@ You can take this Reaction a number of times equal to your Intelligence modifier
 You can create only one instance of each replicated item when you finish a Long Rest. A creature can benefit from only one replicated item at a time.
 
 Creating each replicated magic item requires you to have reached a certain Artificer level.</content>
-  <content contentuid="hb0fdd4d9g503ege786g4e88g495448e216a3" version="1">If the bearer succeeds on a DC 15 Medicine check, they can produce two alchemical extracts.</content>
+  <content contentuid="hb0fdd4d9g503ege786g4e88g495448e216a3" version="1">If the bearer succeeds on a DC 15 &lt;LSTag Type="Skills" Tooltip="Medicine"&gt;Medicine&lt;/LSTag&gt; check, they can produce two alchemical extracts.</content>
   <content contentuid="hd8a61fbeg966eg2925g4b33g06cdd667a7db" version="1">The bearer’s carrying capacity is increased tenfold.</content>
   <content contentuid="h0389208ag20a5gb33cgd6d4g1a76d494f34c" version="1">The bearer can see through darkness, including magical darkness.</content>
   <content contentuid="hb0d3133ege1fag851cg713dg91c9c8490f25" version="1">While the bearer is wielding a shield, the bonus to AC granted by the shield increases by 1.</content>
@@ -3779,7 +3779,7 @@ You can take this Reaction a number of times equal to your Intelligence modifier
   <content contentuid="h1d1129bbg26a2g8dffgb2fdgf8f7a76ceeb7" version="1">Armor of Resistance</content>
   <content contentuid="hab73d382g1a8eg63dege86fg9874a3c11c9c" version="1">Ring of Free Action</content>
   <content contentuid="hd3c53187gc5acg834fg9a70g53edd5e45e58" version="1">Ring of Protection</content>
-  <content contentuid="h3af4f15fgffa3gf824ga850g5f3edec1f758" version="1">You can brew two alchemical solutions instead of one when combining extracts, if you succeed a &lt;LSTag Tooltip="DifficultyClass"&gt;DC&lt;/LSTag&gt; 15 Medicine &lt;LSTag Tooltip="AbilityCheck"&gt;Check&lt;/LSTag&gt;.</content>
+  <content contentuid="h3af4f15fgffa3gf824ga850g5f3edec1f758" version="1">You can brew two alchemical solutions instead of one when combining extracts, if you succeed a &lt;LSTag Tooltip="DifficultyClass"&gt;DC&lt;/LSTag&gt; 15 &lt;LSTag Type="Skills" Tooltip="Medicine"&gt;Medicine&lt;/LSTag&gt; &lt;LSTag Tooltip="AbilityCheck"&gt;Check&lt;/LSTag&gt;.</content>
   <content contentuid="h9d752733g6be8g780age17cg3ef589ca12bc" version="1">Your carrying capacity is increased.</content>
   <content contentuid="hfb02885eg51e1gd167gf1a1ged6463b56463" version="1">You can see normally in darkness, both magical and non-magical, to a distance of 24.</content>
   <content contentuid="hb0f3d315gdfb1g335fg999cgc43d9086449d" version="1">While you are wielding a shield, you gain a bonus to AC.</content>
@@ -3845,17 +3845,17 @@ When you reach certain Artificer levels, you can make an additional elixir at th
 
 Many of the barbarians who walk this path do so to absorb harmful shadow magic into themselves in order to protect others from its influence. A smaller group consumes shadow simply because they cannot resist its ever-present temptation.</content>
   <content contentuid="h69753443g4b64g24dfg671fg01f0a6c73022" version="1">Level 3: Shadow Smoke</content>
-  <content contentuid="h214e9d1dg45fcg6388gdc9cg6130d7c87cf2" version="2">While you are raging, once per turn, you can emit tendrils of shadow smoke. The smoke extends 10 feet from you in every direction. Any creature other than you that is within the smoke is Blinded.</content>
+  <content contentuid="h214e9d1dg45fcg6388gdc9cg6130d7c87cf2" version="2">While you are &lt;LSTag Type="Status" Tooltip="RAGE"&gt;raging&lt;/LSTag&gt;, once per turn, you can emit tendrils of shadow smoke. The smoke extends 10 feet from you in every direction. Any creature other than you that is within the smoke is &lt;LSTag Type="Status" Tooltip="BLINDED"&gt;Blinded&lt;/LSTag&gt;.</content>
   <content contentuid="h491afa5eg7b34g23f1g71d1gd3a73f1a0484" version="1">Shadow Smoke</content>
-  <content contentuid="hc17eba4eg936fg2851g0508gb73011778121" version="1">While you are raging, once per turn, you can emit tendrils of shadow smoke. The smoke extends 10 feet from you in every direction. Any creature other than you that is within the smoke is Blinded.</content>
+  <content contentuid="hc17eba4eg936fg2851g0508gb73011778121" version="1">While you are &lt;LSTag Type="Status" Tooltip="RAGE"&gt;raging&lt;/LSTag&gt;, once per turn, you can emit tendrils of shadow smoke. The smoke extends 10 feet from you in every direction. Any creature other than you that is within the smoke is &lt;LSTag Type="Status" Tooltip="BLINDED"&gt;Blinded&lt;/LSTag&gt;.</content>
   <content contentuid="h99712a6fge628ga06eg47b4ga89071e28928" version="1">Creeping Fog</content>
   <content contentuid="hba39350fgd122gc25bgbeaegca4f83c67943" version="1">Teleport to an unoccupied, obscured spot. Before or after teleporting, you can make one attack.</content>
   <content contentuid="h941c15f0g2e60g0e9fg218dge166bea3e8ed" version="1">Consume Darkness</content>
-  <content contentuid="h1a71759egf1c8g9a25g2327g7210d3bcea88" version="1">While raging, you can feed on the shadows around you to restore your vitality. While in dim light or darkness, you can use a bonus action to regain hit points equal to 1d12 + your Constitution modifier.</content>
+  <content contentuid="h1a71759egf1c8g9a25g2327g7210d3bcea88" version="1">While &lt;LSTag Type="Status" Tooltip="RAGE"&gt;raging&lt;/LSTag&gt;, you can feed on the shadows around you to restore your vitality. While in dim light or darkness, you can use a bonus action to regain hit points equal to 1d12 + your Constitution modifier.</content>
   <content contentuid="h69bf67ebgf486g254dg8139gcbbd39d66230" version="2">Level 6: Creeping Fog</content>
   <content contentuid="h158135d1g6fa7g983eg619eg5cb15bc27602" version="1">You can burst into a mist of raw shadow and then reassemble yourself somewhere else. As an action, you magically teleport, along with any equipment you are wearing or carrying, up to 30 feet to an unoccupied and obscured space you can see. Before or after teleporting, you can make one attack.</content>
   <content contentuid="he97e3b0fg6f9cg22aag0fc7gb7945f9ceb17" version="1">Level 10: Consume Darkness</content>
-  <content contentuid="h4d7a4652g2bf4gcf0dg7e2bg038ddc3b14d4" version="1">While raging, you can feed on the shadows around you to restore your vitality. While in dim light or darkness, you can use a bonus action to regain hit points equal to 1d12 + your Constitution modifier.</content>
+  <content contentuid="h4d7a4652g2bf4gcf0dg7e2bg038ddc3b14d4" version="1">While &lt;LSTag Type="Status" Tooltip="RAGE"&gt;raging&lt;/LSTag&gt;, you can feed on the shadows around you to restore your vitality. While in dim light or darkness, you can use a bonus action to regain hit points equal to 1d12 + your Constitution modifier.</content>
   <content contentuid="hf54abe92g0c59g3206g795cg205f29ea03b8" version="1">A Weapon you are holding is imbued with nature’s power. For the duration, you can use your spellcasting ability instead of Strength for the attack and damage rolls of melee attacks using that weapon, and the weapon’s damage die becomes a d8. If the attack deals damage, it is Force damage.
 
 The spell ends early if you cast it again or if you let go of the weapon.
@@ -3903,7 +3903,7 @@ Defensive Field. While Bloodied, you can take a Bonus Action to gain Temporary H
 
 Lightning Launcher. A gemlike node appears on your armor, from which you can shoot bolts of lightning. The launcher counts as a Simple Ranged weapon, and it deals 1d6 Lightning damage on a hit. Once on each of your turns when you hit a creature with the launcher, you can deal an extra 1d6 Lightning damage to that target.
 Powered Steps. Your Speed increases by 5 feet.
-Dampening Field. You have Advantage on Dexterity (Stealth) checks.</content>
+Dampening Field. You have Advantage on Dexterity (&lt;LSTag Type="Skills" Tooltip="Stealth"&gt;Stealth&lt;/LSTag&gt;) checks.</content>
   <content contentuid="hae5b8629gb6dege582gb0b6g59da26e4eb55" version="1">Level 9: Improved Armorer</content>
   <content contentuid="hf03822e2g7af0g67edg9165g36461a798fbc" version="4">Your Arcane Armor gains additional benefits based on its model, as detailed below.
 
@@ -3989,7 +3989,7 @@ You regain all expended dice when you finish a long rest.</content>
   <content contentuid="h6002b32ag74ffg3470g0a2cg9afe92b897e5" version="1">Level 6: Hearth of Moonlight and Shadow</content>
   <content contentuid="he2f58070g7662g8b76gc3d9gce5303f3d8c8" version="2">Home can be wherever you are. You draw upon the Gloaming Court’s quiet dominion over shadow and secrecy, wrapping yourself and your allies in its subtle protection. As an action, you invoke this power to conjure a protective refuge and immediately gain the benefits of a short rest.
 
-Until you complete your next long rest, you and your allies gain a +5 bonus to Dexterity (Stealth) and Wisdom (Perception) checks.</content>
+Until you complete your next long rest, you and your allies gain a +5 bonus to Dexterity (&lt;LSTag Type="Skills" Tooltip="Stealth"&gt;Stealth&lt;/LSTag&gt;) and Wisdom (&lt;LSTag Type="Skills" Tooltip="Perception"&gt;Perception&lt;/LSTag&gt;) checks.</content>
   <content contentuid="h86d67657g9bf6g0b50g5e7cg56cc562e49a6" version="1">Level 10: Hidden Paths</content>
   <content contentuid="h8a84376bg7fbdg24c6g9d95gf3e5c6364f83" version="1">You can use the hidden, magical pathways that some fey use to traverse space in the blink of an eye. As a bonus action on your turn, you can teleport up to 30 feet to an unoccupied space you can see. Alternatively, you can use your action to teleport one willing creature you touch up to 30 feet to an unoccupied space you can see.
 
@@ -4000,11 +4000,11 @@ You can use this feature a number of times equal to your Wisdom modifier (minimu
   <content contentuid="he20dfbbag75a3gc426g332eg26d5f5687c72" version="1">As a bonus action, you can choose one creature you can see within 60 feet of you and spend a number of those dice equal to half your druid level or less. Roll the spent dice and add them together. The target regains a number of hit points equal to the total. The target also gains 1 temporary hit point per die spent.</content>
   <content contentuid="h8ae6911fg454ag4837gb124g3854cf3dde9a" version="1">Balm of the Summer Court</content>
   <content contentuid="h25cebc5cgd794gb02fg2941g193df53c964f" version="1">Hearth of Moonlight and Shadow</content>
-  <content contentuid="hd876484bg06deg6a8egb4b1gc6a59e051290" version="1">Until you complete your next short or long rest, you and your allies gain a +5 bonus to Dexterity (Stealth) and Wisdom (Perception) checks.</content>
+  <content contentuid="hd876484bg06deg6a8egb4b1gc6a59e051290" version="1">Until you complete your next short or long rest, you and your allies gain a +5 bonus to Dexterity (&lt;LSTag Type="Skills" Tooltip="Stealth"&gt;Stealth&lt;/LSTag&gt;) and Wisdom (&lt;LSTag Type="Skills" Tooltip="Perception"&gt;Perception&lt;/LSTag&gt;) checks.</content>
   <content contentuid="h0bf5656fg0b15g4da8gc1fcg0b504c8b4a4b" version="1">Hearth of Moonlight and Shadow</content>
   <content contentuid="h7b17de26g4a12g2a89g2353gedd40e2fbe9a" version="1">Home can be wherever you are. You draw upon the Gloaming Court’s quiet dominion over shadow and secrecy, wrapping yourself and your allies in its subtle protection. As an action, you invoke this power to conjure a protective refuge and immediately gain the benefits of a short rest.
 
-Until you complete your next long rest, you and your allies gain a +5 bonus to Dexterity (Stealth) and Wisdom (Perception) checks.</content>
+Until you complete your next long rest, you and your allies gain a +5 bonus to Dexterity (&lt;LSTag Type="Skills" Tooltip="Stealth"&gt;Stealth&lt;/LSTag&gt;) and Wisdom (&lt;LSTag Type="Skills" Tooltip="Perception"&gt;Perception&lt;/LSTag&gt;) checks.</content>
   <content contentuid="h447397a3g875fgc842g106dg4b2c03ef1b5b" version="1">Hidden Paths</content>
   <content contentuid="hb6ad15b6g6a5cgc8edg95d4gd631318ac05a" version="1">Hidden Paths</content>
   <content contentuid="h318e3ac4g7a18ga5edgf912g65c014f1354e" version="2">Vampiric Bite</content>
@@ -4029,7 +4029,7 @@ Until you complete your next long rest, you and your allies gain a +5 bonus to D
   <content contentuid="h325e735fg2b3bg04e3g4111g0c40750b7fbe" version="1">Skillful</content>
   <content contentuid="h621fd279gebdag777dg35cdge79dc6dc09a3" version="1">You gain proficiency in one skill of your choice.</content>
   <content contentuid="hffb15f0dg8d46g8ce2g4665g6ab0e628d277" version="1">Keen Senses</content>
-  <content contentuid="hff4e6b44g07dbg7d46g1dfbg11ee89aaef5b" version="1">You have proficiency in the Insight, Perception, or Survival skill.</content>
+  <content contentuid="hff4e6b44g07dbg7d46g1dfbg11ee89aaef5b" version="1">You have proficiency in the &lt;LSTag Type="Skills" Tooltip="Insight"&gt;Insight&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Perception"&gt;Perception&lt;/LSTag&gt;, or &lt;LSTag Type="Skills" Tooltip="Survival"&gt;Survival&lt;/LSTag&gt; skill.</content>
   <content contentuid="h66fbaf70g36bcg4313g969fgfabc9b4f1f69" version="4">You can cast one of your cantrips that has a casting time of an action in place of one of those attacks.</content>
   <content contentuid="h131208e0g1b65g0338gbc3dg9af0e2d478df" version="1">Elven Accuracy</content>
   <content contentuid="h5807bc17g3e71g7234g30c2gf7b6a4fe91da" version="1">Whenever you have advantage on an attack roll using Dexterity, Intelligence, Wisdom, or Charisma, you can reroll one of the dice once.</content>
@@ -4083,7 +4083,7 @@ Weapon Knowledge. You gain proficiency with Martial weapons. You can use a weapo
   <content contentuid="h074e1d16gaccag0b0bg55e9g233c194cbe67" version="1">Battle Smith</content>
   <content contentuid="h4bf8da96g64a3g0f5eg135bg7645978583b0" version="1">A Battle Smith is a combination of protector and medic, an expert at defending others and repairing both materiel and personnel. To aid in their work, Battle Smiths are accompanied by a Steel Defender, a protective companion of their own creation.</content>
   <content contentuid="h6d2cfddegb7bag99e2g6ffbg6a101cdf219d" version="1">Level 9: Arcane Jolt</content>
-  <content contentuid="h1ad514dega841gc35dg8804ga474e60b45ea" version="2">When you hit a target with an attack roll using a magic weapon, or when your Steel Defender hits a target, you can channel magical energy through the strike to unleash Destructive Energy. The target takes an extra 2d6 force damage.
+  <content contentuid="h1ad514dega841gc35dg8804ga474e60b45ea" version="2">When you hit a target with an attack roll using a magic weapon, or when your &lt;LSTag Type="Spell" Tooltip="Target_SteelDefender"&gt;Steel Defender&lt;/LSTag&gt; hits a target, you can channel magical energy through the strike to unleash Destructive Energy. The target takes an extra 2d6 force damage.
 
 Alternatively, you can unleash Restorative Energy by choosing one creature or object you can see within 30 feet of you. Healing energy flows into the chosen recipient, restoring 2d6 hit points to it.</content>
   <content contentuid="h4f02276agb1b7g8939g8d33g4138f4f9a52f" version="1">You can use this energy a number of times equal to your Intelligence modifier (minimum of once), but you can do so no more than once per turn. You regain all expended uses when you finish a Long Rest.</content>
@@ -4091,7 +4091,7 @@ Alternatively, you can unleash Restorative Energy by choosing one creature or ob
   <content contentuid="h7a33c7b9g8cc0g6c2bg348fg50d1aa50e0f5" version="2">When you hit a target with an attack roll using a magic weapon, you can channel magical energy through the strike to unleash Destructive Energy. The target takes an extra 2d6 force damage.</content>
   <content contentuid="hcbe0e0aeg4adbgf201g248cg78fdbe7712a4" version="1">Arcane Jolt (Steel Defender)</content>
   <content contentuid="ha41d11dbgba7eg921eg929fg846ff3d63c75" version="1">Destructive Energy (Steel Defender)</content>
-  <content contentuid="h2a2d4c40ge64cg5bd8gb073g4424cebf9004" version="1">When your Steel Defender hits a target, you can channel magical energy through the strike to unleash Destructive Energy. The target takes an extra 2d6 force damage.</content>
+  <content contentuid="h2a2d4c40ge64cg5bd8gb073g4424cebf9004" version="1">When your &lt;LSTag Type="Spell" Tooltip="Target_SteelDefender"&gt;Steel Defender&lt;/LSTag&gt; hits a target, you can channel magical energy through the strike to unleash Destructive Energy. The target takes an extra 2d6 force damage.</content>
   <content contentuid="h10e88f31ga340g7220g57cagf79b60b98df3" version="1">Arcane Jolt</content>
   <content contentuid="h214b31e4g1222g89d1g1c98g859dc68c80f1" version="1">Restorative Energy</content>
   <content contentuid="hde43de07gcaa5gae30g5a72gf42e5fc93579" version="1">Choose one creature or object you can see within 30 feet of the target. Healing energy flows into the chosen recipient, restoring 2d6 Hit Points to it.</content>
@@ -4135,7 +4135,7 @@ The damage becomes 4d6 when you reach Monster Hunter level 11.</content>
   <content contentuid="ha738254bg5dbag724ag511ag8d59cf1fed09" version="1">War Caster: Green-Flame Blade</content>
   <content contentuid="h7e0866bbgdec1g07c2g7725gef3c6eb68247" version="1">War Caster: True Strike</content>
   <content contentuid="h664f7fdag1793g4256gd73cga50bae7c538a" version="1">War Caster: Vengeful Blade</content>
-  <content contentuid="h67a39d88g2da4ga80bg2675g4c2a3e61a8ce" version="1">War Caster: Shocking Grasp</content>
+  <content contentuid="h67a39d88g2da4ga80bg2675g4c2a3e61a8ce" version="1">War Caster: &lt;LSTag Type="Spell" Tooltip="Target_ShockingGrasp"&gt;Shocking Grasp&lt;/LSTag&gt;</content>
   <content contentuid="h58d3ea5cg20f9gc47cg638cg148f2229c69f" version="1">Cast a spell at a creature moving out of range.</content>
   <content contentuid="hb9127c70g1995gf222g6ab6g02340332c0ad" version="1">Viking</content>
   <content contentuid="he18e2299gab76g9494gca06g85d28e4049b1" version="1">Vikings are battle-hardened warriors and sailors who ply the seas of the Northlands for glory and plunder. As followers of the Reaver’s Way, they have their own sense of honor, yet they can be merciless in times of raiding and war. Vikings are known for their prowess with the spear and axe, and for their belief that they can earn a special place in the halls of the dead through their deeds of valor in battle.</content>
@@ -4144,14 +4144,14 @@ The damage becomes 4d6 when you reach Monster Hunter level 11.</content>
   <content contentuid="h0365a5ccg5ec9g7487g0f4fga94912c1e111" version="1">Level 3: Viking Weapon Mastery</content>
   <content contentuid="h268f496ag5b58g49c9g3c99ga0cd4839f89f" version="1">If you have Weapon Mastery with a Battleaxe, Longsword, or Spear, you can add your Proficiency Bonus to a damage roll with that weapon.</content>
   <content contentuid="h4fa40dc4g9c70g921bg8267gaeb44665f760" version="1">Level 7: Savage Charge</content>
-  <content contentuid="h06128f4dg8b4fg7ee1gbb06gbcef6e2bdfac" version="1">As an Attack action, make a single melee attack. If the attack hits, you can use a Bonus Action to take the Dash action. Movement granted by this Dash action does not provoke Opportunity Attacks.</content>
+  <content contentuid="h06128f4dg8b4fg7ee1gbb06gbcef6e2bdfac" version="1">As an Attack action, make a single melee attack. If the attack hits, you can use a Bonus Action to take the &lt;LSTag Type="Spell" Tooltip="Shout_Dash"&gt;Dash&lt;/LSTag&gt; action. Movement granted by this Dash action does not provoke Opportunity Attacks.</content>
   <content contentuid="h765b9461g9506gb734gcb45gfb2796d10549" version="1">Savage Charge</content>
-  <content contentuid="h2ff7efe3g2f98g2386g3e31g16cac67905a4" version="1">You can use a Bonus Action to take the Dash action. Movement granted by this Dash action does not provoke Opportunity Attacks.</content>
+  <content contentuid="h2ff7efe3g2f98g2386g3e31g16cac67905a4" version="1">You can use a Bonus Action to take the &lt;LSTag Type="Spell" Tooltip="Shout_Dash"&gt;Dash&lt;/LSTag&gt; action. Movement granted by this Dash action does not provoke Opportunity Attacks.</content>
   <content contentuid="h8e6c5eccg23b9gc208g91f9gd9f773d69192" version="1">Level 10: Call of the Northlands</content>
   <content contentuid="h318d1b8eg0580g3d5cgacf3g81c76726bcd3" version="1">You are accustomed to the harsh conditions and vicious monsters of the Northlands. You have Resistance to Cold damage. You have Advantage on attack rolls against Dragons, Giants, and Large or bigger creatures.</content>
   <content contentuid="haa63297agabf6g8665gd863gccf514e607f5" version="1">Surprised</content>
   <content contentuid="h5a9a1666gd0c6gb6d5g9f5dga7c149830daa" version="1">Surprised</content>
-  <content contentuid="hd31e4d13g939ag101eg9e56g93956331fc9c" version="1">Each creature of your choice in a 5-foot-radius Sphere centered on a point within range must succeed on a Wisdom saving throw or have the Incapacitated condition until the end of its next turn, at which point it must repeat the save. If the target fails the second save, the target has the Unconscious condition for the duration. The spell ends on a target if it takes damage or someone within 5 feet of it takes an action to shake it out of the spell’s effect.</content>
+  <content contentuid="hd31e4d13g939ag101eg9e56g93956331fc9c" version="1">Each creature of your choice in a 5-foot-radius Sphere centered on a point within range must succeed on a Wisdom saving throw or have the Incapacitated condition until the end of its next turn, at which point it must repeat the save. If the target fails the second save, the target has the &lt;LSTag Type="Status" Tooltip="SLEEP"&gt;Unconscious&lt;/LSTag&gt; condition for the duration. The spell ends on a target if it takes damage or someone within 5 feet of it takes an action to shake it out of the spell’s effect.</content>
   <content contentuid="h1311946eg0f6eg3884gb766ga518b4884a4d" version="1">Surprised</content>
   <content contentuid="hdaea4751gf57bg4b28g0266g1e1630af444e" version="1">Cannot take &lt;LSTag Tooltip="Action"&gt;actions&lt;/LSTag&gt; or reactions.</content>
   <content contentuid="hebdf4ecbgcaabg1a81g42d5g735a9adcf945" version="5">Ice Elf</content>
@@ -4173,7 +4173,7 @@ The truth is barely any better. Devourers have spent their days consuming the fl
   <content contentuid="h2f0d1be4g0c48gc8dag5d46gb63613816d4b" version="1">Acid Blood</content>
   <content contentuid="hcae93600g722fg2de2g2f0fg60184d7ba2f0" version="1">For 1 minute, your blood becomes acidic. Each time a creature hits you with an attack while within 5 feet of you, it takes 2d6 Acid damage.</content>
   <content contentuid="hfb4b4347g41f8gc00fg03eagf4da78649103" version="1">Acumen</content>
-  <content contentuid="h55f2832cg60b4gcd10g11f2g30f9e75aa0b9" version="1">For 1 hour, you have Advantage on Insight, Intimidation and Persuasion check.</content>
+  <content contentuid="h55f2832cg60b4gcd10g11f2g30f9e75aa0b9" version="1">For 1 hour, you have Advantage on &lt;LSTag Type="Skills" Tooltip="Insight"&gt;Insight&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Intimidation"&gt;Intimidation&lt;/LSTag&gt; and &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Persuasion&lt;/LSTag&gt; check.</content>
   <content contentuid="h0332a04eg8429g6f00gada3gf49674ee7d97" version="1">Flight</content>
   <content contentuid="hd356b0cdg39beg042eg81feg07e80f4dede3" version="1">For 10 minutes, you grow leathery, feathery, or spectral wings from your back. You gain a Fly Speed equal to your Speed. You can’t benefit from this mutation while wearing Heavy armor.</content>
   <content contentuid="h2eddaae5gd399g869eg1cdag9e9a178e24d8" version="1">Infused</content>
@@ -4185,7 +4185,7 @@ The truth is barely any better. Devourers have spent their days consuming the fl
   <content contentuid="h9937e5c1g20b9gf010g9a9ag5025bbaebac2" version="1">Infused: Poison</content>
   <content contentuid="h6537ee84g1c9egec99gef96g0dc4308fed8c" version="1">Infused: Thunder</content>
   <content contentuid="h5eb0c1fbg30ddg233fgb6c8gefbdb310cc80" version="1">Invisibility</content>
-  <content contentuid="h9dbb965ag2bcegf72bg5bb2gc4f359dca388" version="1">For 10 minutes, you have the Invisible condition. This effect ends early if you dismiss it (no action required), or you attack or cast a spell.</content>
+  <content contentuid="h9dbb965ag2bcegf72bg5bb2gc4f359dca388" version="1">For 10 minutes, you have the &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt; condition. This effect ends early if you dismiss it (no action required), or you attack or cast a spell.</content>
   <content contentuid="hd01b6b25g66b1g66d5gcfaag271f0d12728a" version="1">Might</content>
   <content contentuid="h95627a66gf92eg2d99g31e2ge9a622a94222" version="1">For 1 minute, you have Advantage on Strength checks and saving throws. You also have Advantage on attack rolls using Strength, and you deal 1d6 extra damage to targets you hit with a Strength-based attack. The damage is the same type dealt by the attack.</content>
   <content contentuid="hf72e3943ga838g8a6eg437fgf3e3b4cf0bde" version="1">Regeneration</content>
@@ -4195,7 +4195,7 @@ The truth is barely any better. Devourers have spent their days consuming the fl
   <content contentuid="h18dea430g0a51g9ce2g9dc4g23ab4802a3ec" version="1">Acid Blood</content>
   <content contentuid="h5b8f7438g5b18gdde5gc4dfga7996a555481" version="1">For 1 minute, your blood becomes acidic. Each time a creature hits you with an attack while within 5 feet of you, it takes 2d6 Acid damage.</content>
   <content contentuid="h65822f22g5c0agbed4ga2dfg8ecf26db28f0" version="1">Acumen</content>
-  <content contentuid="h1865c71ag5eb9gf397gb7e8g3c4fd9f68123" version="1">For 1 hour, you have Advantage on Insight, Intimidation and Persuasion check.</content>
+  <content contentuid="h1865c71ag5eb9gf397gb7e8g3c4fd9f68123" version="1">For 1 hour, you have Advantage on &lt;LSTag Type="Skills" Tooltip="Insight"&gt;Insight&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Intimidation"&gt;Intimidation&lt;/LSTag&gt; and &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Persuasion&lt;/LSTag&gt; check.</content>
   <content contentuid="h803ef2b4g9d5fg6bf7gcdfbge5aa148caa9d" version="1">Flight</content>
   <content contentuid="hf0deee58g3421g39e9ge698g864491958c4a" version="1">For 10 minutes, you grow leathery, feathery, or spectral wings from your back. You gain a Fly Speed equal to your Speed. You can’t benefit from this mutation while wearing Heavy armor.</content>
   <content contentuid="hf927d573g7918gf498g9bedg56f31a1a2e84" version="1">Infused: Acid</content>
@@ -4220,7 +4220,7 @@ The truth is barely any better. Devourers have spent their days consuming the fl
   <content contentuid="h3f843ebcg8610ga557g917ag613b7d8001e7" version="1">Level 2: Fiendish Vigor</content>
   <content contentuid="h18b3f8afg5a28g03a8gaefdg39fb7c01b1f4" version="1">Prerequisite: Level 2+ Warlock</content>
   <content contentuid="he55ef41cg489dg2db3ga14bg076c3922f5be" version="1">Level 3: Acolyte of the Occult</content>
-  <content contentuid="h718ebc53g9616gcdc4ge2bcg846a784062a6" version="1">You gain proficiency in the Arcana skill.</content>
+  <content contentuid="h718ebc53g9616gcdc4ge2bcg846a784062a6" version="1">You gain proficiency in the &lt;LSTag Type="Skills" Tooltip="Arcana"&gt;Arcana&lt;/LSTag&gt; skill.</content>
   <content contentuid="h6d45afc8gf3a4g9b53ge55cgee1e8ff20f84" version="1">Level 3: Arcane Interference</content>
   <content contentuid="h5524efc2g3048g863bg33c2g18cfc27aae3e" version="1">When a creature you can see within 60 feet of you casts a spell or makes a spell attack, you can use Studied Response against that creature before the spell is cast.</content>
   <content contentuid="hb92bcd84g4cddg1b78g08b9g7f8b71b93820" version="1">Arcane Interference (Melee)</content>
@@ -4268,7 +4268,7 @@ The exact origin of their divine power confounds the elders of established relig
   <content contentuid="ha3545489g1d38g6fa3g0526g220227ae59ac" version="1">You can take a Bonus Action to magically create icy terrain on up to five spaces. The ice-covered spaces become Difficult Terrain and remain until the end of your next turn. When you take this Bonus Action, you may spend one or more Sorcery Points to freeze an additional five spaces for each Sorcery Point spent.</content>
   <content contentuid="h1e52530fgb6a1g58bcg28c8gf49958042c31" version="1">Level 3: Frost Spells</content>
   <content contentuid="h78ec0f4cgdceeg4a48gd10ag8d7fa8a15f49" version="1">When you reach a Sorcerer level specified in the Frost Spells table, you thereafter always have the listed spells prepared. At 3rd level, you learn Blindness, Ice Knife, Misty Step, and Sleep. At 5th level, you add Sleet Storm and Slow. At 7th level, you gain Fire Shield and Ice Storm. Finally, at 9th level, you can cast Cone of Cold and Conjure Elemental.</content>
-  <content contentuid="h633e7853gfe5cgc83fg46c5g12d2c8161229" version="2">At 3rd level, you learn Blindness, Ice Knife, Misty Step, and Sleep. At 5th level, you add Sleet Storm and Slow. At 7th level, you gain Fire Shield and Ice Storm. Finally, at 9th level, you can cast Cone of Cold and Conjure Elemental.</content>
+  <content contentuid="h633e7853gfe5cgc83fg46c5g12d2c8161229" version="2">At 3rd level, you learn &lt;LSTag Type="Spell" Tooltip="Target_Blindness"&gt;Blindness&lt;/LSTag&gt;, Ice Knife, Misty Step, and Sleep. At 5th level, you add Sleet Storm and Slow. At 7th level, you gain Fire Shield and Ice Storm. Finally, at 9th level, you can cast Cone of Cold and Conjure Elemental.</content>
   <content contentuid="he29b881cg8be9ge597gaa47ge013dbcb923e" version="1">Level 3: Frozen Body</content>
   <content contentuid="h4d2eb6abgde1bg02e5g7229g271d5c3cc35b" version="1">Your skin takes on a faintly ice-like, crystalline glow. Your Hit Point maximum increases by 3, and it increases by 1 whenever you gain another Sorcerer level. In addition, Difficult Terrain composed of ice or snow doesn’t cost you extra movement, and when you walk on ice, you only spend 1 foot of movement for every 2 feet you move.</content>
   <content contentuid="h41c12c6fg7222ge59egf356g102fa92de375" version="1">Level 6: Cold-Hearted</content>
@@ -4341,10 +4341,10 @@ Prowling Retribution. Immediately after a creature you can see within 5 feet of 
 Unnerving Aura. When you transform and at the start of each of your subsequent turns, each creature of your choice in a 10-foot Emanation originating from you makes a Wisdom saving throw against your spell save DC. On a failed save, a creature has the Frightened condition until the start of your next turn.</content>
   <content contentuid="h197a4fbbg54d8g3303g20b2ga713257e8f7a" version="1">You gain a bonus to Constitution saving throws equal to your Wisdom modifier (minimum of +1).
 
-In addition, once per turn when you hit a creature with an attack roll while you are transformed using Wrath of the Wild, you regain a number of Hit Points equal to 1d10 plus your Wisdom modifier, provided you are Bloodied when you hit.</content>
-  <content contentuid="hfcbd3784g4436g3a40g1260g63eb8006c7fa" version="2">Your dedication to wild eldritch beings alters you further. When transformed using Wrath of the Wild, you gain the following additional benefits.
+In addition, once per turn when you hit a creature with an attack roll while you are transformed using &lt;LSTag Type="Passive" Tooltip="HollowWarden_3_WrathOfTheWild"&gt;Wrath of the Wild&lt;/LSTag&gt;, you regain a number of Hit Points equal to 1d10 plus your Wisdom modifier, provided you are Bloodied when you hit.</content>
+  <content contentuid="hfcbd3784g4436g3a40g1260g63eb8006c7fa" version="2">Your dedication to wild eldritch beings alters you further. When transformed using &lt;LSTag Type="Passive" Tooltip="HollowWarden_3_WrathOfTheWild"&gt;Wrath of the Wild&lt;/LSTag&gt;, you gain the following additional benefits.
 
-Menacing Aura. When a creature fails its saving throw against your Unnerving Aura, it also can’t regain Hit Points or take Reactions until the start of your next turn.
+Menacing Aura. When a creature fails its saving throw against your &lt;LSTag Type="Status" Tooltip="UNNERVING_AURA"&gt;Unnerving Aura&lt;/LSTag&gt;, it also can’t regain Hit Points or take Reactions until the start of your next turn.
 
 Ominous Strikes. When you hit a creature that has the Frightened condition with an attack roll, that attack deals extra damage equal to your Wisdom modifier.</content>
   <content contentuid="h656241edg097dg71d1gc1ddg80f0965b5079" version="1">Wrath of the Wild</content>
@@ -4375,8 +4375,8 @@ Unnerving Aura. When you transform and at the start of each of your subsequent t
 
 Frightful Avatar. Once per turn, when you hit a creature with an attack roll, you can force it to make a Wisdom saving throw against your spell save DC. On a failed save, the target has the Frightened condition until the end of your next turn.</content>
   <content contentuid="hcd558b81gae7eg26dag6eaegf0f7e3dd0197" version="1">Level 3: Undead Spells</content>
-  <content contentuid="h72a8bf1agc8fbgec94g5bd1g5c0893342c80" version="1">The magic of your patron ensures you always have certain spells ready; when you reach a Warlock level specified in the Undead Spells table, you thereafter always have the listed spells prepared. At 3rd level, you learn Bane, Blindness, Phantasmal Force, and Ray of Sickness. At 5th level, you learn Speak with Dead and Animate Dead. At 7th level, you learn Greater Invisibility and Phantasmal Killer. At 9th level, you learn Danse Macabre and Cloudkill.</content>
-  <content contentuid="h423f4d8eg647cg79b9g302bg9ad97549087a" version="2">At 3rd level, you learn Bane, Blindness, Phantasmal Force, and Ray of Sickness. At 5th level, you learn Speak with Dead and Animate Dead. At 7th level, you learn Greater Invisibility and Phantasmal Killer. At 9th level, you learn Danse Macabre and Cloudkill.</content>
+  <content contentuid="h72a8bf1agc8fbgec94g5bd1g5c0893342c80" version="1">The magic of your patron ensures you always have certain spells ready; when you reach a Warlock level specified in the Undead Spells table, you thereafter always have the listed spells prepared. At 3rd level, you learn &lt;LSTag Type="Spell" Tooltip="Target_Bane"&gt;Bane&lt;/LSTag&gt;, &lt;LSTag Type="Spell" Tooltip="Target_Blindness"&gt;Blindness&lt;/LSTag&gt;, Phantasmal Force, and Ray of Sickness. At 5th level, you learn Speak with Dead and &lt;LSTag Type="Spell" Tooltip="Target_AnimateDead"&gt;Animate Dead&lt;/LSTag&gt;. At 7th level, you learn &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;Greater Invisibility&lt;/LSTag&gt; and Phantasmal Killer. At 9th level, you learn Danse Macabre and Cloudkill.</content>
+  <content contentuid="h423f4d8eg647cg79b9g302bg9ad97549087a" version="2">At 3rd level, you learn Bane, &lt;LSTag Type="Spell" Tooltip="Target_Blindness"&gt;Blindness&lt;/LSTag&gt;, Phantasmal Force, and Ray of Sickness. At 5th level, you learn Speak with Dead and Animate Dead. At 7th level, you learn &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;Greater Invisibility&lt;/LSTag&gt; and Phantasmal Killer. At 9th level, you learn Danse Macabre and Cloudkill.</content>
   <content contentuid="h51d8435ag421eg4abdg2702ga3868c2dab5c" version="1">Level 6: Grave Touched</content>
   <content contentuid="h9978d0deg7d77g5755g43fbg0caf50e3b407" version="2">Your patron’s powers have a profound effect on your body and magic, granting you the following benefits.
 
@@ -4390,7 +4390,7 @@ Undead Endurance. You don’t need to sleep, and magic can’t put you to sleep.
 
 Necrotic Resilience. You have Immunity to Necrotic damage.</content>
   <content contentuid="hcaaac561g47fbgc64dga290gc1f58fa033fa" version="1">Astral Flood</content>
-  <content contentuid="h08797ed7gc753g8f41gd903g4ec54ed567d1" version="1">You channel energy from the Astral Sea to unleash a torrent of magic from you in a 30-foot Cone. Each creature in the Cone must succeed on a Dexterity saving throw or take Radiant damage. The target can see only within 15 feet of itself, and it has the Blinded condition for everything beyond that distance until the end of your next turn.</content>
+  <content contentuid="h08797ed7gc753g8f41gd903g4ec54ed567d1" version="1">You channel energy from the Astral Sea to unleash a torrent of magic from you in a 30-foot Cone. Each creature in the Cone must succeed on a Dexterity saving throw or take Radiant damage. The target can see only within 15 feet of itself, and it has the &lt;LSTag Type="Status" Tooltip="BLINDED"&gt;Blinded&lt;/LSTag&gt; condition for everything beyond that distance until the end of your next turn.</content>
   <content contentuid="h7b203ccagf3bbgbc50ge697g2f7d6dd55d71" version="1">Usable Classes: Sorcerer, Wizard</content>
   <content contentuid="h5cc2b487g9e1cg67f3gff45gb8bebf140d50" version="1">Usable Classes: Sorcerer, Wizard</content>
   <content contentuid="h81b6ff86g5390gac9bg1d77ga53e64111601" version="1">Usable Classes: Sorcerer, Wizard</content>
@@ -4448,7 +4448,7 @@ Necrotic Resilience. You have Immunity to Necrotic damage.</content>
   <content contentuid="ha989ddfeg14aege15egc09fgf298fc8f086e" version="1">Great Old One Patron</content>
   <content contentuid="h3504f51eg1ac0gd563g881eg515b53b1f37b" version="1">When you choose this subclass, you might bind yourself to an unspeakable being from the Far Realm or an elder god—a being such as Tharizdun, the Chained God; Zargon, the Returner; Hadar, the Dark Hunger; or Great Cthulhu. Or you might invoke several entities without yoking yourself to one. The motives of these beings are incomprehensible, and the Great Old One might be indifferent to your existence. But the secrets you’ve learned nevertheless allow you to draw strange magic from it.</content>
   <content contentuid="h68dcfb27g52ddg20aag7977g147e317f34ce" version="1">Level 3: Hexblade Spells</content>
-  <content contentuid="h4336900ag6e5egc73bgadb8g0a8300eeb536" version="1">The magic of your patron ensures you always have certain spells prepared. When you reach a Warlock level specified in the Hexblade Spells table, you thereafter always have the listed spells prepared. At 3rd level, you learn Arcane Vigor, Hex, Magic Weapon, Shield, Wrathful Smite. At 5th level, you learn Bestow Curse and Conjure Barrage. At 7th level, you learn Freedom of Movement, Staggering Smite. At 9th level, you learn Steel Wind Strike.</content>
+  <content contentuid="h4336900ag6e5egc73bgadb8g0a8300eeb536" version="1">The magic of your patron ensures you always have certain spells prepared. When you reach a Warlock level specified in the Hexblade Spells table, you thereafter always have the listed spells prepared. At 3rd level, you learn &lt;LSTag Type="Spell" Tooltip="Shout_ArcaneVigor"&gt;Arcane Vigor&lt;/LSTag&gt;, Hex, Magic Weapon, Shield, Wrathful Smite. At 5th level, you learn Bestow Curse and Conjure Barrage. At 7th level, you learn Freedom of Movement, Staggering Smite. At 9th level, you learn Steel Wind Strike.</content>
   <content contentuid="h6b8ec4b1g6350g0a0ag1d7dgc74d66ad8dd7" version="1">At 3rd level, you learn Arcane Vigor, Hex, Magic Weapon, Shield, Wrathful Smite. At 5th level, you learn Bestow Curse and Conjure Barrage. At 7th level, you learn Freedom of Movement, Staggering Smite. At 9th level, you learn Steel Wind Strike.</content>
   <content contentuid="hfa17cac1gac88g9d72gf29eg0946ab8c0bb4" version="1">Level 3: Hexblade Manifest</content>
   <content contentuid="ha92a78f3ge96agd47egb8ddg6ad716d3cc56" version="3">Hexblade's Curse. You can cast Hex without expending a spell slot a number of times equal to your Charisma modifier (minimum of once), and you regain all expended uses when you finish a Long Rest. When you cast Hex, a spectral weapon resembling your patron orbits the cursed target.
@@ -4625,7 +4625,7 @@ If you hit a creature with this weapon and deal damage to it, you can reduce its
 
 If you hit a creature with this weapon and deal damage to the creature, you have Advantage on your next attack roll against that creature before the end of your next turn.</content>
   <content contentuid="heb62505ag46b9gede3gde91gf79191d5fe3f" version="1">Level 3: Umbral Sight</content>
-  <content contentuid="h69aa6922g1e3fg07e9g5e91g36b8b2c05d1e" version="2">Once per turn, when you move into a Heavily or Lightly Obscured area, you gain the Invisible condition.</content>
+  <content contentuid="h69aa6922g1e3fg07e9g5e91g36b8b2c05d1e" version="2">Once per turn, when you move into a Heavily or Lightly Obscured area, you gain the &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt; condition.</content>
   <content contentuid="h340e5304g5b60g19d5gdfcegce1b33d1ff16" version="7">Turn off  "&lt;LSTag Type="Image" Info="TutorialDualWieldToggle"/&gt;Toggle Dual Wielding"</content>
   <content contentuid="had2ab3bfgf4fbga6e6gecbdgd688b4b2e4e0" version="2">Slasher: Enhanced Critical</content>
   <content contentuid="hb9a7c09eg9f65g5801gb3e4gb060b99c7378" version="1">When you score a Critical Hit that deals Slashing damage to a creature, it has Disadvantage on attack rolls until the start of your next turn.</content>
@@ -4638,8 +4638,8 @@ If you hit a creature with this weapon and deal damage to the creature, you have
   <content contentuid="h80d2cf8bgc729g9a24gbc58gb659d3b9da3a" version="1">Mind</content>
   <content contentuid="h8a6990cbg9b40g71f3gb9cfg5c82ea25fcf2" version="1">The Mind Domain celebrates the power of the mortal mind, channeling psychic energy to protect the faithful and smite your enemies. While this is most often associated with the Path of Light or the Riedran Path of Inspiration, followers of the daelkyr can also master this power. Visions of Xoriat can drive a priest to madness, but they can also reveal deadly secrets of the mind.</content>
   <content contentuid="h72fe5c98g4eeagbdcfg176cg9e7d2200729b" version="1">Level 3: Mind Domain Spells</content>
-  <content contentuid="hd98d7d87g77cegbc88gd214g64ac7bacec24" version="1">Your connection to this divine domain ensures you always have certain spells ready. When you reach a Cleric level specified in the Mind Domain Spells table, you thereafter always have the listed spells prepared. At 3rd level they learn Command, Detect Thoughts, Dissonant Whispers, and Mind Spike; at 5th level, Counterspell and Fear; at 7th level, Confusion and Phantasmal Killer; and at 9th level, Synaptic Static and Telekinesis.</content>
-  <content contentuid="h793cd839gb6abg5b14g2409gcd0bd8f9ce42" version="1">At 3rd level they learn Command, Detect Thoughts, Dissonant Whispers, and Mind Spike; at 5th level, Counterspell and Fear; at 7th level, Confusion and Phantasmal Killer; and at 9th level, Synaptic Static and Telekinesis.</content>
+  <content contentuid="hd98d7d87g77cegbc88gd214g64ac7bacec24" version="1">Your connection to this divine domain ensures you always have certain spells ready. When you reach a Cleric level specified in the Mind Domain Spells table, you thereafter always have the listed spells prepared. At 3rd level they learn Command, Detect Thoughts, Dissonant Whispers, and Mind Spike; at 5th level, Counterspell and Fear; at 7th level, &lt;LSTag Type="Spell" Tooltip="Target_Confusion"&gt;Confusion&lt;/LSTag&gt; and Phantasmal Killer; and at 9th level, Synaptic Static and Telekinesis.</content>
+  <content contentuid="h793cd839gb6abg5b14g2409gcd0bd8f9ce42" version="1">At 3rd level they learn Command, Detect Thoughts, Dissonant Whispers, and Mind Spike; at 5th level, Counterspell and Fear; at 7th level, &lt;LSTag Type="Spell" Tooltip="Target_Confusion"&gt;Confusion&lt;/LSTag&gt; and Phantasmal Killer; and at 9th level, Synaptic Static and Telekinesis.</content>
   <content contentuid="h8f6de0c2g375fgd164gdd46g3b76457a3d70" version="1">Level 3: Psychic Feedback</content>
   <content contentuid="h5360cb80gee7ag0e61g2927g4eace8e2c5e6" version="2">When a creature you can see within 30 feet of yourself succeeds on a saving throw, you can take a Reaction and expend a use of your Channel Divinity to impose Disadvantage on the saving throw, prying into their mind before they succeed or fail.</content>
   <content contentuid="h65dab31ag9d8cg8927g3507g782f6b5249c9" version="1">Level 3: Psychic Force</content>
@@ -4673,8 +4673,8 @@ You and your allies in the projection gain a +2 bonus to Intelligence, Wisdom, a
   <content contentuid="h1498d59bg1126gb9c5gd9b1ga55c4cbb3816" version="1">Once per turn when you hit a creature with your pact weapon, you can expend a Pact Magic spell slot to deal an extra 1d8 Force damage to the target, plus another 1d8 per level of the spell slot, and you can give the target the Prone condition if it is Huge or smaller.</content>
   <content contentuid="h91a9a031gbb78g3004g2f6cg6dcdb8f2cea3" version="1">You can use Two-Weapon Fighting even if your weapons aren't &lt;LSTag Tooltip="Light"&gt;Light&lt;/LSTag&gt;. You cannot dual-wield &lt;LSTag Tooltip="TwoHanded"&gt;Two-Handed&lt;/LSTag&gt; weapons.&lt;br&gt;&lt;br&gt;When you take the Attack action on your turn and attack with a melee weapon, you can make one Off-Hand Attack as a Bonus Action later on the same turn. If you have mastered the Nick property and have a Nick weapon equipped in your off hand, you can make up to two Off-Hand Attacks per turn.</content>
   <content contentuid="h7f4aa580ga87dg16dcgfbe8g89f017ded271" version="1">Level 3: Shadow Spells</content>
-  <content contentuid="h822a72b8g17f5g73a6gd5f7g245ac996eb94" version="1">When you reach a Sorcerer level specified in the Shadow Spells table, you thereafter always have the listed spells prepared. Shadow Magic sorcerers gain additional spells at certain levels: Bane, Darkness, Inflict Wounds, and Pass Without Trace at 3rd level; Hunger of Hadar and Fear at 5th level; Greater Invisibility and Phantasmal Killer at 7th level; and Contagion and Cloudkill at 9th level.</content>
-  <content contentuid="hce90f19eg2ee2g0ff4g4c21g7ebf85d46c9d" version="1">Shadow Magic sorcerers gain additional spells at certain levels: Bane, Darkness, Inflict Wounds, and Pass Without Trace at 3rd level; Hunger of Hadar and Fear at 5th level; Greater Invisibility and Phantasmal Killer at 7th level; and Contagion and Cloudkill at 9th level.</content>
+  <content contentuid="h822a72b8g17f5g73a6gd5f7g245ac996eb94" version="1">When you reach a Sorcerer level specified in the Shadow Spells table, you thereafter always have the listed spells prepared. Shadow Magic sorcerers gain additional spells at certain levels: &lt;LSTag Type="Spell" Tooltip="Target_Bane"&gt;Bane&lt;/LSTag&gt;, Darkness, Inflict Wounds, and Pass Without Trace at 3rd level; Hunger of Hadar and Fear at 5th level; &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;Greater Invisibility&lt;/LSTag&gt; and Phantasmal Killer at 7th level; and &lt;LSTag Type="Spell" Tooltip="Target_Contagion"&gt;Contagion&lt;/LSTag&gt; and Cloudkill at 9th level.</content>
+  <content contentuid="hce90f19eg2ee2g0ff4g4c21g7ebf85d46c9d" version="1">Shadow Magic sorcerers gain additional spells at certain levels: Bane, Darkness, Inflict Wounds, and Pass Without Trace at 3rd level; Hunger of Hadar and Fear at 5th level; &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;Greater Invisibility&lt;/LSTag&gt; and Phantasmal Killer at 7th level; and Contagion and Cloudkill at 9th level.</content>
   <content contentuid="h312226b3g88ffg25afg2137g749c468fee54" version="1">Level 3: Eyes of the Dark</content>
   <content contentuid="ha1f41cf1g38dagde18ga234gcff8d509b5e3" version="1">Level 3: Strength of the Grave</content>
   <content contentuid="h8169cd0cg492cg6dbeg7bafg507ce72f8ac4" version="1">Shadow Sorcery</content>
@@ -4752,8 +4752,8 @@ Whenever you cast an Abjuration spell with a spell slot, the ward regains a numb
   <content contentuid="h21e9c371g94d2g99bbgc117g1f69a24cfd8a" version="1">Recharge Arcane Ward</content>
   <content contentuid="h441c9c45ge8e7g3d2cg79e6g8a57eab6e20d" version="1">You can expend a spell slot, and the ward regains a number of Hit Points equal to twice the level of the spell slot expended.</content>
   <content contentuid="h19c5b950gb887g4a56g312cga3c9a0b8839a" version="1">Level 6: Projected Ward</content>
-  <content contentuid="h173a0fccg668ag5a93gc996gfe83b0867a07" version="1">When a creature that you can see within 30 feet of yourself takes damage, you can take a Reaction to cause your Arcane Ward to absorb that damage.</content>
-  <content contentuid="hf1f2ce33g9f28ga79dg8ad9g713bd9d1afd1" version="1">When a creature that you can see within 30 feet of yourself takes damage, you can take a Reaction to cause your Arcane Ward to absorb that damage.</content>
+  <content contentuid="h173a0fccg668ag5a93gc996gfe83b0867a07" version="1">When a creature that you can see within 30 feet of yourself takes damage, you can take a Reaction to cause your &lt;LSTag Type="Passive" Tooltip="ArcaneWard"&gt;Arcane Ward&lt;/LSTag&gt; to absorb that damage.</content>
+  <content contentuid="hf1f2ce33g9f28ga79dg8ad9g713bd9d1afd1" version="1">When a creature that you can see within 30 feet of yourself takes damage, you can take a Reaction to cause your &lt;LSTag Type="Passive" Tooltip="ArcaneWard"&gt;Arcane Ward&lt;/LSTag&gt; to absorb that damage.</content>
   <content contentuid="h288cd5f8gfde5gf844g35b4g78176c8d8034" version="1">Level 10: Improved Abjuration</content>
   <content contentuid="h9d3fbbaegc6b1gf48egd8c4gef06e95785f3" version="1">Each time you take a &lt;LSTag Tooltip="ShortRest"&gt;Short Rest&lt;/LSTag&gt;, your &lt;LSTag Type="Passive" Tooltip="ArcaneWard"&gt;Arcane Ward&lt;/LSTag&gt; is fully restored.</content>
   <content contentuid="h4b6ab214gd4f9gba28g0fb5gc087fbca986d" version="1">Devastator: Unarmed Attack</content>
@@ -4812,23 +4812,23 @@ When you cast this spell, you can designate creatures to be unaffected by it.</c
   <content contentuid="haac8d098g36f5gfad0g0c19g710686be3050" version="1">Aganazzar's Scorcher</content>
   <content contentuid="h05279eecg66b6g48b2gd7bbg31b8b9364190" version="1">A line of roaring flame 30 feet long and 5 feet wide emanates from you in a direction you choose. Each creature in the line must make a Dexterity saving throw. A creature takes fire damage on a failed save, or half as much damage on a successful one.</content>
   <content contentuid="hd072401cgab74ga74bgb28egccb3e4a6554d" version="1">Cloak of Shadow</content>
-  <content contentuid="h23041527g684fg9b54gfd8bgbc94bca6aa62" version="1">You cloak yourself in shadow, giving you advantage on Dexterity (Stealth) checks against creatures that rely on sight.</content>
+  <content contentuid="h23041527g684fg9b54gfd8bgbc94bca6aa62" version="1">You cloak yourself in shadow, giving you advantage on Dexterity (&lt;LSTag Type="Skills" Tooltip="Stealth"&gt;Stealth&lt;/LSTag&gt;) checks against creatures that rely on sight.</content>
   <content contentuid="hc9492c94g19bfg3230gbfc3g6cf10c6d02e5" version="1">Cloak of Shadow</content>
-  <content contentuid="h8dbcd1e2ga506gd79fg540bgdeebf6743060" version="1">You cloak yourself in shadow, giving you advantage on Dexterity (Stealth) checks against creatures that rely on sight.</content>
+  <content contentuid="h8dbcd1e2ga506gd79fg540bgdeebf6743060" version="1">You cloak yourself in shadow, giving you advantage on Dexterity (&lt;LSTag Type="Skills" Tooltip="Stealth"&gt;Stealth&lt;/LSTag&gt;) checks against creatures that rely on sight.</content>
   <content contentuid="h954ddf9fg7f78ge82dg57c0gb1a304bf4d54" version="1">Fire Rune</content>
   <content contentuid="h8756f6c6ga536g0a7agc01agf500547496f2" version="1">You touch a melee weapon and place a magical effect into it, creating a visible rune etched into the weapon. Attacks made by the invoked weapon deal an extra 1d8 Fire damage on a hit.</content>
   <content contentuid="h7db07aaegcba0g874eg8391ge8926782e7f8" version="1">Fire Rune</content>
   <content contentuid="h241ed709g7588g2cc5g9cd2gbc1ec16c5753" version="1">Attacks made by the invoked weapon deal an extra 1d8 Fire damage on a hit.</content>
   <content contentuid="h06dbb138g6afagfebbg9a03gd5d229bb475e" version="1">Dazing Blast</content>
-  <content contentuid="h36e08fceg5a47gf889gc415g5a67ba284ba1" version="1">A wave of force leaves your palms, targeting a creature within range. The target makes a Constitution saving throw. On a failed save, the creature takes 2d6 Force damage and has the Stunned condition until the end of its next turn. On a successful save, the creature takes the damage only.</content>
+  <content contentuid="h36e08fceg5a47gf889gc415g5a67ba284ba1" version="1">A wave of force leaves your palms, targeting a creature within range. The target makes a Constitution saving throw. On a failed save, the creature takes 2d6 Force damage and has the &lt;LSTag Type="Status" Tooltip="STUNNED"&gt;Stunned&lt;/LSTag&gt; condition until the end of its next turn. On a successful save, the creature takes the damage only.</content>
   <content contentuid="h1d86fe95gbfdbg4380gabf5g485af2f71992" version="1">Level 3: Shadow Domain Spells</content>
-  <content contentuid="h7b73f5fagb632g4dd6gbb1bg52e10cb075ff" version="1">Your connection to this divine domain ensures you always have certain spells ready. When you reach a Cleric level specified in the Shadow Domain Spells table, you thereafter always have the listed spells prepared. The Shadow Domain grants the following spells as you gain Cleric levels: Bane, False Life, Blindness, and Darkness at 3rd level; Blink and Fear at 5th level; Black Tentacles and Greater Invisibility at 7th level; and Cone of Cold and Dream at 9th level.</content>
-  <content contentuid="hb05d9f4bgc914g4d44g95b9ga646b28fd85b" version="1">The Shadow Domain grants the following spells as you gain Cleric levels: Bane, False Life, Blindness, and Darkness at 3rd level; Blink and Fear at 5th level; Black Tentacles and Greater Invisibility at 7th level; and Cone of Cold and Dream at 9th level.</content>
+  <content contentuid="h7b73f5fagb632g4dd6gbb1bg52e10cb075ff" version="1">Your connection to this divine domain ensures you always have certain spells ready. When you reach a Cleric level specified in the Shadow Domain Spells table, you thereafter always have the listed spells prepared. The Shadow Domain grants the following spells as you gain Cleric levels: &lt;LSTag Type="Spell" Tooltip="Target_Bane"&gt;Bane&lt;/LSTag&gt;, False Life, &lt;LSTag Type="Spell" Tooltip="Target_Blindness"&gt;Blindness&lt;/LSTag&gt;, and Darkness at 3rd level; Blink and Fear at 5th level; Black Tentacles and &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;Greater Invisibility&lt;/LSTag&gt; at 7th level; and Cone of Cold and Dream at 9th level.</content>
+  <content contentuid="hb05d9f4bgc914g4d44g95b9ga646b28fd85b" version="1">The Shadow Domain grants the following spells as you gain Cleric levels: Bane, False Life, &lt;LSTag Type="Spell" Tooltip="Target_Blindness"&gt;Blindness&lt;/LSTag&gt;, and Darkness at 3rd level; Blink and Fear at 5th level; Black Tentacles and &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;Greater Invisibility&lt;/LSTag&gt; at 7th level; and Cone of Cold and Dream at 9th level.</content>
   <content contentuid="h1064bb85gee8cg09fbge5ebg6e90aa761e30" version="1">Shadow Domain</content>
   <content contentuid="h904f48b3g5c0bg6e25g75bcg2b014d46c23f" version="2">Shadow</content>
   <content contentuid="h034102c0gf054g2c35ga023g5f4e2e8fbffd" version="1">The Shadow domain embraces the darkness that surrounds all things and manipulates the transitory gray that separates light from dark. Shadow domain clerics walk a subtle path, frequently changing allegiances and preferring to operate unseen.</content>
   <content contentuid="h52d0bda6g4b49g2a89gf69bg489e840efe5a" version="1">Level 3: Cover of Night</content>
-  <content contentuid="h5aa5a2a8gba10g31e1gabfeg038d2569ac84" version="1">You gain proficiency in the Stealth skill and darkvision. In addition, you can use a bonus action to Hide.</content>
+  <content contentuid="h5aa5a2a8gba10g31e1gabfeg038d2569ac84" version="1">You gain proficiency in the &lt;LSTag Type="Skills" Tooltip="Stealth"&gt;Stealth&lt;/LSTag&gt; skill and darkvision. In addition, you can use a bonus action to &lt;LSTag Type="Spell" Tooltip="Shout_Hide"&gt;Hide&lt;/LSTag&gt;.</content>
   <content contentuid="hb2f444e4g0325g881ag13bcgf25bad34406e" version="1">Level 3: Lengthen Shadow</content>
   <content contentuid="h69f399c6g8e60g3971g78a2gebd2397144ff" version="1">You can manipulate your own shadow to extend your reach. When you cast a cleric spell with a range of touch, your shadow can deliver the spell as if you had cast the spell. Your target must be within 15 feet of you, and you must be able to see the target. You can use this feature even if you are in an area where you cast no shadow.</content>
   <content contentuid="hb5ac88b0ga681g79ebg1b09g63b221dbec59" version="1">Level 3: Shadow Grasp</content>
@@ -4852,11 +4852,11 @@ When you cast this spell, you can designate creatures to be unaffected by it.</c
   <content contentuid="haf76903dg7bbdg5e64g7f90g970b37ad3960" version="1">Guiding Whispers. You know the Guidance cantrip. It has a range of 60 feet when you cast it.</content>
   <content contentuid="h86ac4829gb9e1g65b8gf4b3g9e412c0d7a5e" version="1">Guiding Whispers</content>
   <content contentuid="hf142ccaeg2d4cg6976g4ac2g7597d90fed0d" version="1">Level 3: Spirits from Beyond</content>
-  <content contentuid="hadba9481g03c7gb0e4g2fc9gf098670ca5a9" version="2">You can call forth spirits of the dead to empower you and your allies. When you take a Bonus Action to give a creature a Bardic Inspiration die, you can call forth the powers of a random spirit. To determine the spirit you channel, roll the Bardic Inspiration die and refer to the Spirits from Beyond table. The spirit remains channeled until you unleash it or until you finish a Long Rest.
+  <content contentuid="hadba9481g03c7gb0e4g2fc9gf098670ca5a9" version="2">You can call forth spirits of the dead to empower you and your allies. When you take a Bonus Action to give a creature a &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die, you can call forth the powers of a random spirit. To determine the spirit you channel, roll the Bardic Inspiration die and refer to the Spirits from Beyond table. The spirit remains channeled until you unleash it or until you finish a Long Rest.
 
 Controlled Channeling. As a Bonus Action, you can expend a use of your Bardic Inspiration and channel a specific spirit. When you do so, choose the spirit from the Spirits from Beyond table rather than rolling. The chosen spirit’s corresponding number must be less than or equal to the highest number on your Bardic Inspiration die; for example, if your Bardic Inspiration die is a d8, you can choose to channel any spirit up to (and including) the Shade.
 
-Unleashing a Spirit. As a Magic action, you can unleash one of your channeled spirits. Choose one creature you can see within 30 feet of yourself as the spirit’s target. The spirit then takes effect; if a spirit’s effect requires a saving throw, the DC equals your Bard spell save DC. This action allows you to actually use the spirit.</content>
+&lt;LSTag Type="Spell" Tooltip="Target_UnleashingASpirit"&gt;Unleashing a Spirit&lt;/LSTag&gt;. As a Magic action, you can unleash one of your channeled spirits. Choose one creature you can see within 30 feet of yourself as the spirit’s target. The spirit then takes effect; if a spirit’s effect requires a saving throw, the DC equals your Bard spell save DC. This action allows you to actually use the spirit.</content>
   <content contentuid="hc94fe18bg4a60g7150g9266g8db53b913dac" version="1">Spirits From Beyond</content>
   <content contentuid="h3b40a7b0g581fga77bg3d22g30944ffbaf78" version="1">Spirits From Beyond: Beloved</content>
   <content contentuid="hf382e28aged60gce44g754cg188b504d016d" version="1">Spirits From Beyond: Sharpshooter</content>
@@ -4868,16 +4868,16 @@ Unleashing a Spirit. As a Magic action, you can unleash one of your channeled sp
   <content contentuid="h8b0f281eg7854g1a32gf59fge016a5551f0b" version="1">Spirits From Beyond: Shade</content>
   <content contentuid="h1b99642bgb883g462cg638fg192cfcf25647" version="1">Spirits From Beyond: Arsonist</content>
   <content contentuid="h9329b80cg3c57g3510gedb5gde3327d9570b" version="1">Spirits From Beyond: Coward</content>
-  <content contentuid="hb5b80dd1g369bg905ag47a7g28e7465806d8" version="1">You can call forth spirits of the dead to empower you and your allies. When you take a Bonus Action to give a creature a Bardic Inspiration die, you can call forth the powers of a random spirit. To determine the spirit you channel, roll the Bardic Inspiration die and refer to the Spirits from Beyond table. The spirit remains channeled until you unleash it or until you finish a Long Rest.</content>
-  <content contentuid="hc7d9adccgd21cg6730g04c3g3a1c38c6c5a9" version="2">Beloved. The target regains Hit Points equal to a roll of your Bardic Inspiration die plus your Charisma modifier.</content>
-  <content contentuid="h5b47bba7gdab8g8410ga59dgef9c6100ab29" version="2">Sharpshooter. The target takes Force damage equal to a roll of your Bardic Inspiration die plus your Charisma modifier.</content>
-  <content contentuid="he73898ceg2342gac1agce15gffad564f5c59" version="2">Avenger. Until the end of your next turn, any creature that hits the target with a melee attack roll takes Force damage equal to a roll of your Bardic Inspiration die.</content>
+  <content contentuid="hb5b80dd1g369bg905ag47a7g28e7465806d8" version="1">You can call forth spirits of the dead to empower you and your allies. When you take a Bonus Action to give a creature a &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die, you can call forth the powers of a random spirit. To determine the spirit you channel, roll the Bardic Inspiration die and refer to the Spirits from Beyond table. The spirit remains channeled until you unleash it or until you finish a Long Rest.</content>
+  <content contentuid="hc7d9adccgd21cg6730g04c3g3a1c38c6c5a9" version="2">Beloved. The target regains Hit Points equal to a roll of your &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die plus your Charisma modifier.</content>
+  <content contentuid="h5b47bba7gdab8g8410ga59dgef9c6100ab29" version="2">Sharpshooter. The target takes Force damage equal to a roll of your &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die plus your Charisma modifier.</content>
+  <content contentuid="he73898ceg2342gac1agce15gffad564f5c59" version="2">Avenger. Until the end of your next turn, any creature that hits the target with a melee attack roll takes Force damage equal to a roll of your &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die.</content>
   <content contentuid="h7d06d7d0g728fgd57ag44f5g66f05c613163" version="3">Renegade. Until the end of its turn, the target can use its Reaction to teleport up to 30 feet to an unoccupied space it can see.</content>
   <content contentuid="h61deeb2fg018dgeadegdab2g65d4b9e1683a" version="2">Fortune Teller. The target has Advantage on D20 Tests until the start of your next turn.</content>
-  <content contentuid="h2bd86b9fg5a4bg7828gd29cg98815c2ef7d3" version="2">Wayfarer. The target gains Temporary Hit Points equal to a roll of your Bardic Inspiration die plus your Bard level. While the target has these Temporary Hit Points, its Speed increases by 10 feet.</content>
-  <content contentuid="h53224a2ag2d24g306bg844dge14be06ef6b9" version="2">Trickster. The target makes a Wisdom saving throw. On a failed save, the target takes Psychic damage equal to two rolls of your Bardic Inspiration die and has the Charmed condition until the start of your next turn. On a successful save, the target takes half as much damage only.</content>
-  <content contentuid="hcb079ee5g1c25gbdc5gf618gc2aef3acfd28" version="2">Shade. The target has the Invisible condition until the end of its next turn or until the target makes an attack roll, deals damage, or casts a spell. When the invisibility ends, each creature in a 5-foot Emanation originating from the target must succeed on a Constitution saving throw or take Necrotic damage equal to two rolls of your Bardic Inspiration die.</content>
-  <content contentuid="ha71f769bge1a3g46dfg432fga8899602df6a" version="2">Arsonist. The target makes a Dexterity saving throw, taking Fire damage equal to four rolls of your Bardic Inspiration die on a failed save or half as much damage on a successful one.</content>
+  <content contentuid="h2bd86b9fg5a4bg7828gd29cg98815c2ef7d3" version="2">Wayfarer. The target gains Temporary Hit Points equal to a roll of your &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die plus your Bard level. While the target has these Temporary Hit Points, its Speed increases by 10 feet.</content>
+  <content contentuid="h53224a2ag2d24g306bg844dge14be06ef6b9" version="2">Trickster. The target makes a Wisdom saving throw. On a failed save, the target takes Psychic damage equal to two rolls of your &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die and has the Charmed condition until the start of your next turn. On a successful save, the target takes half as much damage only.</content>
+  <content contentuid="hcb079ee5g1c25gbdc5gf618gc2aef3acfd28" version="2">Shade. The target has the &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt; condition until the end of its next turn or until the target makes an attack roll, deals damage, or casts a spell. When the invisibility ends, each creature in a 5-foot Emanation originating from the target must succeed on a Constitution saving throw or take Necrotic damage equal to two rolls of your &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die.</content>
+  <content contentuid="ha71f769bge1a3g46dfg432fga8899602df6a" version="2">Arsonist. The target makes a Dexterity saving throw, taking Fire damage equal to four rolls of your &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die on a failed save or half as much damage on a successful one.</content>
   <content contentuid="h373150f8gf513g0146g7190ge9494becea23" version="2">Coward. The target and each creature of your choice in a 30-foot Emanation originating from the target must succeed on a Wisdom saving throw or have the Frightened condition until the start of your next turn. While a creature is Frightened, its Speed is halved (round down), and it can take either an action or a Bonus Action, not both.</content>
   <content contentuid="hffce3b1cg9e68gb50cgbc7eg803cec074d21" version="1">Controlled Channeling</content>
   <content contentuid="h945acb09g1397g1556g11b6g3c002e37946c" version="1">Controlled Channeling: Beloved</content>
@@ -4890,18 +4890,18 @@ Unleashing a Spirit. As a Magic action, you can unleash one of your channeled sp
   <content contentuid="he31164f3gc7eeg457ag9c53ge89b52235660" version="1">Controlled Channeling: Shade</content>
   <content contentuid="hc2dbe1c0gf4a2g7ed0g532agdde0fc25cd5d" version="1">Controlled Channeling: Arsonist</content>
   <content contentuid="hff226ec3g9b2dg45b2g19dfg56c02c4af940" version="1">Controlled Channeling: Coward</content>
-  <content contentuid="hd0b1b087g7e7fg7cf3gdc0fg4b7196bb961f" version="1">As a Bonus Action, you can expend a use of your Bardic Inspiration and channel a specific spirit. When you do so, choose the spirit from the Spirits from Beyond table rather than rolling. The chosen spirit’s corresponding number must be less than or equal to the highest number on your Bardic Inspiration die; for example, if your Bardic Inspiration die is a d8, you can choose to channel any spirit up to (and including) the Shade.</content>
+  <content contentuid="hd0b1b087g7e7fg7cf3gdc0fg4b7196bb961f" version="1">As a Bonus Action, you can expend a use of your &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; and channel a specific spirit. When you do so, choose the spirit from the &lt;LSTag Type="Passive" Tooltip="Spirits_3_SpiritsFromBeyond"&gt;Spirits from Beyond&lt;/LSTag&gt; table rather than rolling. The chosen spirit’s corresponding number must be less than or equal to the highest number on your Bardic Inspiration die; for example, if your Bardic Inspiration die is a d8, you can choose to channel any spirit up to (and including) the Shade.</content>
   <content contentuid="h23b11d5dg4140gd4e3g0710ge0e1bf4a740e" version="1">Unleashing a Spirit</content>
   <content contentuid="h99fc91bfg4ca1g9784g96bege336a9f9cf88" version="1">As a Magic action, you can unleash one of your channeled spirits. Choose one creature you can see within 30 feet of yourself as the spirit’s target. The spirit then takes effect; if a spirit’s effect requires a saving throw, the DC equals your Bard spell save DC. This action allows you to actually use the spirit.</content>
-  <content contentuid="h809e5f68g6c1fg087fg4ebbgd6a42f20a3f2" version="1">The target regains Hit Points equal to a roll of your Bardic Inspiration die plus your Charisma modifier.</content>
-  <content contentuid="ha93da29dg5863g46a5gb636gdc16581b4520" version="1">The target takes Force damage equal to a roll of your Bardic Inspiration die plus your Charisma modifier.</content>
-  <content contentuid="h97319f1bgef21gc6f0g305bg9cc81c5b14c1" version="1">Until the end of your next turn, any creature that hits the target with a melee attack roll takes Force damage equal to a roll of your Bardic Inspiration die.</content>
+  <content contentuid="h809e5f68g6c1fg087fg4ebbgd6a42f20a3f2" version="1">The target regains Hit Points equal to a roll of your &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die plus your Charisma modifier.</content>
+  <content contentuid="ha93da29dg5863g46a5gb636gdc16581b4520" version="1">The target takes Force damage equal to a roll of your &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die plus your Charisma modifier.</content>
+  <content contentuid="h97319f1bgef21gc6f0g305bg9cc81c5b14c1" version="1">Until the end of your next turn, any creature that hits the target with a melee attack roll takes Force damage equal to a roll of your &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die.</content>
   <content contentuid="h6b7ca201g1238g4bbdg17feg37877398fd9e" version="2">Until the end of its turn, the target can use its Reaction to teleport up to 30 feet to an unoccupied space it can see.</content>
   <content contentuid="hf34a9c9bga45bgc852g5af5g53f40d5fc0f3" version="1">The target has Advantage on D20 Tests until the start of your next turn.</content>
-  <content contentuid="h3c143767g21a8g66bcg6a21gf96dcfb36b88" version="1">The target gains Temporary Hit Points equal to a roll of your Bardic Inspiration die plus your Bard level. While the target has these Temporary Hit Points, its Speed increases by 10 feet.</content>
-  <content contentuid="h8bd54844g8c51g684dg0147ga45b20304d23" version="1">The target makes a Wisdom saving throw. On a failed save, the target takes Psychic damage equal to two rolls of your Bardic Inspiration die and has the Charmed condition until the start of your next turn. On a successful save, the target takes half as much damage only.</content>
-  <content contentuid="h1558545egaf7dg1079g8177g9f6871b6f525" version="1">The target has the Invisible condition until the end of its next turn or until the target makes an attack roll, deals damage, or casts a spell. When the invisibility ends, each creature in a 5-foot Emanation originating from the target must succeed on a Constitution saving throw or take Necrotic damage equal to two rolls of your Bardic Inspiration die.</content>
-  <content contentuid="hec346c79gf7e0ga44egbc79gbe72af6c9ba3" version="1">The target makes a Dexterity saving throw, taking Fire damage equal to four rolls of your Bardic Inspiration die on a failed save or half as much damage on a successful one.</content>
+  <content contentuid="h3c143767g21a8g66bcg6a21gf96dcfb36b88" version="1">The target gains Temporary Hit Points equal to a roll of your &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die plus your Bard level. While the target has these Temporary Hit Points, its Speed increases by 10 feet.</content>
+  <content contentuid="h8bd54844g8c51g684dg0147ga45b20304d23" version="1">The target makes a Wisdom saving throw. On a failed save, the target takes Psychic damage equal to two rolls of your &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die and has the Charmed condition until the start of your next turn. On a successful save, the target takes half as much damage only.</content>
+  <content contentuid="h1558545egaf7dg1079g8177g9f6871b6f525" version="1">The target has the &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt; condition until the end of its next turn or until the target makes an attack roll, deals damage, or casts a spell. When the invisibility ends, each creature in a 5-foot Emanation originating from the target must succeed on a Constitution saving throw or take Necrotic damage equal to two rolls of your &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die.</content>
+  <content contentuid="hec346c79gf7e0ga44egbc79gbe72af6c9ba3" version="1">The target makes a Dexterity saving throw, taking Fire damage equal to four rolls of your &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die on a failed save or half as much damage on a successful one.</content>
   <content contentuid="h173fc315gc0d2g81edgd93dg3ddf2abd9626" version="1">The target and each creature of your choice in a 30-foot Emanation originating from the target must succeed on a Wisdom saving throw or have the Frightened condition until the start of your next turn. While a creature is Frightened, its Speed is halved (round down), and it can take either an action or a Bonus Action, not both.</content>
   <content contentuid="h7f175533g6214gdd3dg85abgf900f49f70ea" version="1">Unleashing a Spirit: Beloved</content>
   <content contentuid="h2d7ed16fgf4dag658eg9a3bg2d0403eee929" version="1">Unleashing a Spirit: Sharpshooter</content>
@@ -4931,7 +4931,7 @@ Spiritual Manifestation. You always have the Spirit Guardians spell prepared. In
   <content contentuid="h575cf64dg1928g3ab1g38b2gac008a149822" version="1">Wayfarer</content>
   <content contentuid="h9186b28dg0766gc68bg29a8ga4ca99c2272e" version="1">Gains Temporary Hit Points. While it has these Temporary Hit Points, its Speed increases by 10 feet.</content>
   <content contentuid="h35ce1531gbf74g63ebgb93dge033e33d1130" version="1">Shade</content>
-  <content contentuid="hf545430ag2493gc858g08d3g0bef38197077" version="1">Has the Invisible condition. When the invisibility ends, each creature in a 5-foot Emanation originating from the character must succeed on a Constitution saving throw or take Necrotic damage equal to two rolls of your Bardic Inspiration die.</content>
+  <content contentuid="hf545430ag2493gc858g08d3g0bef38197077" version="1">Has the &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt; condition. When the invisibility ends, each creature in a 5-foot Emanation originating from the character must succeed on a Constitution saving throw or take Necrotic damage equal to two rolls of your &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die.</content>
   <content contentuid="h4f8f14ccgd5a6gc212g98ebg59206e3227ef" version="1">Coward</content>
   <content contentuid="hc04acb85gbc27gf6ecga81eg712f62387e98" version="1">Speed is halved (round down), and it can take either an action or a Bonus Action, not both.</content>
   <content contentuid="h48078124g7f94gbb02g1bbeg8729dfed349b" version="1">Blade of Radiance</content>
@@ -4953,7 +4953,7 @@ In addition, whenever you kill an Aberration, Beast, Fiend, or Undead of CR 1/2 
   <content contentuid="h61182600gdefdg90cdg3670gd4d17060e741" version="2">Level 3: Armor of the Faithful</content>
   <content contentuid="h87a8aa38gfa6eg9164g4acbgf38e8e39787f" version="1">As a Reaction when a creature targets you with an attack, you can expend 1 Divine Point to force it to make a Wisdom saving throw. On a failed save, the attacker must choose a new target or the attack has no effect, and it can’t target you again until the start of your next turn. This feature does not protect you from areas of effect.</content>
   <content contentuid="h4786c94egf555g6fe0g55b0g55cb3a928893" version="2">Level 3: Divine Inspiration</content>
-  <content contentuid="h5d3f13dbgaaafgc317g4fb1ga68568021092" version="1">When you make an Intelligence (History or Religion) or Wisdom (Insight) check, you gain a bonus to the roll equal to your Wisdom modifier.</content>
+  <content contentuid="h5d3f13dbgaaafgc317g4fb1ga68568021092" version="1">When you make an Intelligence (&lt;LSTag Type="Skills" Tooltip="History"&gt;History&lt;/LSTag&gt; or &lt;LSTag Type="Skills" Tooltip="Religion"&gt;Religion&lt;/LSTag&gt;) or Wisdom (&lt;LSTag Type="Skills" Tooltip="Insight"&gt;Insight&lt;/LSTag&gt;) check, you gain a bonus to the roll equal to your Wisdom modifier.</content>
   <content contentuid="h797675dag18a1ge22agbb1bgb5b01c18fd4d" version="2">Level 3: Rend the Blasphemous</content>
   <content contentuid="h5b6f609dg9e15g8c7cg33f8gbe509d75e00e" version="1">After you take the Attack action with your sanctified blade, you can take a Bonus Action and expend 1 Divine Point to make an additional attack with it, gaining a bonus to the attack roll equal to your Wisdom modifier (minimum 1).</content>
   <content contentuid="h7aef76d5g0c5egb8cfg0085g9e626ecff011" version="1">Rend the Blasphemous</content>
@@ -4981,26 +4981,26 @@ In addition, whenever you kill an Aberration, Beast, Fiend, or Undead of CR 1/2 
   <content contentuid="h1f2a95a9gb577g787bgb156g888616ccad6a" version="1">Level 3: Mask of Civility</content>
   <content contentuid="h9bf00f77g7323g0f09g943dg0f62ae2d5816" version="1">Level 6: Brains and Brawn</content>
   <content contentuid="hcb5a649cg1519gbd23g0221g4d0efabd2166" version="1">Level 10: Cunning and Brutal</content>
-  <content contentuid="h19bace45g8db7g181dgc420ge0fc17190c49" version="2">When you activate your Rage, your countenance distorts and your body swells. Creatures that haven’t witnessed your transformation, now or previously, don’t recognize you. In addition, while your Rage is active, you gain the following benefits:
+  <content contentuid="h19bace45g8db7g181dgc420ge0fc17190c49" version="2">When you activate your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt;, your countenance distorts and your body swells. Creatures that haven’t witnessed your transformation, now or previously, don’t recognize you. In addition, while your Rage is active, you gain the following benefits:
 
 You can roll 1d8 in place of the normal damage of your Unarmed Strike.
 
 When you hit a creature with an Unarmed Strike, you can push it 10 feet or force the creature to make a Constitution saving throw (DC 8 plus your Strength modifier and your Proficiency Bonus). On a failed save, the creature has the Prone condition.
 
 When you make an Unarmed Strike, your reach is 5 feet greater than normal.</content>
-  <content contentuid="hb18ef098g90c9g4ad7gaf03g5aee30c02615" version="1">You are proficient in one of the following skills of your choice: Arcana, History, Investigation, Medicine, Nature, Persuasion, or Religion</content>
-  <content contentuid="hb0b38705ga312g7e31g9767g722d245f3d33" version="1">While your Rage is not active, you have Resistance to Psychic damage. While your Rage is active, you have Resistance to every damage type except Force and Psychic.</content>
-  <content contentuid="hcdd6b1c9gc361g1c98gc596g4eefab4fdf0f" version="1">While your Rage is not active, you can take the Disengage or Help action as a Bonus Action. While your Rage is active, your attack rolls with Unarmed Strikes can score a Critical Hit on a roll of 19 or 20 on the d20.</content>
+  <content contentuid="hb18ef098g90c9g4ad7gaf03g5aee30c02615" version="1">You are proficient in one of the following skills of your choice: &lt;LSTag Type="Skills" Tooltip="Arcana"&gt;Arcana&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="History"&gt;History&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Investigation"&gt;Investigation&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Medicine"&gt;Medicine&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Nature"&gt;Nature&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Persuasion&lt;/LSTag&gt;, or &lt;LSTag Type="Skills" Tooltip="Religion"&gt;Religion&lt;/LSTag&gt;</content>
+  <content contentuid="hb0b38705ga312g7e31g9767g722d245f3d33" version="1">While your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; is not active, you have Resistance to Psychic damage. While your Rage is active, you have Resistance to every damage type except Force and Psychic.</content>
+  <content contentuid="hcdd6b1c9gc361g1c98gc596g4eefab4fdf0f" version="1">While your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; is not active, you can take the Disengage or Help action as a Bonus Action. While your Rage is active, your attack rolls with Unarmed Strikes can score a Critical Hit on a roll of 19 or 20 on the d20.</content>
   <content contentuid="h954836cfg0b63g6106g5d15g224a3463e27e" version="1">Face of Rage: Push</content>
-  <content contentuid="h2c508ab1g6e88g9fc6g8d98gf93c24fc5e1a" version="1">When you activate your Rage, when you hit a creature with an Unarmed Strike, you can push it 10 feet.</content>
+  <content contentuid="h2c508ab1g6e88g9fc6g8d98gf93c24fc5e1a" version="1">When you activate your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt;, when you hit a creature with an Unarmed Strike, you can push it 10 feet.</content>
   <content contentuid="h534ed7cdg1c82g686bg5c11g853eb4fc79da" version="1">Face of Rage: Prone</content>
-  <content contentuid="h9ab20eb3gc598g3449gb504g354483f2972b" version="1">When you activate your Rage, when you hit a creature with an Unarmed Strike, you can force the creature to make a Constitution saving throw (DC 8 plus your Strength modifier and your Proficiency Bonus). On a failed save, the creature has the Prone condition.</content>
+  <content contentuid="h9ab20eb3gc598g3449gb504g354483f2972b" version="1">When you activate your &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt;, when you hit a creature with an Unarmed Strike, you can force the creature to make a Constitution saving throw (DC 8 plus your Strength modifier and your Proficiency Bonus). On a failed save, the creature has the Prone condition.</content>
   <content contentuid="hf0667bf6g77dagda24g515cg27017347e947" version="1">Path of the Berserker</content>
-  <content contentuid="h054c34e8gf7acg1ce5g9297g2f198a57cc90" version="2">Barbarians who walk the Path of the Berserker direct their Rage primarily toward violence. Their path is one of untrammeled fury, and they thrill in the chaos of battle as they allow their Rage to seize and empower them.</content>
+  <content contentuid="h054c34e8gf7acg1ce5g9297g2f198a57cc90" version="2">Barbarians who walk the Path of the Berserker direct their &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; primarily toward violence. Their path is one of untrammeled fury, and they thrill in the chaos of battle as they allow their &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; to seize and empower them.</content>
   <content contentuid="hfe2d7a7cg1f66g7b4cg4485g45ffc2e4f8ca" version="1">Path of the Wild Heart</content>
-  <content contentuid="h0a89d75bg6efag48a6gf526g8742bbe1176f" version="2">Barbarians who follow the Path of the Wild Heart view themselves as kin to animals. These Barbarians learn magical means to communicate with animals, and their Rage heightens their connection to animals as it fills them with supernatural might.</content>
+  <content contentuid="h0a89d75bg6efag48a6gf526g8742bbe1176f" version="2">Barbarians who follow the Path of the Wild Heart view themselves as kin to animals. These Barbarians learn magical means to communicate with animals, and their &lt;LSTag Type="Status" Tooltip="RAGE"&gt;Rage&lt;/LSTag&gt; heightens their connection to animals as it fills them with supernatural might.</content>
   <content contentuid="h20c62466g58aegc458g775bg12619ff97e87" version="1">Path of the Giant</content>
-  <content contentuid="haa843db4g20ebg9021gacedg3f8ada559a41" version="2">Barbarians who walk the Path of the Giant draw strength from the same primal forces as giants. As they rage, these barbarians surge with elemental power and grow in size, taking on forms that evoke the glory of giants. Some barbarians look like oversized versions of themselves, perhaps with a hint of elemental energy flaring in their eyes and around their weapons. Others transform more dramatically, taking on the appearance of an actual giant or a form similar to an Elemental, wreathed in fire, frost, or lightning.</content>
+  <content contentuid="haa843db4g20ebg9021gacedg3f8ada559a41" version="2">Barbarians who walk the Path of the Giant draw strength from the same primal forces as giants. As they &lt;LSTag Type="Status" Tooltip="RAGE"&gt;rage&lt;/LSTag&gt;, these barbarians surge with elemental power and grow in size, taking on forms that evoke the glory of giants. Some barbarians look like oversized versions of themselves, perhaps with a hint of elemental energy flaring in their eyes and around their weapons. Others transform more dramatically, taking on the appearance of an actual giant or a form similar to an Elemental, wreathed in fire, frost, or lightning.</content>
   <content contentuid="h64ffc9d5ga96fg168bg296eg9642cbd7f4b0" version="1">Path of Wild Magic</content>
   <content contentuid="h08c08b52g956bgcf55gaba1gfea165770305" version="2">Many places in the multiverse abound with beauty, intense emotion, and rampant magic; the Feywild, the Upper Planes, and other realms of supernatural power radiate with such forces and can profoundly influence people. As folk of deep feeling, barbarians are especially susceptible to these wild influences, with some barbarians being transformed by the magic. These magic-suffused barbarians walk the Path of Wild Magic. Elf, tiefling, aasimar, and genasi barbarians often seek this path, eager to manifest the otherworldly magic of their ancestors.</content>
   <content contentuid="h9c95882dg83f6g1bbdg05f2geae221b89b7a" version="1">False Life</content>
@@ -5018,13 +5018,13 @@ When you make an Unarmed Strike, your reach is 5 feet greater than normal.</cont
   <content contentuid="h5cfaf826gcbcdg6716gd3c9gb82508ad025d" version="1">With a short phrase of void speech, you gather writhing darkness around your hand. When you cast the spell, and as an action on subsequent turns, you can unleash a bolt of darkness at a target within range. Make a ranged spell attack. If your target is in dim light or darkness, you have advantage on the roll. On a hit, the target takes necrotic damage and is frightened of you until the start of your next turn.</content>
   <content contentuid="hfa2950d9g0184g255ag6ff3gfe24dbf54ebc" version="1">Void Strike</content>
   <content contentuid="h69e1f672gc48fg3f52g323bg3be6611e1538" version="1">Murder of Crows </content>
-  <content contentuid="ha5f5579fg9ce6ge4abg474ag9e80c16acfae" version="1">You summon and unleash a murder of deadly crows. Each creature of your choice in a 30-foot Cone originating from you makes a Dexterity saving throw. On a failed save, the target takes 5d6 Force damage and has the Blinded condition. On a successful save, it takes half as much damage only. A Blinded creature repeats the save at the end of each of its turns, ending the effect on itself on a success.</content>
+  <content contentuid="ha5f5579fg9ce6ge4abg474ag9e80c16acfae" version="1">You summon and unleash a murder of deadly crows. Each creature of your choice in a 30-foot Cone originating from you makes a Dexterity saving throw. On a failed save, the target takes 5d6 Force damage and has the &lt;LSTag Type="Status" Tooltip="BLINDED"&gt;Blinded&lt;/LSTag&gt; condition. On a successful save, it takes half as much damage only. A Blinded creature repeats the save at the end of each of its turns, ending the effect on itself on a success.</content>
   <content contentuid="h9652267bgde21g4799ga95ag6f6fadec6806" version="1">Murmurs of Doom</content>
   <content contentuid="h5ed5413eg93c7gb24cg21d8g7901b49c4c83" version="1">You begin a whispered dirge that is magically accompanied by the howling of spirits and other grim portents. For the duration, an aura radiates from you in a 30-foot Emanation. When you create the aura and at the start of each of your turns while it persists, you can choose one creature in it to make a Constitution saving throw. On a failure, the creature takes 3d8 Necrotic damage.</content>
   <content contentuid="h49cf69a9g3850ga86fg9854g543c73e1e561" version="1">Murmurs of Doom</content>
   <content contentuid="hea3f9087gcfa4gad7eg1453gcafb3a204579" version="1">For the duration, you can choose one creature in it to make a Constitution saving throw. On a failure, the creature takes 3d8 Necrotic damage.</content>
   <content contentuid="h95738422ged47g3260g1b9dg2cefcd3f0146" version="1">Searing Orb</content>
-  <content contentuid="hdf6371dcga18fg87bcgbe0dgf6e2f7928012" version="1">You create and hurl a pulsing orb of energy at one creature within range. Make a ranged spell attack against the target. On a hit, the target takes Radiant damage. Hit or miss, the orb then explodes in a flash of light. The target and each creature within 10 feet of it make a Constitution saving throw. On a failed save, a creature has the Blinded condition until the end of its next turn.</content>
+  <content contentuid="hdf6371dcga18fg87bcgbe0dgf6e2f7928012" version="1">You create and hurl a pulsing orb of energy at one creature within range. Make a ranged spell attack against the target. On a hit, the target takes Radiant damage. Hit or miss, the orb then explodes in a flash of light. The target and each creature within 10 feet of it make a Constitution saving throw. On a failed save, a creature has the &lt;LSTag Type="Status" Tooltip="BLINDED"&gt;Blinded&lt;/LSTag&gt; condition until the end of its next turn.</content>
   <content contentuid="h144827a5g121ag0953g6918gbec2aad13de2" version="1">Searing Orb</content>
   <content contentuid="hdfa4f375gf615g4ca4g83d9g72b194e8669b" version="1">Scroll of Cloak of Shadow</content>
   <content contentuid="h4787af58gb589g4278gafcfg39dfbb20933e" version="1">Scroll of Hell's Lash</content>
@@ -5215,10 +5215,10 @@ When you make an Unarmed Strike, your reach is 5 feet greater than normal.</cont
   <content contentuid="h76c410ccg5631g4bacg921eg33961cecb6b9" version="2">For the next minute, you can teleport up to 30 feet as a Bonus Action on each of your turns.</content>
   <content contentuid="h313de399g6ff6g4c30ga121gd02ae57ae801" version="2">For the next minute, you can teleport up to 30 feet as a Bonus Action on each of your turns.</content>
   <content contentuid="hbb61a1bfgd1cdg4166ga626g58ef98721406" version="2">For the next minute, you can teleport up to 30 feet as a Bonus Action on each of your turns.</content>
-  <content contentuid="hb3d1182cg5d54g444cgb977g26e77a6a099e" version="2">You have the Invisible condition for 1 minute. This invisibility ends on a creature immediately after it makes an attack roll, deals damage, or casts a spell.</content>
-  <content contentuid="h3f87293dg3247g4d73gb758gf7485044db3c" version="2">You have the Invisible condition for 1 minute. This invisibility ends on a creature immediately after it makes an attack roll, deals damage, or casts a spell.</content>
-  <content contentuid="hb4ffbe2cg154fg4614ga481g770425e23306" version="2">You have the Invisible condition for 1 minute. This invisibility ends on a creature immediately after it makes an attack roll, deals damage, or casts a spell.</content>
-  <content contentuid="h8382539fg0076g44d2gb673g042eb6831f24" version="2">You have the Invisible condition for 1 minute. This invisibility ends on a creature immediately after it makes an attack roll, deals damage, or casts a spell.</content>
+  <content contentuid="hb3d1182cg5d54g444cgb977g26e77a6a099e" version="2">You have the &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt; condition for 1 minute. This invisibility ends on a creature immediately after it makes an attack roll, deals damage, or casts a spell.</content>
+  <content contentuid="h3f87293dg3247g4d73gb758gf7485044db3c" version="2">You have the &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt; condition for 1 minute. This invisibility ends on a creature immediately after it makes an attack roll, deals damage, or casts a spell.</content>
+  <content contentuid="hb4ffbe2cg154fg4614ga481g770425e23306" version="2">You have the &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt; condition for 1 minute. This invisibility ends on a creature immediately after it makes an attack roll, deals damage, or casts a spell.</content>
+  <content contentuid="h8382539fg0076g44d2gb673g042eb6831f24" version="2">You have the &lt;LSTag Type="Status" Tooltip="INVISIBLE"&gt;Invisible&lt;/LSTag&gt; condition for 1 minute. This invisibility ends on a creature immediately after it makes an attack roll, deals damage, or casts a spell.</content>
   <content contentuid="h55adfd44g7c29g4b67g894fg9b98ff76115a" version="1">A spectral shield hovers near you for the next minute, granting you a +2 bonus to AC and immunity to Magic Missile.</content>
   <content contentuid="h413145b9g72c2g4630ga50ag6b4c5d367395" version="1">A spectral shield hovers near you for the next minute, granting you a +2 bonus to AC and immunity to Magic Missile.</content>
   <content contentuid="hfedbac46g363eg4c64g9537g61335c5397d3" version="1">A spectral shield hovers near you for the next minute, granting you a +2 bonus to AC and immunity to Magic Missile.</content>
@@ -5716,7 +5716,7 @@ Whenever the spell deals damage to a target, you regain hit points equal to half
   <content contentuid="hbbfea48fg9939g4a68g9f77g75b827833bb9" version="1">Usable Classes: Artificer, Bard, Cleric, Sorcerer, Wizard</content>
   <content contentuid="h72cfddcagd9adg46e5g9370g300ae4624cf3" version="1">Scroll of Mage Hand</content>
   <content contentuid="h64daa63ag9736g4405gbd0fgb7a1a6818a53" version="1">Usable Classes: Artificer, Bard, Sorcerer, Warlock, Wizard</content>
-  <content contentuid="h06c20aa3ga24ag4712g8d65gef0c57b09d88" version="1">Scroll of Minor Illusion</content>
+  <content contentuid="h06c20aa3ga24ag4712g8d65gef0c57b09d88" version="1">Scroll of &lt;LSTag Type="Spell" Tooltip="Target_ImprovedMinorIllusion"&gt;Minor Illusion&lt;/LSTag&gt;</content>
   <content contentuid="h51f7caaeg9372g4e86gaf59g32f47c7ca3fd" version="1">Usable Classes: Bard, Sorcerer, Warlock, Wizard</content>
   <content contentuid="h80896363g0d60g4d9aga98dg6683f010415d" version="1">Scroll of Poison Spray</content>
   <content contentuid="h47e76386g3be1g40b1g97deg21f1ba49349a" version="1">Usable Classes: Artificer, Druid, Sorcerer, Warlock, Wizard</content>
@@ -5911,7 +5911,7 @@ While shape-shifted with this trait, you have Advantage on Charisma checks.
 
 You stay in the new form until you take an action to revert to your true form.</content>
   <content contentuid="h3aa8fe16g20f5gd9bcg6b2ag37c43ec4a76a" version="1">Changeling Instincts</content>
-  <content contentuid="he0997113gd8aeg5a32g0cadg6583a1780b19" version="1">Thanks to your connection to the fey realm, you gain proficiency in two of the following skills of your choice: Deception, Insight, Intimidation, Performance, or Persuasion.</content>
+  <content contentuid="he0997113gd8aeg5a32g0cadg6583a1780b19" version="1">Thanks to your connection to the fey realm, you gain proficiency in two of the following skills of your choice: &lt;LSTag Type="Skills" Tooltip="Deception"&gt;Deception&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Insight"&gt;Insight&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Intimidation"&gt;Intimidation&lt;/LSTag&gt;, &lt;LSTag Type="Skills" Tooltip="Performance"&gt;Performance&lt;/LSTag&gt;, or &lt;LSTag Type="Skills" Tooltip="Persuasion"&gt;Persuasion&lt;/LSTag&gt;.</content>
   <content contentuid="h45db1baag1a66g5173g7046g451d6c939820" version="1">Shape-Shifter</content>
   <content contentuid="haddbec72gf9c4g510bg8c8cgba4bcfd87301" version="1">As an action, you can shape-shift to change your appearance and your voice. You determine the specifics of the changes, including your coloration, hair length, and sex. You can also adjust your height and weight and can change your size between Medium and Small. You can make yourself appear as a member of another playable species, though none of your game statistics change. You can’t duplicate the appearance of an individual you’ve never seen, and you must adopt a form that has the same basic arrangement of limbs that you have. This trait doesn’t change your clothing and equipment.
 
@@ -5920,8 +5920,8 @@ While shape-shifted with this trait, you have Advantage on Charisma checks.
 You stay in the new form until you take an action to revert to your true form.</content>
   <content contentuid="h91db12d5g8008g270dg0954g09a1733b596c" version="1">Dismiss Shape-Shifter</content>
   <content contentuid="h92a4c2d5gc8f0g7ee9g69d9gbcc22fbfd18f" version="3">Pickpocketing</content>
-  <content contentuid="h38834643g8993gebb9g329bg7091b7ffff24" version="1">When you cast Mage Hand, you can cast it as a Bonus Action, and you can make the spectral hand Invisible. The hand can also attempt to pick pockets, making a Dexterity (Sleight of Hand) check using your own modifier as the Arcane Trickster.</content>
-  <content contentuid="hf1072944g3718g45edgace3ga7e816803e30" version="1">Reach into the target's pockets and attempt to steal an item. The Dexterity (Sleight of Hand) check uses your own modifier as the Arcane Trickster.</content>
+  <content contentuid="h38834643g8993gebb9g329bg7091b7ffff24" version="1">When you cast Mage Hand, you can cast it as a Bonus Action, and you can make the spectral hand Invisible. The hand can also attempt to pick pockets, making a Dexterity (&lt;LSTag Type="Skills" Tooltip="SleightOfHand"&gt;Sleight of Hand&lt;/LSTag&gt;) check using your own modifier as the Arcane Trickster.</content>
+  <content contentuid="hf1072944g3718g45edgace3ga7e816803e30" version="1">Reach into the target's pockets and attempt to steal an item. The Dexterity (&lt;LSTag Type="Skills" Tooltip="SleightOfHand"&gt;Sleight of Hand&lt;/LSTag&gt;) check uses your own modifier as the Arcane Trickster.</content>
   <content contentuid="hc7b21ba7g1c09g7de4g9eaag014c9a24930a" version="1">When you cast a spell that forces a creature to make a saving throw, you can spend 2 Sorcery Points to give one target of the spell Disadvantage on saves against the spell.</content>
   <content contentuid="ha614b061ga252gec97g0245gecd6aee49796" version="1">When you cast a spell that has a casting time of an action, you can spend 2 Sorcery Points to change the casting time to a Bonus Action for this casting. You can’t modify a spell in this way if you’ve already cast a level 1+ spell on the current turn, nor can you cast a level 1+ spell on this turn after modifying a spell in this way.</content>
   <content contentuid="hd25a31d6gfc99g5602g7ce2gdace45ce4abf" version="1">When you cast a spell that forces other creatures to make a saving throw, you can protect some of those creatures from the spell’s full force. To do so, spend 1 Sorcery Point and choose a number of those creatures up to your Charisma modifier (minimum of one creature). A chosen creature automatically succeeds on its saving throw against the spell, and it takes no damage if it would normally take half damage on a successful save.</content>
@@ -5962,18 +5962,18 @@ In addition, you can take the Disengage action as a Bonus Action for the spell�
   <content contentuid="h7934c92cg8530g3159g655ag6b05c5e60aef" version="1">Arcane Ward: 15</content>
   <content contentuid="h4f08c9a8gd738g8d4dg31c2gb975d622852c" version="1">Arcane Ward: 20</content>
   <content contentuid="h3e550e8eg5409g3a80g52e3ga4f1d383264d" version="1">Projected Ward: 2</content>
-  <content contentuid="h621ec36dg3794g4862g4538gb2c4399f06cd" version="1">When a creature that you can see within 30 feet of yourself takes damage, you can take a Reaction to cause your Arcane Ward to absorb that damage.</content>
+  <content contentuid="h621ec36dg3794g4862g4538gb2c4399f06cd" version="1">When a creature that you can see within 30 feet of yourself takes damage, you can take a Reaction to cause your &lt;LSTag Type="Passive" Tooltip="ArcaneWard"&gt;Arcane Ward&lt;/LSTag&gt; to absorb that damage.</content>
   <content contentuid="h9cb11bc4g520dg35a2g4731g7635211c5e76" version="1">Whenever you take damage, the ward takes the damage instead, and if you have any Resistances or Vulnerabilities, apply them before reducing the ward’s Hit Points. If the damage reduces the ward to 0 Hit Points, you take any remaining damage. While the ward has 0 Hit Points, it can’t absorb damage, but its magic remains.</content>
   <content contentuid="h295148d7ga456gb0ffg5573g8f507e9bf7fe" version="1">Projected Ward: 5</content>
-  <content contentuid="hcd21cc8fgd961g0feeg16afgf78a1e0a3fba" version="1">When a creature that you can see within 30 feet of yourself takes damage, you can take a Reaction to cause your Arcane Ward to absorb that damage.</content>
+  <content contentuid="hcd21cc8fgd961g0feeg16afgf78a1e0a3fba" version="1">When a creature that you can see within 30 feet of yourself takes damage, you can take a Reaction to cause your &lt;LSTag Type="Passive" Tooltip="ArcaneWard"&gt;Arcane Ward&lt;/LSTag&gt; to absorb that damage.</content>
   <content contentuid="hd1cf6300g0d28g0951g5071g79972ff7f6ac" version="1">Projected Ward: 10</content>
-  <content contentuid="h221aec9fgee6dgf291gdaedg74950253b4a2" version="1">When a creature that you can see within 30 feet of yourself takes damage, you can take a Reaction to cause your Arcane Ward to absorb that damage.</content>
+  <content contentuid="h221aec9fgee6dgf291gdaedg74950253b4a2" version="1">When a creature that you can see within 30 feet of yourself takes damage, you can take a Reaction to cause your &lt;LSTag Type="Passive" Tooltip="ArcaneWard"&gt;Arcane Ward&lt;/LSTag&gt; to absorb that damage.</content>
   <content contentuid="h2a863d0egbd90g1d88g062fgd7908dabd2e0" version="1">Projected Ward: 15</content>
-  <content contentuid="h97912cc4g21bfg2c6egbd0cgbc22ad403d83" version="1">When a creature that you can see within 30 feet of yourself takes damage, you can take a Reaction to cause your Arcane Ward to absorb that damage.</content>
+  <content contentuid="h97912cc4g21bfg2c6egbd0cgbc22ad403d83" version="1">When a creature that you can see within 30 feet of yourself takes damage, you can take a Reaction to cause your &lt;LSTag Type="Passive" Tooltip="ArcaneWard"&gt;Arcane Ward&lt;/LSTag&gt; to absorb that damage.</content>
   <content contentuid="hc26cfac5g1d2cg4692g1e56g8a0726a5fa88" version="1">Projected Ward: 20</content>
-  <content contentuid="h6df157b5g12d3g2b2bgd643g1dd6b4025001" version="1">When a creature that you can see within 30 feet of yourself takes damage, you can take a Reaction to cause your Arcane Ward to absorb that damage.</content>
+  <content contentuid="h6df157b5g12d3g2b2bgd643g1dd6b4025001" version="1">When a creature that you can see within 30 feet of yourself takes damage, you can take a Reaction to cause your &lt;LSTag Type="Passive" Tooltip="ArcaneWard"&gt;Arcane Ward&lt;/LSTag&gt; to absorb that damage.</content>
   <content contentuid="hc2e7a124g2079gd707g16edg7f33dc23e62e" version="1">Projected Ward: 25</content>
-  <content contentuid="hb4209506g884fg3190g8d94g0432d0658315" version="1">When a creature that you can see within 30 feet of yourself takes damage, you can take a Reaction to cause your Arcane Ward to absorb that damage.</content>
+  <content contentuid="hb4209506g884fg3190g8d94g0432d0658315" version="1">When a creature that you can see within 30 feet of yourself takes damage, you can take a Reaction to cause your &lt;LSTag Type="Passive" Tooltip="ArcaneWard"&gt;Arcane Ward&lt;/LSTag&gt; to absorb that damage.</content>
   <content contentuid="h08045ad1gb50dgc96dg8318gd971f112b84f" version="1">You can call on your fiendish patron to alter fate in your favor. When you make an ability check or a saving throw, you can use this feature to add 1d10 to your roll. You can do so after seeing the roll but before any of the roll’s effects occur.</content>
   <content contentuid="h3deb4586gfae5g7a55gadcagd4ee75ff94b8" version="1">You can use this feature a number of times equal to your Charisma modifier (minimum of once), but you can use it no more than once per roll. You regain all expended uses when you finish a Long Rest.</content>
   <content contentuid="h8b958c8ag5476g5bd5g1951gae850853f115" version="1">Dark One’s Own Luck</content>
@@ -6052,7 +6052,7 @@ If a creature is frightened of you, it has Disadvantage on ability checks and at
   <content contentuid="h646d3264gf6b6g560fg5c71g2bdcf82ed18f" version="1">Level 3: Fast movement</content>
   <content contentuid="h1577c90agd0bag445egb032g8a550e8a9aa3" version="1">Your Speed increases by 10 feet. It increases by another 5 feet when you reach Bard levels 6 (total increase of 15 feet).</content>
   <content contentuid="he6ec7f15ga89dg3c20g36ccg1213e02112e6" version="1">Level 3: Inspirational Dance</content>
-  <content contentuid="hdfb7e043ga3ecgc3afg13c5g96138794e52b" version="1">You learn how to use the universal language of dance. As a Bonus Action, you can expend one use of your Bardic Inspiration to dance and reinvigorate another creature of your choice who can see you.
+  <content contentuid="hdfb7e043ga3ecgc3afg13c5g96138794e52b" version="1">You learn how to use the universal language of dance. As a Bonus Action, you can expend one use of your &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; to dance and reinvigorate another creature of your choice who can see you.
 
 When you do, roll your Bardic Inspiration die; that creature gains a number of Temporary Hit Points equal to the number rolled plus your Charisma modifier (minimum of 2 Temporary Hit Points). When a creature gains Temporary Hit Points in this way, it can immediately take a Reaction to move up to its Speed without provoking Opportunity Attacks or take the Dodge action.</content>
   <content contentuid="h4540df02gb020g8e3bg3167gaa78385a6a3d" version="1">Level 6: Entrancing Movement</content>
@@ -6061,7 +6061,7 @@ When you do, roll your Bardic Inspiration die; that creature gains a number of T
 In addition, you always have the Charm Person spell prepared, and you can cast it without a Verbal component. With this feature, you can cast it without expending a spell slot; when you do, it is cast as a level 3 spell, and the targets don’t make their saving throws with Advantage as a result of you or your allies fighting them. Once you cast the spell with this feature, you can’t do so in this way again until you finish a Long Rest.</content>
   <content contentuid="hd49fcd64gff1eg845agd28bg3ab0a14daac8" version="1">Level 6: Fast movement</content>
   <content contentuid="h4cb69536g5c74geea4gc43dgd9f79ab9e5bd" version="1">Inspirational Dance</content>
-  <content contentuid="h391dd984g6a8cge5b0g94c0g187d5c88d2a9" version="1">Roll your Bardic Inspiration die; that creature gains a number of Temporary Hit Points equal to the number rolled plus your Charisma modifier (minimum of 2 Temporary Hit Points). When a creature gains Temporary Hit Points in this way, it can immediately take a Reaction to move up to its Speed without provoking Opportunity Attacks or take the Dodge action.</content>
+  <content contentuid="h391dd984g6a8cge5b0g94c0g187d5c88d2a9" version="1">Roll your &lt;LSTag Type="ActionResource" Tooltip="BardicInspiration"&gt;Bardic Inspiration&lt;/LSTag&gt; die; that creature gains a number of Temporary Hit Points equal to the number rolled plus your Charisma modifier (minimum of 2 Temporary Hit Points). When a creature gains Temporary Hit Points in this way, it can immediately take a Reaction to move up to its Speed without provoking Opportunity Attacks or take the Dodge action.</content>
   <content contentuid="ha3470339g553agf518ge686g4bd2e7eabe4e" version="1">Inspirational Dance</content>
   <content contentuid="h20d37566g7400g2868g5deag4485da129eed" version="1">Psychic Blade</content>
   <content contentuid="hff527d02g065ag6c5bgaafeg7ba35d5b2763" version="1">As a Bonus Action, you manifest a second Psychic Blade in your free hand and throw it at a creature you can see, dealing Psychic damage. The blade has the Vex weapon mastery property, then vanishes.</content>
@@ -6112,7 +6112,7 @@ Dhampirs often arise from encounters with vampires; some are the descendants of 
   <content contentuid="h02533ba5gec0ag9e9dg4fc4g73c9249f2bec" version="1">Heroic Sorcery</content>
   <content contentuid="hd517f270gefc4g3302ge7ecge9468f84b00a" version="1">You are the reincarnation of a legendary hero known to have slain many terrible foes, and your sorcerous magic draws from your legendary past. Being called back to life, whether by the gods, a very powerful mage, or a cycle of reincarnation, has awakened a well of magic and your ancient instincts for battle.</content>
   <content contentuid="hb63faa4cg7994gfa72g49ffg512d528710ca" version="1">Level 3: Heroic Spells</content>
-  <content contentuid="h4ed71b8cg3ed3gd84eg3c79gb92ad8cf0e94" version="1">When you reach certain Sorcerer levels, you always have the following spells prepared: Green-Flame Blade, True Strike, Heroism, Magic Weapon, Mirror Image, and Shield at level 3; Haste and Phantom Steed at level 5; Death Ward and Stoneskin at level 7; and Hold Monster at level 9. These spells don't count against the number of spells you can prepare.</content>
+  <content contentuid="h4ed71b8cg3ed3gd84eg3c79gb92ad8cf0e94" version="1">When you reach certain Sorcerer levels, you always have the following spells prepared: Green-Flame Blade, True Strike, Heroism, Magic Weapon, Mirror Image, and Shield at level 3; &lt;LSTag Type="Spell" Tooltip="Target_Haste"&gt;Haste&lt;/LSTag&gt; and Phantom Steed at level 5; Death Ward and Stoneskin at level 7; and Hold Monster at level 9. These spells don't count against the number of spells you can prepare.</content>
   <content contentuid="h81636128ge683g92f7g0c18g5a4d21a7d6cd" version="1">Level 3: Martial Sorcery</content>
   <content contentuid="h269da4dcg7dabg981bg4001gfcda57b7c806" version="1">Heroic Soul. At the start of each of your turns, you can spend 1 Sorcery Point to gain Temporary Hit Points equal to 1d6 plus your Sorcerer level (no action required).
 
@@ -6229,7 +6229,7 @@ Discipline. You are the shield against the endless terrors that lie beyond the s
   <content contentuid="h53bf4744g8817g4dc1g9f65g4ca743366100" version="1">Level 3: Watcher’s Will</content>
   <content contentuid="h55809fbag7bd0g427fgaea4gcc7103f95f2c" version="1">You can use your Channel Oath to invest your presence with the warding power of your faith. You can choose a number of creatures you can see within 30 feet of you, up to a number equal to your Charisma modifier (minimum of one creature). For 1 minute, you and the chosen creatures have advantage on Intelligence, Wisdom, and Charisma saving throws.</content>
   <content contentuid="h1c396853g089ag4cf6gaac4g3a465614eb89" version="1">Level 3: Abjure the Extraplanar</content>
-  <content contentuid="h9aa052ddgf617g4344ga11dg4ad49e29159e" version="1">You can use your Channel Oath to try to banish an extraplanar creature. Each aberration, celestial, elemental, fey, or fiend within 30 feet of you must succeed on a Wisdom saving throw or be Turned for 1 minute. A Turned creature is forced to flee and cannot come close to you.</content>
+  <content contentuid="h9aa052ddgf617g4344ga11dg4ad49e29159e" version="1">You can use your Channel Oath to try to &lt;LSTag Type="Status" Tooltip="TURNED"&gt;banish&lt;/LSTag&gt; an extraplanar creature. Each aberration, celestial, elemental, fey, or fiend within 30 feet of you must succeed on a Wisdom saving throw or be Turned for 1 minute. A Turned creature is forced to flee and cannot come close to you.</content>
   <content contentuid="h7d68e487g894dg47f1g8cdcg0ca8573c0e57" version="1">Level 7: Aura of the Sentinel</content>
   <content contentuid="h41b477e4g3e5cg4162gb3dbga2e44d7f9e08" version="1">You emit an aura of alertness while you aren’t incapacitated. When you and any creatures of your choice within 10 feet of you roll initiative, you all gain a bonus to initiative equal to your proficiency bonus.</content>
   <content contentuid="hfe23251ag4606g4bd5gb621g1bf49c9afed5" version="1">Watcher’s Will</content>
@@ -6258,7 +6258,7 @@ Discipline. You are the shield against the endless terrors that lie beyond the s
 
 Clerics who serve these deities—examples of which appear on the Twilight Deities table—bring comfort to those who seek rest and protect them by venturing into the encroaching darkness to ensure that the dark is a comfort, not a terror.</content>
   <content contentuid="had547f10gf9b5gc30cg6122g99ef0b90d2ad" version="1">Level 3: Twilight Domain Spells</content>
-  <content contentuid="h434df1f3gdadag1149g4c36g6bfc2c7a1bec" version="1">When you reach certain Cleric levels, you always have the following spells prepared: Faerie Fire, Sleep, Moonbeam, and See Invisibility at level 3; Aura of Vitality and Void Strike at level 5; Freedom of Movement and Greater Invisibility at level 7; and Circle of Power and Dawn at level 9. These spells don't count against the number of spells you can prepare.</content>
+  <content contentuid="h434df1f3gdadag1149g4c36g6bfc2c7a1bec" version="1">When you reach certain Cleric levels, you always have the following spells prepared: Faerie Fire, Sleep, Moonbeam, and See Invisibility at level 3; Aura of Vitality and Void Strike at level 5; Freedom of Movement and &lt;LSTag Type="Spell" Tooltip="Target_Invisibility_Greater"&gt;Greater Invisibility&lt;/LSTag&gt; at level 7; and Circle of Power and Dawn at level 9. These spells don't count against the number of spells you can prepare.</content>
   <content contentuid="h0060ddb2gfe04g6d96g6e94g9496e7fff0e0" version="2">Level 3: Eyes of Night</content>
   <content contentuid="h73451af6g0c9dge1e4g112ag73be890335ef" version="2">You can see through the deepest gloom. You have superior darkvision, you can see in dim light as if it were bright light and in darkness as if it were dim light.
 
@@ -6308,7 +6308,7 @@ After selecting three different cantrips, this mode ends.</content>
   <content contentuid="h2a7ec7c7g207cg45f8g927cg6c9f50c0fb9b" version="1">Magic Initiate: Hellfire</content>
   <content contentuid="h9bfda308gf51bg41ccg97c0ga96e9d21a338" version="1">Magic Initiate: Sorcerous Burst</content>
   <content contentuid="h3f64848bg052dg43f2g810eg7be150061cc4" version="1">Magic Initiate: Vicious Mockery</content>
-  <content contentuid="h37588848gdc10g2334gdf51ga179befdb18d" version="1">As you finish a Short or Long Rest, you can play a song on a Musical Instrument with which you have proficiency and give Heroic Inspiration to allies who hear the song. The number of allies you can affect in this way equals your Proficiency Bonus.</content>
+  <content contentuid="h37588848gdc10g2334gdf51ga179befdb18d" version="1">As you finish a Short or Long Rest, you can play a song on a Musical Instrument with which you have proficiency and give &lt;LSTag Type="Status" Tooltip="HEROIC_INSPIRATION_TEMP"&gt;Heroic Inspiration&lt;/LSTag&gt; to allies who hear the song. The number of allies you can affect in this way equals your Proficiency Bonus.</content>
   <content contentuid="hdb7f26d7gc116gec10g33c4g5d76f22454ca" version="1">Divine Soul</content>
   <content contentuid="h490ad4f0gd12fg2b06g615bg7c7d9ecf0520" version="1">Sometimes the spark of magic that fuels a sorcerer comes from a divine source that glimmers within the soul. Having such a blessed soul is a sign that your innate magic might come from a distant but powerful familial connection to a divine being. Perhaps your ancestor was an angel, transformed into a mortal and sent to fight in a god’s name. Or your birth might align with an ancient prophecy, marking you as a servant of the gods or a chosen vessel of divine magic.
 
@@ -6344,9 +6344,9 @@ Level 9: two Level 5 spells.</content>
   <content contentuid="h4e44007fg48fbg0a5ag6a60g8458e847f21e" version="1">Level 3: Webbing</content>
   <content contentuid="hb012aa29g2700gd0c7g3c87g74a98a1affc6" version="2">You can magically produce sticky, silken spider webs from your hands. As a Bonus Action, you can use them to do one of the following.
 
-Pulling Web. Strike a creature or object within [1] with a skin-adhering web and pull it up to [1] closer to you. Only a target of Large size or smaller can be moved, and a creature resists with a successful Dexterity saving throw. An ally is always pulled.
+&lt;LSTag Type="Spell" Tooltip="Target_ArachnoidStalker_Pull"&gt;Pulling Web&lt;/LSTag&gt;. Strike a creature or object within [1] with a skin-adhering web and pull it up to [1] closer to you. Only a target of Large size or smaller can be moved, and a creature resists with a successful Dexterity saving throw. An ally is always pulled.
 
-Web Swing. Project a line of web at a point you can see within [1] and pull yourself to that point without provoking Opportunity Attacks.
+&lt;LSTag Type="Spell" Tooltip="Target_ArachnoidStalker_WebSwing"&gt;Web Swing&lt;/LSTag&gt;. Project a line of web at a point you can see within [1] and pull yourself to that point without provoking Opportunity Attacks.
 
 Web. You cast Web without a spell slot as a part of the Bonus Action used for this feature. The webs fill a [2] radius and dissolve after 1 minute, and a creature caught inside must succeed on a Dexterity saving throw or become &lt;LSTag Type="Status" Tooltip="WEB"&gt;Enwebbed&lt;/LSTag&gt;. You can cast this spell using this feature twice. You regain one expended use when you finish a Short Rest, and you regain all expended uses when you finish a Long Rest.
 


### PR DESCRIPTION
## Summary

Many descriptions mention another skill, status, spell, action resource, or passive without linking to its tooltip. This makes it impossible to inspect the referenced mechanic directly from the description.

This PR adds 313 missing `LSTag` cross-references across 213 descriptions:

- 117 skill references
- 87 status references
- 71 spell references
- 25 action-resource references
- 13 passive references

## Scope

Links are added only when the text clearly refers to another gameplay entity.

Twelve self-referential feature headings are intentionally left unlinked, since they name the feature currently being described rather than reference another mechanic. Ambiguous ordinary-word matches are also excluded.

For Menacing Aura, the `Status:UNNERVING_AURA` tooltip is attached to the referenced Unnerving Aura, while the Menacing Aura heading remains plain text.

No wording or gameplay logic is changed.
