### PR TITLE
Preserve Pact of the Blade binding when weapons are unequipped

### DIFF
--- a/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Story/RawFiles/Goals/dnd5.5e_Remove_PactOfBlade.txt
+++ b/Mods/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Story/RawFiles/Goals/dnd5.5e_Remove_PactOfBlade.txt
@@ -66,40 +66,86 @@ HasActiveStatus(_MagicItem, "ARCANE_ARMOR_WEAPON", 1)
 THEN
 RemoveStatus(_MagicItem, "ARCANE_ARMOR_WEAPON", NULL_00000000-0000-0000-0000-000000000000);
 
-IF
-Unequipped(_MagicItem, _Char)
-AND
-HasActiveStatus(_MagicItem, "PACT_BLADE", 1)
+// Pact of the Blade remains bound while the weapon is merely unequipped.
+// Track one pact weapon per warlock and clear the previous bond only when a
+// new PACT_BLADE status is applied, or when the warlock dies.
+PROC
+PROC_DND55E_ClearPactBlade((CHARACTER)_Warlock, (ITEM)_Weapon)
 THEN
-RemoveStatus(_MagicItem, "PACT_BLADE", NULL_00000000-0000-0000-0000-000000000000);
+RemoveStatus(_Weapon, "PACT_BLADE", NULL_00000000-0000-0000-0000-000000000000);
+RemoveStatus(_Weapon, "PACT_BLADE_NECROTIC", NULL_00000000-0000-0000-0000-000000000000);
+RemoveStatus(_Weapon, "PACT_BLADE_PSYCHIC", NULL_00000000-0000-0000-0000-000000000000);
+RemoveStatus(_Weapon, "PACT_BLADE_RADIANT", NULL_00000000-0000-0000-0000-000000000000);
+RemoveStatus(_Weapon, "PACT_BLADE_WEAPON", NULL_00000000-0000-0000-0000-000000000000);
+NOT DB_DND55E_PactBlade(_Warlock, _Weapon);
+
+// Register every pact weapon, including conjured weapons and all damage-type
+// variants. Applying a new bond removes the previous bond for this warlock.
+IF
+StatusApplied((ITEM)_NewWeapon, "PACT_BLADE", _, _)
+AND
+GetInventoryOwner(_NewWeapon, (CHARACTER)_Warlock)
+AND
+DB_DND55E_PactBlade(_Warlock, (ITEM)_OldWeapon)
+AND
+_OldWeapon != _NewWeapon
+THEN
+PROC_DND55E_ClearPactBlade(_Warlock, _OldWeapon);
+DB_DND55E_PactBlade(_Warlock, _NewWeapon);
 
 IF
-Unequipped(_MagicItem, _Char)
+StatusApplied((ITEM)_Weapon, "PACT_BLADE", _, _)
 AND
-HasActiveStatus(_MagicItem, "PACT_BLADE_NECROTIC", 1)
+GetInventoryOwner(_Weapon, (CHARACTER)_Warlock)
 THEN
-RemoveStatus(_MagicItem, "PACT_BLADE_NECROTIC", NULL_00000000-0000-0000-0000-000000000000);
+DB_DND55E_PactBlade(_Warlock, _Weapon);
+
+// Existing saves do not yet contain DB_DND55E_PactBlade. Before this fix an
+// active pact weapon could only survive while equipped, so recover it from the
+// main-hand slot when the save is loaded.
+IF
+SavegameLoaded()
+AND
+DB_Players((CHARACTER)_Warlock)
+AND
+GetEquippedItem(_Warlock, "Melee Main Weapon", (ITEM)_Weapon)
+AND
+HasActiveStatus(_Weapon, "PACT_BLADE", 1)
+THEN
+DB_DND55E_PactBlade(_Warlock, _Weapon);
+
+// Also recover the owner relation if an old-save weapon is unequipped before
+// the load migration can see it. Unequipping itself must not end the bond.
+IF
+Unequipped((ITEM)_Weapon, (CHARACTER)_Warlock)
+AND
+HasActiveStatus(_Weapon, "PACT_BLADE", 1)
+THEN
+DB_DND55E_PactBlade(_Warlock, _Weapon);
 
 IF
-Unequipped(_MagicItem, _Char)
+Died((CHARACTER)_Warlock)
 AND
-HasActiveStatus(_MagicItem, "PACT_BLADE_PSYCHIC", 1)
+DB_DND55E_PactBlade(_Warlock, (ITEM)_Weapon)
 THEN
-RemoveStatus(_MagicItem, "PACT_BLADE_PSYCHIC", NULL_00000000-0000-0000-0000-000000000000);
+PROC_DND55E_ClearPactBlade(_Warlock, _Weapon);
+
+// Keep the auxiliary damage-type status from surviving any external removal
+// of the main pact status (for example, respec or another mod).
+IF
+StatusRemoved((ITEM)_Weapon, "PACT_BLADE", _, _)
+THEN
+RemoveStatus(_Weapon, "PACT_BLADE_NECROTIC", NULL_00000000-0000-0000-0000-000000000000);
+RemoveStatus(_Weapon, "PACT_BLADE_PSYCHIC", NULL_00000000-0000-0000-0000-000000000000);
+RemoveStatus(_Weapon, "PACT_BLADE_RADIANT", NULL_00000000-0000-0000-0000-000000000000);
+RemoveStatus(_Weapon, "PACT_BLADE_WEAPON", NULL_00000000-0000-0000-0000-000000000000);
 
 IF
-Unequipped(_MagicItem, _Char)
+StatusRemoved((ITEM)_Weapon, "PACT_BLADE", _, _)
 AND
-HasActiveStatus(_MagicItem, "PACT_BLADE_RADIANT", 1)
+DB_DND55E_PactBlade((CHARACTER)_Warlock, _Weapon)
 THEN
-RemoveStatus(_MagicItem, "PACT_BLADE_RADIANT", NULL_00000000-0000-0000-0000-000000000000);
-
-IF
-Unequipped(_MagicItem, _Char)
-AND
-HasActiveStatus(_MagicItem, "PACT_BLADE_WEAPON", 1)
-THEN
-RemoveStatus(_MagicItem, "PACT_BLADE_WEAPON", NULL_00000000-0000-0000-0000-000000000000);
+NOT DB_DND55E_PactBlade(_Warlock, _Weapon);
 
 IF
 Unequipped(_MagicItem, _Char)


### PR DESCRIPTION
## Summary

Preserve Pact of the Blade when a bonded weapon is removed from the active weapon slot and moved to the inventory.

This replaces the closed draft #1117 with the exact Story implementation used by the tested build.

Partially addresses #1112. This PR fixes the first reported issue only: losing the pact binding when the weapon is unequipped.

## Problem

`dnd5.5e_Remove_PactOfBlade.txt` explicitly removed `PACT_BLADE` and its related Normal, Necrotic, Psychic, and Radiant statuses whenever the bonded weapon triggered `Unequipped`.

As a result, simply moving a pact weapon from the active slot to the inventory ended the bond. Re-equipping the same weapon did not restore the pact effects.

## Changes

- Removed the rules that clear Pact of the Blade solely because the weapon was unequipped.
- Added a Story database that tracks one bonded weapon per Warlock.
- When a different weapon receives `PACT_BLADE`, the previous weapon's pact statuses are cleared before the new bond is recorded.
- Existing saves recover the currently equipped pact weapon when loaded.
- The recorded bond is cleared when the main `PACT_BLADE` status is removed or the Warlock dies.
- Related damage-type statuses are cleared together with the main pact status when the bond actually ends.

## Result

A bonded weapon can be moved to the inventory and equipped again without losing Pact of the Blade. Binding a different weapon still replaces the previous bond.

## Trading safeguard

Keeping the bond while the weapon is unequipped does not make the weapon tradable. `PACT_BLADE` grants `Attribute(InventoryBound)`, and the patch preserves that status while the weapon remains in the Warlock's inventory. In-game verification confirmed that the bonded weapon remains visible in the character inventory but is absent from the merchant trade list.

<img width="3511" height="1359" alt="Bonded weapon in character inventory" src="https://github.com/user-attachments/assets/eaecba50-1b57-4175-b896-9c90c4548bc8" />
<img width="670" height="1057" alt="Pact of the Blade status retained" src="https://github.com/user-attachments/assets/a52bf1d9-3a84-40f9-8800-ca134603d519" />
<img width="1028" height="1096" alt="Bonded weapon inventory state" src="https://github.com/user-attachments/assets/ebc42bce-3a33-4e66-b4d4-045a7f0118ea" />
<img width="2504" height="1423" alt="Bonded weapon absent from merchant trade list" src="https://github.com/user-attachments/assets/d4f97ac0-2c97-4422-bb00-2ed154e4d0bd" />

## Scope

This PR only addresses the first issue described in #1112. It does not change the Charisma ability-selection condition or Throw-action availability.

## Validation

- The submitted Story implementation matches the file installed in the working TEST build.
- In-game testing confirmed that the bond survives unequipping and re-equipping for both the standard and elemental pact variants.
- In-game testing confirmed that a bonded weapon remains excluded from merchant trading while unequipped.

